### PR TITLE
Adjust column binding

### DIFF
--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGridBoundColumn.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGridBoundColumn.cs
@@ -30,9 +30,9 @@ namespace Windows.UI.Xaml.Controls
     /// </summary>
     public abstract partial class DataGridBoundColumn : DataGridColumn
     {
-        private BindingBase _binding;
+        private Binding _binding;
 
-        public BindingBase Binding
+        public Binding Binding
         {
             get
             {


### PR DESCRIPTION
[Silverlight](https://docs.microsoft.com/en-us/previous-versions/windows/silverlight/dotnet-windows-silverlight/cc896573(v=vs.95)) and [Uwp](https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.uwp.ui.controls.datagridboundcolumn.binding?view=win-comm-toolkit-dotnet-stable#Microsoft_Toolkit_Uwp_UI_Controls_DataGridBoundColumn_Binding) both has Binding(instead of BindingBase) type.