### PR TITLE
Fixed problems in several `DependencyProperty.Register` calls found by the PVS-Studio static code analyzer

### DIFF
--- a/src/Runtime/Runtime/Microsoft.Expression.Interactivity.Core/WORKINPROGRESS/ControlStoryboardAction.cs
+++ b/src/Runtime/Runtime/Microsoft.Expression.Interactivity.Core/WORKINPROGRESS/ControlStoryboardAction.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Expression.Interactivity.Core
 	public partial class ControlStoryboardAction : StoryboardAction
 	{
 		public static readonly DependencyProperty ControlStoryboardProperty =
-			DependencyProperty.Register("ControlStoryboard",
+			DependencyProperty.Register(nameof(ControlStoryboardOption),
 										typeof(ControlStoryboardOption),
 										typeof(ControlStoryboardAction),
 										null);

--- a/src/Runtime/Runtime/System.Windows.Media.Effects/WORKINPROGRESS/PixelShader.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Effects/WORKINPROGRESS/PixelShader.cs
@@ -7,7 +7,7 @@ namespace System.Windows.Media.Effects
 {
     public sealed partial class PixelShader : DependencyObject
     {
-        public static readonly DependencyProperty UriSourceProperty = DependencyProperty.Register("UriSourceProperty", typeof(Uri), typeof(PixelShader), new PropertyMetadata());
+        public static readonly DependencyProperty UriSourceProperty = DependencyProperty.Register(nameof(UriSource), typeof(Uri), typeof(PixelShader), new PropertyMetadata());
         
 
         public Uri UriSource

--- a/src/Runtime/Runtime/System.Windows.Media.Effects/WORKINPROGRESS/ShaderEffect.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Effects/WORKINPROGRESS/ShaderEffect.cs
@@ -7,7 +7,7 @@ namespace System.Windows.Media.Effects
 {
     public abstract partial class ShaderEffect : Effect
     {
-        protected static readonly DependencyProperty PixelShaderProperty = DependencyProperty.Register("PixelShaderProperty", typeof(PixelShader), typeof(ShaderEffect), new PropertyMetadata());
+        protected static readonly DependencyProperty PixelShaderProperty = DependencyProperty.Register(nameof(PixelShader), typeof(PixelShader), typeof(ShaderEffect), new PropertyMetadata());
         
 
         protected PixelShader PixelShader

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/TextBox.cs
@@ -1684,7 +1684,7 @@ element.setAttribute(""data-isreadonly"",""{1}"");
 
         public event RoutedEventHandler SelectionChanged;
 
-        public static readonly DependencyProperty SelectionForegroundProperty = DependencyProperty.Register("SelectiongoreGround", typeof(Brush), typeof(TextBox), null);
+        public static readonly DependencyProperty SelectionForegroundProperty = DependencyProperty.Register(nameof(SelectionForeground), typeof(Brush), typeof(TextBox), null);
 
         public Brush SelectionForeground
         {

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/WORKINPROGRESS/VirtualizingStackPanel.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/WORKINPROGRESS/VirtualizingStackPanel.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Controls
 	{
 		public static readonly DependencyProperty VirtualizationModeProperty = DependencyProperty.Register("VirtualizationMode", typeof(VirtualizationMode), typeof(VirtualizingStackPanel), null);
 		public static readonly DependencyProperty IsVirtualizingProperty = DependencyProperty.Register("IsVirtualizing", typeof(bool), typeof(VirtualizingStackPanel), null);
-		public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register("OrientationProperty", typeof(Orientation), typeof(VirtualizingStackPanel), new PropertyMetadata());
+		public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register(nameof(Orientation), typeof(Orientation), typeof(VirtualizingStackPanel), new PropertyMetadata());
 		public Orientation Orientation
 		{
 			get

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Media.Animation/WORKINPROGRESS/PointAnimation.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Media.Animation/WORKINPROGRESS/PointAnimation.cs
@@ -14,9 +14,9 @@ namespace Windows.UI.Xaml.Media.Animation
 {
 	public sealed partial class PointAnimation : Timeline
 	{
-		public static readonly DependencyProperty FromProperty = DependencyProperty.Register("FromProperty", typeof(Nullable<Point>), typeof(PointAnimation), new PropertyMetadata());
-		public static readonly DependencyProperty ToProperty = DependencyProperty.Register("ToProperty", typeof(Nullable<Point>), typeof(PointAnimation), new PropertyMetadata());
-		public static readonly DependencyProperty ByProperty = DependencyProperty.Register("ByProperty", typeof(Nullable<Point>), typeof(PointAnimation), new PropertyMetadata());
+		public static readonly DependencyProperty FromProperty = DependencyProperty.Register(nameof(From), typeof(Nullable<Point>), typeof(PointAnimation), new PropertyMetadata());
+		public static readonly DependencyProperty ToProperty = DependencyProperty.Register(nameof(To), typeof(Nullable<Point>), typeof(PointAnimation), new PropertyMetadata());
+		public static readonly DependencyProperty ByProperty = DependencyProperty.Register(nameof(By), typeof(Nullable<Point>), typeof(PointAnimation), new PropertyMetadata());
 		public Nullable<Point> From
 		{
 			get

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Media/WORKINPROGRESS/ImageBrush.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Media/WORKINPROGRESS/ImageBrush.cs
@@ -10,7 +10,7 @@ namespace Windows.UI.Xaml.Media
 {
 	public sealed partial class ImageBrush : TileBrush
 	{
-		public static readonly DependencyProperty ImageSourceProperty = DependencyProperty.Register("ImageSourceProperty", typeof(ImageSource), typeof(ImageBrush), new PropertyMetadata());
+		public static readonly DependencyProperty ImageSourceProperty = DependencyProperty.Register(nameof(ImageSource), typeof(ImageSource), typeof(ImageBrush), new PropertyMetadata());
 		public ImageSource ImageSource
 		{
 			get

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Media/WORKINPROGRESS/TileBrush.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Media/WORKINPROGRESS/TileBrush.cs
@@ -10,9 +10,9 @@ namespace Windows.UI.Xaml.Media
 {
 	public abstract partial class TileBrush : Brush
 	{
-		public static readonly DependencyProperty AlignmentXProperty = DependencyProperty.Register("AlignmentXProperty", typeof(AlignmentX), typeof(TileBrush), new PropertyMetadata());
-		public static readonly DependencyProperty AlignmentYProperty = DependencyProperty.Register("AlignmentYProperty", typeof(AlignmentY), typeof(TileBrush), new PropertyMetadata());
-		public static readonly DependencyProperty StretchProperty = DependencyProperty.Register("StretchProperty", typeof(Stretch), typeof(TileBrush), new PropertyMetadata());
+		public static readonly DependencyProperty AlignmentXProperty = DependencyProperty.Register(nameof(AlignmentX), typeof(AlignmentX), typeof(TileBrush), new PropertyMetadata());
+		public static readonly DependencyProperty AlignmentYProperty = DependencyProperty.Register(nameof(AlignmentY), typeof(AlignmentY), typeof(TileBrush), new PropertyMetadata());
+		public static readonly DependencyProperty StretchProperty = DependencyProperty.Register(nameof(Stretch), typeof(Stretch), typeof(TileBrush), new PropertyMetadata());
 		public AlignmentX AlignmentX
 		{
 			get

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Shapes/Shape.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Shapes/Shape.cs
@@ -1017,7 +1017,7 @@ context.restore();
         public PenLineCap StrokeDashCap
         {
             get { return (PenLineCap)GetValue(StrokeDashCapProperty); }
-            set { SetValue(StrokeStartLineCapProperty, value); }
+            set { SetValue(StrokeDashCapProperty, value); }
         }
 
         /// <summary>
@@ -1027,7 +1027,7 @@ context.restore();
         /// The identifier for the StrokeDashCap dependency property.
         /// </returns>
         public static readonly DependencyProperty StrokeDashCapProperty =
-            DependencyProperty.Register("StrokeDashCap", typeof(PenLineCap), typeof(Shape), new PropertyMetadata(PenLineCap.Flat));
+            DependencyProperty.Register(nameof(StrokeDashCap), typeof(PenLineCap), typeof(Shape), new PropertyMetadata(PenLineCap.Flat));
 
 #endif
 


### PR DESCRIPTION
Some dependency properties configured with the incorrect CLR "wrapper' properties names. Some CLR "wrapper" properties use the incorrect dependency property as a backing field in their getters/setters. The `nameof` directive used instead of the hardcoded constants for referencing the CLR "wrapper" properties names and preventing such a problem in the future.