### PR TITLE
Adjust types

### DIFF
--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/AutoCompleteBox.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/AutoCompleteBox.cs
@@ -761,13 +761,17 @@ namespace Windows.UI.Xaml.Controls
         /// <param name="e">Event data for the event.</param>
 #if MIGRATION
         protected virtual void OnDropDownClosed(EventArgs e)
+        {
+            if (DropDownClosed != null)
+                DropDownClosed(this, new RoutedPropertyChangedEventArgs<bool>(true, false));
+        }
 #else
         protected virtual void OnDropDownClosed(RoutedEventArgs e)
-#endif
         {
             if (DropDownClosed != null)
                 DropDownClosed(this, e);
         }
+#endif
 
         /// <summary>
         /// Invoked when the DropDownOpened event is raised.
@@ -812,7 +816,7 @@ namespace Windows.UI.Xaml.Controls
         /// Occurs when the drop-down portion of the ComboBox closes.
         /// </summary>
 #if MIGRATION
-        public event EventHandler DropDownClosed;
+        public event RoutedPropertyChangedEventHandler<bool> DropDownClosed;
 #else
         public event RoutedEventHandler DropDownClosed;
 #endif

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGridRow.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGridRow.cs
@@ -43,7 +43,7 @@ namespace Windows.UI.Xaml.Controls
     /// <summary>
     /// Represents a System.Windows.Controls.DataGrid row.
     /// </summary>
-    public partial class DataGridRow : DependencyObject
+    public partial class DataGridRow : Control
     {
         public DataGridRow()
         {


### PR DESCRIPTION
According to [this](https://docs.microsoft.com/en-us/previous-versions/windows/silverlight/dotnet-windows-silverlight/dd459699(v=vs.95)) DropDownClosed event is RoutedPropertyChangedEventHandler<bool> for Silverlight.

And DataGridRow [derives](https://docs.microsoft.com/en-us/previous-versions/windows/silverlight/dotnet-windows-silverlight/cc189610(v=vs.95)) from Control