### PR TITLE
Handle callback parameters

### DIFF
--- a/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_JSObjectReference.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_JSObjectReference.cs
@@ -73,6 +73,10 @@ namespace CSHTML5.Types
                 {
                     result = array[ArrayIndex];
                 }
+                else if(Value != null && Value.GetType().FullName == "DotNetBrowser.JSObject")
+                {
+                    result = ((dynamic)Value).GetProperty(ArrayIndex.ToString());
+                }
                 else
                 {
                     throw new InvalidOperationException("Value is marked as array but is neither an object[] nor a JSArray. ReferenceId: " + (this.ReferenceId ?? "n/a").ToString());


### PR DESCRIPTION
For example, we get callback parameters in the format {0: '2020', 1: '12', 2: '15'} instead of array.
