### PR TITLE
Fixed potential (minor) possible null dereferencing problems found by the PVS-Studio static code analyzer

### DIFF
--- a/src/Compiler/Compiler/3_ConvertingCSharpToExeOrDll/BuildLogger.cs
+++ b/src/Compiler/Compiler/3_ConvertingCSharpToExeOrDll/BuildLogger.cs
@@ -129,12 +129,11 @@ namespace DotNetForHtml5.Compiler
         {
             for (int i = indent; i > 0; i--)
             {
-                if (OnWrite != null)
-                    OnWrite(this, new OnWriteEventArgs() { Text = "\t" });
+                OnWrite?.Invoke(this, new OnWriteEventArgs() { Text = "\t" });
                 //streamWriter.Write("\t");
             }
-            if (OnWrite != null)
-                OnWrite(this, new OnWriteEventArgs() { Text = line + e.Message });
+
+            OnWrite?.Invoke(this, new OnWriteEventArgs() { Text = line + e.Message });
             //streamWriter.WriteLine(line + e.Message);
         }
 

--- a/src/Runtime/Runtime/Core/WebRequestHelper/INTERNAL_WebRequestHelper_JSOnly.cs
+++ b/src/Runtime/Runtime/Core/WebRequestHelper/INTERNAL_WebRequestHelper_JSOnly.cs
@@ -434,10 +434,7 @@ namespace System
             SetEventArgs(e);
             if (!_isFirstTryAtSendingUnsafeRequest || !IsCrashInPreflight) // if NOT(first unsafe try AND preflight error). The only case we do not want to enter this if is when the request will be resent without credentials.
             {
-                if (DownloadStringCompleted != null)
-                {
-                    DownloadStringCompleted(_sender, e);
-                }
+                DownloadStringCompleted?.Invoke(_sender, e);
             }
             _isFirstTryAtSendingUnsafeRequest = false;
         }

--- a/src/Runtime/Runtime/PagedCollectionView/CollectionViewGroupRoot.cs
+++ b/src/Runtime/Runtime/PagedCollectionView/CollectionViewGroupRoot.cs
@@ -262,10 +262,7 @@ namespace Windows.UI.Xaml.Data
         {
             Debug.Assert(args != null, "Arguments passed in should not be null");
 
-            if (this.CollectionChanged != null)
-            {
-                this.CollectionChanged(this, args);
-            }
+            CollectionChanged?.Invoke(this, args);
         }
 
         /// <summary>
@@ -273,10 +270,7 @@ namespace Windows.UI.Xaml.Data
         /// </summary>
         protected override void OnGroupByChanged()
         {
-            if (this.GroupDescriptionChanged != null)
-            {
-                this.GroupDescriptionChanged(this, EventArgs.Empty);
-            }
+            GroupDescriptionChanged?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>

--- a/src/Runtime/Runtime/PagedCollectionView/PagedCollectionView.cs
+++ b/src/Runtime/Runtime/PagedCollectionView/PagedCollectionView.cs
@@ -3078,10 +3078,7 @@ namespace Windows.UI.Xaml.Data
                 return;
             }
 
-            if (this.CurrentChanging != null)
-            {
-                this.CurrentChanging(this, args);
-            }
+            CurrentChanging?.Invoke(this, args);
         }
 
         /// <summary>
@@ -3136,10 +3133,7 @@ namespace Windows.UI.Xaml.Data
         /// <param name="e">PropertyChangedEventArgs for this change</param>
         private void OnPropertyChanged(PropertyChangedEventArgs e)
         {
-            if (this.PropertyChanged != null)
-            {
-                this.PropertyChanged(this, e);
-            }
+            PropertyChanged?.Invoke(this, e);
         }
 
         /// <summary>

--- a/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/HtmlCanvasElement.cs
+++ b/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/HtmlCanvasElement.cs
@@ -486,50 +486,32 @@ $0.miterLimit = $1", jsContext2d,
 
         public virtual void OnPointerMoved(HtmlCanvasPointerRoutedEventArgs e)
         {
-            if (PointerMoved != null)
-            {
-                PointerMoved(this, e);
-            }
+            PointerMoved?.Invoke(this, e);
         }
 
         public virtual void OnPointerPressed(HtmlCanvasPointerRoutedEventArgs e)
         {
-            if (PointerPressed != null)
-            {
-                PointerPressed(this, e);
-            }
+            PointerPressed?.Invoke(this, e);
         }
 
         public virtual void OnRightTapped(HtmlCanvasPointerRoutedEventArgs e)
         {
-            if (RightTapped != null)
-            {
-                RightTapped(this, e);
-            }
+            RightTapped?.Invoke(this, e);
         }
 
         public virtual void OnPointerReleased(HtmlCanvasPointerRoutedEventArgs e)
         {
-            if (PointerReleased != null)
-            {
-                PointerReleased(this, e);
-            }
+            PointerReleased?.Invoke(this, e);
         }
 
         public virtual void OnPointerEntered(HtmlCanvasPointerRoutedEventArgs e)
         {
-            if (PointerEntered != null)
-            {
-                PointerEntered(this, e);
-            }
+            PointerEntered?.Invoke(this, e);
         }
 
         public virtual void OnPointerExited(HtmlCanvasPointerRoutedEventArgs e)
         {
-            if (PointerExited != null)
-            {
-                PointerExited(this, e);
-            }
+            PointerExited?.Invoke(this, e);
         }
 
         ContextMenu _contextMenu;
@@ -553,8 +535,7 @@ $0.miterLimit = $1", jsContext2d,
 
         internal void INTERNAL_RaiseContextMenuOpeningEvent(double pointerLeft, double pointerTop)
         {
-            if (ContextMenuOpening != null)
-                ContextMenuOpening(this, new ContextMenuEventArgs(pointerLeft, pointerTop));
+            ContextMenuOpening?.Invoke(this, new ContextMenuEventArgs(pointerLeft, pointerTop));
         }
     }
 }

--- a/src/Runtime/Runtime/System.ComponentModel.Composition.Hosting/WORKINPROGRESS/DeploymentCatalog.cs
+++ b/src/Runtime/Runtime/System.ComponentModel.Composition.Hosting/WORKINPROGRESS/DeploymentCatalog.cs
@@ -213,10 +213,7 @@ namespace System.ComponentModel.Composition.Hosting
         /// </param>
         protected virtual void OnChanged(ComposablePartCatalogChangeEventArgs e)
         {
-            if (this.Changed != null)
-            {
-                this.Changed(this, e);
-            }
+            Changed?.Invoke(this, e);
         }
 
         /// <summary>
@@ -227,10 +224,7 @@ namespace System.ComponentModel.Composition.Hosting
         /// </param>
         protected virtual void OnChanging(ComposablePartCatalogChangeEventArgs e)
         {
-            if (this.Changing != null)
-            {
-                this.Changing(this, e);
-            }
+            Changing?.Invoke(this, e);
         }
 
         /// <summary>

--- a/src/Runtime/Runtime/System.ComponentModel/GroupDescription.cs
+++ b/src/Runtime/Runtime/System.ComponentModel/GroupDescription.cs
@@ -74,10 +74,7 @@ namespace System.ComponentModel
         /// </summary>
         protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
         {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, e);
-            }
+            PropertyChanged?.Invoke(this, e);
         }
 
         #endregion INotifyPropertyChanged

--- a/src/Runtime/Runtime/System.ComponentModel/SortDescriptionCollection.cs
+++ b/src/Runtime/Runtime/System.ComponentModel/SortDescriptionCollection.cs
@@ -115,18 +115,12 @@ namespace System.ComponentModel
         /// </summary>
         private void OnCollectionChanged(NotifyCollectionChangedAction action, object item, int index)
         {
-            if (CollectionChanged != null)
-            {
-                CollectionChanged(this, new NotifyCollectionChangedEventArgs(action, item, index));
-            }
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action, item, index));
         }
         // raise CollectionChanged event to any listeners
         void OnCollectionChanged(NotifyCollectionChangedAction action)
         {
-            if (CollectionChanged != null)
-            {
-                CollectionChanged(this, new NotifyCollectionChangedEventArgs(action));
-            }
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action));
         }
         #endregion Protected Methods
 

--- a/src/Runtime/Runtime/System.Net/WebClient.cs
+++ b/src/Runtime/Runtime/System.Net/WebClient.cs
@@ -136,10 +136,7 @@ namespace System.Net
         //todo: replace that with something in javascript (and see todo on INTERNAL_TestIfCompletedStatus even though this will not be used that way)
         void OnDownloadStringCompleted(object sender, INTERNAL_WebRequestHelper_JSOnly_RequestCompletedEventArgs e)
         {
-            if (DownloadStringCompleted != null)
-            {
-                DownloadStringCompleted(sender, new DownloadStringCompletedEventArgs(e));
-            }
+            DownloadStringCompleted?.Invoke(sender, new DownloadStringCompletedEventArgs(e));
         }
 
         // Exceptions:
@@ -801,10 +798,7 @@ namespace System.Net
         public event UploadStringCompletedEventHandler UploadStringCompleted;
         void OnUploadStringCompleted(object sender, UploadStringCompletedEventArgs e)
         {
-            if (UploadStringCompleted != null)
-            {
-                UploadStringCompleted(sender, e);
-            }
+            UploadStringCompleted?.Invoke(sender, e);
         }
 
 

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/ButtonBase.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/ButtonBase.cs
@@ -130,11 +130,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
         /// </summary>
         protected virtual void OnClick()
         {
-            if (Click != null)
-                Click(this, new RoutedEventArgs()
-                {
-                    OriginalSource = this //todo: the OriginalSource should not aways be the button itself: if the button contains inner elements, it is supposed to be the inner element on which the user has clicked.
-                });
+            Click?.Invoke(this, new RoutedEventArgs
+            {
+                OriginalSource = this //todo: the OriginalSource should not aways be the button itself: if the button contains inner elements, it is supposed to be the inner element on which the user has clicked.
+            });
         }
 
 #if MIGRATION

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/Popup.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/Popup.cs
@@ -79,10 +79,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
         public event EventHandler Opened;
         void OnOpened()
         {
-            if(Opened != null)
-            {
-                Opened(this, new EventArgs());
-            }
+            Opened?.Invoke(this, new EventArgs());
         }
 
         /// <summary>
@@ -91,10 +88,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
         public event EventHandler Closed;
         void OnClosed()
         {
-            if (Closed != null)
-            {
-                Closed(this, new EventArgs());
-            }
+            Closed?.Invoke(this, new EventArgs());
         }
 
         /// <summary>
@@ -327,8 +321,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
             }
 
             // Raise the internal "PopupMoved" event, which is useful for example to hide the validation popups of TextBoxes in case the user scrolls and the TextBox is no longer visible on screen (cf. ZenDesk 628):
-            if (INTERNAL_PopupMoved != null)
-                INTERNAL_PopupMoved(this, new EventArgs());
+            INTERNAL_PopupMoved?.Invoke(this, new EventArgs());
         }
 
 
@@ -599,8 +592,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
         internal void CloseFromAnOutsideClick()
         {
-            if (ClosedDueToOutsideClick != null)
-                ClosedDueToOutsideClick(this, new EventArgs());
+            ClosedDueToOutsideClick?.Invoke(this, new EventArgs());
 
             if (IsOpen)
                 this.IsOpen = false;

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/RangeBase.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/RangeBase.cs
@@ -210,11 +210,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
         /// <param name="newValue">New value of the Value property.</param>
         protected virtual void OnValueChanged(double oldValue, double newValue)
         {
-            if (this.ValueChanged != null)
 #if MIGRATION
-                this.ValueChanged(this, new RoutedPropertyChangedEventArgs<double>(oldValue, newValue));
+            ValueChanged?.Invoke(this, new RoutedPropertyChangedEventArgs<double>(oldValue, newValue));
 #else
-                this.ValueChanged(this, new RangeBaseValueChangedEventArgs(oldValue, newValue));
+            ValueChanged?.Invoke(this, new RangeBaseValueChangedEventArgs(oldValue, newValue));
 #endif
         }
     }

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/ScrollBar.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/ScrollBar.cs
@@ -229,8 +229,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
             if (newValue != this.Value)
             {
                 this.SetCurrentValue(RangeBase.ValueProperty, newValue); // Note: we do not use "this.Value = newValue" because it deletes any bindings that the user may have set to the scrollbar with <ScrollBar Value="{Binding...}"/>.
-                if (this.Scroll != null)
-                    this.Scroll(this, new ScrollEventArgs(newValue, scrollEventType));
+                Scroll?.Invoke(this, new ScrollEventArgs(newValue, scrollEventType));
             }
         }
 
@@ -263,8 +262,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
                 _horizontalLargeIncrease.IsHitTestVisible = true;
 
             // Call the "Scroll" event passing the "EndScroll" argument:
-            if (this.Scroll != null)
-                this.Scroll(this, new ScrollEventArgs(this.Value, ScrollEventType.EndScroll));
+            Scroll?.Invoke(this, new ScrollEventArgs(this.Value, ScrollEventType.EndScroll));
         }
 
         void ChangeValueBasedOnPointerMovement(double pointerMovementInPixels)
@@ -306,8 +304,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
                     UpdateThumbPositionAndSize(totalControlSizeInMainDirection);
 
                     // Call the "Scroll" event:
-                    if (this.Scroll != null)
-                        this.Scroll(this, new ScrollEventArgs(newValue, ScrollEventType.ThumbTrack));
+                    Scroll?.Invoke(this, new ScrollEventArgs(newValue, ScrollEventType.ThumbTrack));
                 }
             }
         }

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/Selector.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/Selector.cs
@@ -475,10 +475,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
         /// <param name="e">The arguments for the event.</param>
         protected virtual void OnSelectionChanged(SelectionChangedEventArgs e)
         {
-            if (this.SelectionChanged != null)
-            {
-                this.SelectionChanged(this, e);
-            }
+            SelectionChanged?.Invoke(this, e);
         }
 
         protected override void OnItemsChanged(NotifyCollectionChangedEventArgs e)

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/Thumb.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/Thumb.cs
@@ -88,8 +88,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
             this.IsDragging = true;
 
             // Raise the "DragStarted" event:
-            if (DragStarted != null)
-                DragStarted(this, new DragStartedEventArgs(_pointerX, _pointerY));
+            DragStarted?.Invoke(this, new DragStartedEventArgs(_pointerX, _pointerY));
         }
 
 #if MIGRATION
@@ -122,8 +121,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
                 double verticalChange = e.GetCurrentPoint(null).Position.Y - _pointerY;
 #endif
                 // Raise the "DragDelta" event:
-                if (DragDelta != null)
-                    DragDelta(this, new DragDeltaEventArgs(horizontalChange, verticalChange));
+                DragDelta?.Invoke(this, new DragDeltaEventArgs(horizontalChange, verticalChange));
 
                 // Remember the new pointer position:
 #if MIGRATION
@@ -155,8 +153,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
                 this.IsDragging = false;
 
                 // Raise the "DragCompleted" event:
-                if (DragCompleted != null)
-                    DragCompleted(this, new DragCompletedEventArgs(0d, 0d, false));
+                DragCompleted?.Invoke(this, new DragCompletedEventArgs(0d, 0d, false));
             }
         }
 

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/ToggleButton.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls.Primitives/ToggleButton.cs
@@ -424,13 +424,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
         /// </summary>
         protected void OnChecked()
         {
-            if (Checked != null)
+            Checked?.Invoke(this, new RoutedEventArgs
             {
-                Checked(this, new RoutedEventArgs()
-                {
-                    OriginalSource = this
-                });
-            }
+                OriginalSource = this
+            });
             _isChecked = true;
             UpdateVisualStates();
         }
@@ -444,13 +441,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
         /// </summary>
         protected void OnIndeterminate()
         {
-            if (Indeterminate != null)
+            Indeterminate?.Invoke(this, new RoutedEventArgs
             {
-                Indeterminate(this, new RoutedEventArgs()
-                {
-                    OriginalSource = this
-                });
-            }
+                OriginalSource = this
+            });
             _isChecked = null;
             UpdateVisualStates();
         }
@@ -464,13 +458,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
         /// </summary>
         protected void OnUnchecked()
         {
-            if (Unchecked != null)
+            Unchecked?.Invoke(this, new RoutedEventArgs
             {
-                Unchecked(this, new RoutedEventArgs()
-                {
-                    OriginalSource = this
-                });
-            }
+                OriginalSource = this
+            });
             _isChecked = false;
             UpdateVisualStates();
 

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/AutoCompleteBox.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/AutoCompleteBox.cs
@@ -391,8 +391,7 @@ namespace Windows.UI.Xaml.Controls
 
         protected virtual void OnTextChanged(RoutedEventArgs e)
         {
-            if (TextChanged != null)
-                TextChanged(this, e);
+            TextChanged?.Invoke(this, e);
         }
 
         /// <summary>
@@ -777,8 +776,7 @@ namespace Windows.UI.Xaml.Controls
 #else
         protected virtual void OnDropDownClosed(RoutedEventArgs e)
         {
-            if (DropDownClosed != null)
-                DropDownClosed(this, e);
+            DropDownClosed?.Invoke(this, e);
         }
 #endif
 
@@ -792,8 +790,7 @@ namespace Windows.UI.Xaml.Controls
         protected virtual void OnDropDownOpened(RoutedEventArgs e)
 #endif
         {
-            if (DropDownOpened != null)
-                DropDownOpened(this, e);
+            DropDownOpened?.Invoke(this, e);
         }
 
         /// <summary>

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/ComboBox.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/ComboBox.cs
@@ -263,8 +263,7 @@ namespace Windows.UI.Xaml.Controls
         protected virtual void OnDropDownClosed(RoutedEventArgs e)
 #endif
         {
-            if (DropDownClosed != null)
-                DropDownClosed(this, e);
+            DropDownClosed?.Invoke(this, e);
         }
 
         /// <summary>
@@ -277,8 +276,7 @@ namespace Windows.UI.Xaml.Controls
         protected virtual void OnDropDownOpened(RoutedEventArgs e)
 #endif
         {
-            if (DropDownOpened != null)
-                DropDownOpened(this, e);
+            DropDownOpened?.Invoke(this, e);
         }
 
         /// <summary>

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/ContextMenu.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/ContextMenu.cs
@@ -258,8 +258,7 @@ namespace Windows.UI.Xaml.Controls
         /// <param name="e">The event data for the System.Windows.Controls.ContextMenu.Closed event.</param>
         protected virtual void OnClosed(RoutedEventArgs e)
         {
-            if (this.Closed != null)
-                this.Closed(this, new RoutedEventArgs());
+            Closed?.Invoke(this, new RoutedEventArgs());
         }
 
         /// <summary>
@@ -268,8 +267,7 @@ namespace Windows.UI.Xaml.Controls
         /// <param name="e">The event data for the System.Windows.Controls.ContextMenu.Opened event.</param>
         protected virtual void OnOpened(RoutedEventArgs e)
         {
-            if (this.Opened != null)
-                this.Opened(this, new RoutedEventArgs());
+            Opened?.Invoke(this, new RoutedEventArgs());
         }
 
         #endregion

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGrid.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGrid.cs
@@ -123,10 +123,7 @@ namespace Windows.UI.Xaml.Controls
 
         protected virtual void OnLoadingRow(DataGridRowEventArgs e)
         {
-            if (LoadingRow != null)
-            {
-                LoadingRow(this, e);
-            }
+            LoadingRow?.Invoke(this, e);
         }
 
         [Obsolete("Use AlternatingRowBackground instead")]

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGridRow.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGridRow.cs
@@ -91,14 +91,11 @@ namespace Windows.UI.Xaml.Controls
         public void OnMouseLeftButtonUp(object sender, PointerRoutedEventArgs e)
 #endif
         {
-            if (MouseLeftButtonUp != null)
-            {
 #if MIGRATION
-                MouseLeftButtonUp(this, new MouseButtonEventArgs());
+            MouseLeftButtonUp?.Invoke(this, new MouseButtonEventArgs());
 #else
-                MouseLeftButtonUp(this, new PointerRoutedEventArgs());
+            MouseLeftButtonUp?.Invoke(this, new PointerRoutedEventArgs());
 #endif
-            }
         }
 
         //public object Header //todo: see what it should actually be.

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGridRowEventArgs.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DataGridRowEventArgs.cs
@@ -15,7 +15,6 @@
 
 using CSHTML5.Internal;
 using System;
-using System.Windows;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DragDropTarget_2.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/DragDropTarget_2.cs
@@ -169,8 +169,7 @@ namespace Windows.UI.Xaml.Controls
                     ItemDragEventArgs itemDragStartingEventArgs = new ItemDragEventArgs(selectionCollection);
 
                     // Raise the "ItemDragStarting" event:
-                    if (ItemDragStarting != null)
-                        ItemDragStarting(this, itemDragStartingEventArgs);
+                    ItemDragStarting?.Invoke(this, itemDragStartingEventArgs);
 
                     // Show the popup, unless the user has cancelled the drag operation:
                     if (itemDragStartingEventArgs.Handled && itemDragStartingEventArgs.Cancel)
@@ -426,7 +425,7 @@ namespace Windows.UI.Xaml.Controls
                             dataObject.SetData("ItemDragEventArgs", new ItemDragEventArgs(selectionCollection));
 
 #if !(BRIDGE && MIGRATION)
-                            dragDropTargetUnderPointer.ItemDroppedOnSource(dragDropTargetUnderPointer, new MS.DragEventArgs(dataObject, e));
+                            dragDropTargetUnderPointer.ItemDroppedOnSource?.Invoke(dragDropTargetUnderPointer, new MS.DragEventArgs(dataObject, e));
 #endif
                         }
                     }
@@ -449,7 +448,7 @@ namespace Windows.UI.Xaml.Controls
 
                             // Raise the Drop event:
 #if !(BRIDGE && MIGRATION)
-                            dragDropTargetUnderPointer.Drop(dragDropTargetUnderPointer, new MS.DragEventArgs(dataObject, e));
+                            dragDropTargetUnderPointer.Drop?.Invoke(dragDropTargetUnderPointer, new MS.DragEventArgs(dataObject, e));
 #endif
                         }
 
@@ -472,8 +471,7 @@ namespace Windows.UI.Xaml.Controls
             }
 
             // Raise the "ItemDragCompleted" event:
-            if (ItemDragCompleted != null)
-                ItemDragCompleted(this, new ItemDragEventArgs(selectionCollection));
+            ItemDragCompleted?.Invoke(this, new ItemDragEventArgs(selectionCollection));
         }
 
         void PutSourceBackToOriginalPlace()
@@ -516,10 +514,7 @@ namespace Windows.UI.Xaml.Controls
         /// <param name="dragOverEventArgs">Information about the event.</param>
         protected virtual void OnDragOver(MS.DragEventArgs dragOverEventArgs)
         {
-            if (this.DragOver != null)
-            {
-                this.DragOver(this, dragOverEventArgs);
-            }
+            DragOver?.Invoke(this, dragOverEventArgs);
 
         }
 

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/INTERNAL_CalendarOrClockBase.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/INTERNAL_CalendarOrClockBase.cs
@@ -121,14 +121,8 @@ namespace Windows.UI.Xaml.Controls
 
         internal void OnSelectedDatesCollectionChanged(SelectionChangedEventArgs e)
         {
-            if (SelectionChanged != null)
-            {
-                SelectionChanged(this, e);
-            }
-            if (SelectedDatesChanged != null)
-            {
-                SelectedDatesChanged(this, e);
-            }
+            SelectionChanged?.Invoke(this, e);
+            SelectedDatesChanged?.Invoke(this, e);
         }
 
         #endregion

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/INTERNAL_DateTimePickerBase.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/INTERNAL_DateTimePickerBase.cs
@@ -208,8 +208,7 @@ namespace Windows.UI.Xaml.Controls
 
             RefreshTextBox();
 
-            if (SelectedDateChanged != null)
-                SelectedDateChanged(this, e); // fire public event
+            SelectedDateChanged?.Invoke(this, e); // fire public event
         }
 
         protected abstract INTERNAL_CalendarOrClockBase GenerateCalendarOrClock();

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/PasswordBox.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/PasswordBox.cs
@@ -131,10 +131,7 @@ namespace Windows.UI.Xaml.Controls
         /// </summary>
         protected void OnPasswordChanged(RoutedEventArgs eventArgs)
         {
-            if (PasswordChanged != null)
-            {
-                PasswordChanged(this, eventArgs);
-            }
+            PasswordChanged?.Invoke(this, eventArgs);
         }
 
         #endregion

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/Slider.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/Slider.cs
@@ -236,8 +236,7 @@ namespace Windows.UI.Xaml.Controls
             if (newValue != this.Value)
             {
                 this.SetCurrentValue(RangeBase.ValueProperty, newValue); // Note: we do not use "this.Value = newValue" because it deletes any bindings that the user may have set to the scrollbar with <ScrollBar Value="{Binding...}"/>.
-                if (this.Scroll != null)
-                    this.Scroll(this, new ScrollEventArgs(newValue, scrollEventType));
+                Scroll?.Invoke(this, new ScrollEventArgs(newValue, scrollEventType));
             }
 
             if (Orientation == Orientation.Horizontal)
@@ -294,8 +293,7 @@ namespace Windows.UI.Xaml.Controls
         void OnDragCompleted()
         {
             // Call the "Scroll" event passing the "EndScroll" argument:
-            if (this.Scroll != null)
-                this.Scroll(this, new ScrollEventArgs(this.Value, ScrollEventType.EndScroll));
+            Scroll?.Invoke(this, new ScrollEventArgs(this.Value, ScrollEventType.EndScroll));
 
             if (_horizontalLargeDecrease != null)
                 _horizontalLargeDecrease.IsHitTestVisible = true;
@@ -342,8 +340,7 @@ namespace Windows.UI.Xaml.Controls
                     UpdateThumbPositionAndSize(totalControlSizeInMainDirection);
 
                     // Call the "Scroll" event:
-                    if (this.Scroll != null)
-                        this.Scroll(this, new ScrollEventArgs(newValue, ScrollEventType.ThumbTrack));
+                    Scroll?.Invoke(this, new ScrollEventArgs(newValue, ScrollEventType.ThumbTrack));
                 }
             }
         }

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/TextBox.cs
@@ -316,10 +316,7 @@ element.setAttribute(""data-acceptsreturn"", ""{1}"");
         /// <param name="eventArgs">The arguments for the event.</param>
         protected virtual void OnTextChanged(TextChangedEventArgs eventArgs)
         {
-            if (TextChanged != null)
-            {
-                TextChanged(this, eventArgs);
-            }
+            TextChanged?.Invoke(this, eventArgs);
         }
 
         #endregion

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/TileViewItem.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/TileViewItem.cs
@@ -42,19 +42,13 @@ namespace Windows.UI.Xaml.Controls
         internal void Maximize()
         {
             VisualStateManager.GoToState(this, "Maximized", false);
-            if (OnMaximize != null)
-            {
-                OnMaximize(this, null);
-            }
+            OnMaximize?.Invoke(this, null);
         }
 
         internal void Minimize()
         {
             VisualStateManager.GoToState(this, "Minimized", false);
-            if (OnMinimize != null)
-            {
-                OnMinimize(this, null);
-            }
+            OnMinimize?.Invoke(this, null);
         }
 
         public event EventHandler OnMaximize;

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/ToolTip.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/ToolTip.cs
@@ -142,8 +142,7 @@ namespace Windows.UI.Xaml.Controls
                         toolTip._timerForClosingTooltipAfter5Seconds.Start();
 
                         // Raise the "Opened" event:
-                        if (toolTip.Opened != null)
-                            toolTip.Opened(toolTip, new RoutedEventArgs());
+                        toolTip.Opened?.Invoke(toolTip, new RoutedEventArgs());
                     }
                 }
                 else
@@ -156,8 +155,7 @@ namespace Windows.UI.Xaml.Controls
                         toolTip._parentPopup.IsOpen = false;
 
                         // Raise the "Closed" event:
-                        if (toolTip.Closed != null)
-                            toolTip.Closed(toolTip, new RoutedEventArgs());
+                        toolTip.Closed?.Invoke(toolTip, new RoutedEventArgs());
                     }
                 }
             }

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/WORKINPROGRESS/DataForm.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/WORKINPROGRESS/DataForm.cs
@@ -5259,7 +5259,7 @@ namespace Windows.UI.Xaml.Controls
                             propertyInfo.Name,
                             textBox.Text,
                             true /* doConversion */,
-                            propertyInfo != null ? propertyInfo.PropertyType : null,
+                            propertyInfo.PropertyType,
                             bindingExpression.ParentBinding.Converter,
                             bindingExpression.ParentBinding.ConverterParameter,
 #if MIGRATION

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Data/CollectionView.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Data/CollectionView.cs
@@ -719,10 +719,7 @@ namespace Windows.UI.Xaml.Data
         /// </summary>
         protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
         {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, e);
-            }
+            PropertyChanged?.Invoke(this, e);
         }
 
         /// <summary>
@@ -815,13 +812,12 @@ namespace Windows.UI.Xaml.Data
         protected virtual void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
         {
             if (args == null)
-                throw new ArgumentNullException("args");
+                throw new ArgumentNullException(nameof(args));
 
             unchecked
             { ++_timestamp; }    // invalidate enumerators because of a change
 
-            if (CollectionChanged != null)
-                CollectionChanged(this, args);
+            CollectionChanged?.Invoke(this, args);
 
             // Collection changes change the count unless an item is being
             // replaced or moved within the collection.
@@ -938,10 +934,7 @@ namespace Windows.UI.Xaml.Data
                 return;
             }
 
-            if (CurrentChanging != null)
-            {
-                CurrentChanging(this, args);
-            }
+            CurrentChanging?.Invoke(this, args);
         }
 
         /// <summary>

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Data/CollectionViewGroup.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Data/CollectionViewGroup.cs
@@ -98,10 +98,7 @@ namespace Windows.UI.Xaml.Data
         /// </summary>
         protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
         {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, e);
-            }
+            PropertyChanged?.Invoke(this, e);
         }
 
         #endregion INotifyPropertyChanged

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Data/INTERNAL_PagedCollectionView.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Data/INTERNAL_PagedCollectionView.cs
@@ -321,10 +321,7 @@ namespace Windows.UI.Xaml.Data
 
         protected virtual void OnPropertyChanged(string propertyName)
         {
-            if (this.PropertyChanged != null)
-            {
-                this.PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-            }
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 #endif
         // old version 
@@ -578,10 +575,7 @@ namespace Windows.UI.Xaml.Data
 
         private void OnPageChanged()
         {
-            if (PageChanged != null)
-            {
-                PageChanged(this, new EventArgs());
-            }
+            PageChanged?.Invoke(this, new EventArgs());
             ChangeOutputColletion();
             _isPageChanging = false;
         }

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Documents/Hyperlink.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Documents/Hyperlink.cs
@@ -76,8 +76,7 @@ namespace Windows.UI.Xaml.Documents
         void Hyperlink_PointerPressed(object sender, PointerRoutedEventArgs e)
 #endif
         {
-            if (Click != null)
-                Click(this, new RoutedEventArgs());
+            Click?.Invoke(this, new RoutedEventArgs());
 
             if (_uri != null)
                 HtmlPage.Window.Navigate(_uri, "_blank");

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Media.Animation/ObjectAnimationUsingKeyFrames.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Media.Animation/ObjectAnimationUsingKeyFrames.cs
@@ -340,8 +340,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
             private void INTERNAL_RaiseCompletedEvent()
             {
-                if (Completed != null)
-                    Completed(this, new EventArgs());
+                Completed?.Invoke(this, new EventArgs());
             }
 
             internal void Start()

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Media.Animation/Timeline.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Media.Animation/Timeline.cs
@@ -252,8 +252,7 @@ namespace Windows.UI.Xaml.Media.Animation
         public event EventHandler Completed;
         internal void INTERNAL_RaiseCompletedEvent()
         {
-            if (Completed != null)
-                Completed(this, new EventArgs());
+            Completed?.Invoke(this, new EventArgs());
         }
 
         internal HashSet2<Guid> CompletedGuids = new HashSet2<Guid>();
@@ -267,8 +266,8 @@ namespace Windows.UI.Xaml.Media.Animation
             {
                 CompletedGuids.Add(guid);
             }
-            if (Completed != null)
-                Completed(this, new EventArgs());
+
+            Completed?.Invoke(this, new EventArgs());
         }
 
         internal virtual void Stop(FrameworkElement frameworkElement, string groupName, bool revertToFormerValue = false)

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Media.Imaging/BitmapImage.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Media.Imaging/BitmapImage.cs
@@ -164,13 +164,10 @@ namespace Windows.UI.Xaml.Media.Imaging
         public event ExceptionRoutedEventHandler ImageFailed;
         protected void OnImageFailed()
         {
-            if (ImageFailed != null)
+            ImageFailed?.Invoke(this, new ExceptionRoutedEventArgs()
             {
-                ImageFailed(this, new ExceptionRoutedEventArgs()
-                {
-                    OriginalSource = this
-                });
-            }
+                OriginalSource = this
+            });
         }
 
         /// <summary>
@@ -179,13 +176,10 @@ namespace Windows.UI.Xaml.Media.Imaging
         public event RoutedEventHandler ImageOpened;
         protected void OnImageOpened()
         {
-            if (ImageOpened != null)
+            ImageOpened?.Invoke(this, new RoutedEventArgs()
             {
-                ImageOpened(this, new RoutedEventArgs()
-                {
-                    OriginalSource = this
-                });
-            }
+                OriginalSource = this
+            });
         }
 
         //internal override void INTERNAL_AttachToDomEvents()
@@ -213,10 +207,7 @@ namespace Windows.UI.Xaml.Media.Imaging
         public event EventHandler UriSourceChanged;
         protected void OnUriSourceChanged()
         {
-            if (UriSourceChanged != null)
-            {
-                UriSourceChanged(this, new EventArgs());
-            }
+            UriSourceChanged?.Invoke(this, new EventArgs());
         }
 
 #if WORKINPROGRESS

--- a/src/Runtime/Runtime/Windows.UI.Xaml/Application.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml/Application.cs
@@ -141,8 +141,7 @@ namespace Windows.UI.Xaml
                 .INTERNAL_GetCurrentDispatcher().BeginInvoke((Action)(() =>
             {
                 // Raise the "Startup" event:
-                if (this.Startup != null)
-                    Startup(this, new StartupEventArgs());
+                Startup?.Invoke(this, new StartupEventArgs());
 
                 // Call the "OnLaunched" method:
                 this.OnLaunched(new LaunchActivatedEventArgs());

--- a/src/Runtime/Runtime/Windows.UI.Xaml/DependencyObject.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml/DependencyObject.cs
@@ -193,10 +193,7 @@ namespace Windows.UI.Xaml
 
         private void OnInheritedContextChanged(FrameworkElement newParent)
         {
-            if (this.InheritedContextChanged != null)
-            {
-                this.InheritedContextChanged(this, EventArgs.Empty);
-            }
+            InheritedContextChanged?.Invoke(this, EventArgs.Empty);
             foreach (DependencyObject listener in this._contextListeners)
             {
                 listener._inheritedParent = newParent;

--- a/src/Runtime/Runtime/Windows.UI.Xaml/DispatcherTimer.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml/DispatcherTimer.cs
@@ -116,10 +116,7 @@ namespace Windows.UI.Xaml
         /// </summary>
         protected void OnTick()
         {
-            if (Tick != null)
-            {
-                Tick(this, new EventArgs());
-            }
+            Tick?.Invoke(this, new EventArgs());
         }
 
         /// <summary>

--- a/src/Runtime/Runtime/Windows.UI.Xaml/FrameworkElement.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml/FrameworkElement.cs
@@ -366,10 +366,7 @@ namespace Windows.UI.Xaml
         private static void IsEnabled_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             FrameworkElement frameworkElement = (FrameworkElement)d;
-            if (frameworkElement.IsEnabledChanged != null)
-            {
-                frameworkElement.IsEnabledChanged(frameworkElement, e);
-            }
+            frameworkElement.IsEnabledChanged?.Invoke(frameworkElement, e);
             UIElement.InvalidateForceInheritPropertyOnChildren(frameworkElement, e.Property);
         }
 
@@ -524,10 +521,7 @@ namespace Windows.UI.Xaml
 
         private void RaiseDataContextChangedEvent(DependencyPropertyChangedEventArgs e)
         {
-            if (this.DataContextChanged != null)
-            {
-                this.DataContextChanged(this, e);
-            }
+            DataContextChanged?.Invoke(this, e);
         }
 
         /// <summary>Occurs when the data context for this element changes. </summary>
@@ -1100,8 +1094,7 @@ namespace Windows.UI.Xaml
 
         internal void INTERNAL_RaiseLoadedEvent()
         {
-            if (Loaded != null)
-                Loaded(this, new RoutedEventArgs());
+            Loaded?.Invoke(this, new RoutedEventArgs());
         }
 
         /// <summary>
@@ -1111,8 +1104,7 @@ namespace Windows.UI.Xaml
 
         internal void INTERNAL_RaiseUnloadedEvent()
         {
-            if (Unloaded != null)
-                Unloaded(this, new RoutedEventArgs());
+            Unloaded?.Invoke(this, new RoutedEventArgs());
         }
 
         #endregion

--- a/src/Runtime/Runtime/Windows.UI.Xaml/FrameworkElement_HandlingSizeAndAlignment.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml/FrameworkElement_HandlingSizeAndAlignment.cs
@@ -1677,8 +1677,7 @@ if ($0.tagName.toLowerCase() != 'span')
 
         internal void INTERNAL_RaiseContextMenuOpeningEvent(double pointerLeft, double pointerTop)
         {
-            if (ContextMenuOpening != null)
-                ContextMenuOpening(this, new ContextMenuEventArgs(pointerLeft, pointerTop));
+            ContextMenuOpening?.Invoke(this, new ContextMenuEventArgs(pointerLeft, pointerTop));
         }
 
         #endregion

--- a/src/Runtime/Runtime/Windows.UI.Xaml/UIElement.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml/UIElement.cs
@@ -550,10 +550,7 @@ namespace Windows.UI.Xaml
             // Invalidate the children so that they will inherit the new value.
             InvalidateForceInheritPropertyOnChildren((UIElement)d, e.Property);
 
-            if (uiElement.IsVisibleChanged != null)
-            {    
-                uiElement.IsVisibleChanged(d, e);
-            }
+            uiElement.IsVisibleChanged?.Invoke(d, e);
         }
 
         private static object CoerceIsVisibleProperty(DependencyObject d, object baseValue)
@@ -1148,11 +1145,9 @@ namespace Windows.UI.Xaml
 #endif
         {
 #if MIGRATION
-            if (LostMouseCapture != null)
-                LostMouseCapture(this, e);
+            LostMouseCapture?.Invoke(this, e);
 #else
-            if (PointerCaptureLost != null)
-                PointerCaptureLost(this, e);
+            PointerCaptureLost?.Invoke(this, e);
 #endif
         }
 

--- a/src/Runtime/Runtime/Windows.UI.Xaml/WORKINPROGRESS/Application.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml/WORKINPROGRESS/Application.cs
@@ -51,10 +51,7 @@ namespace Windows.UI.Xaml
 
         internal void OnUnhandledException(Exception exception, bool handled)
         {
-            if(UnhandledException != null)
-            {
-                UnhandledException(this, new ApplicationUnhandledExceptionEventArgs(exception, handled));
-            }
+            UnhandledException?.Invoke(this, new ApplicationUnhandledExceptionEventArgs(exception, handled));
         }
 
         //        void RaiseUnhandledException(object jsElement)

--- a/src/Simulator/Simulator/XamlInspection/TreeNode.cs
+++ b/src/Simulator/Simulator/XamlInspection/TreeNode.cs
@@ -34,7 +34,7 @@ namespace DotNetForHtml5.EmulatorWithoutJavascript.XamlInspection
             set
             {
                 _title = value;
-                NotifiyPropertyChanged("Title");
+                NotifyPropertyChanged("Title");
             }
         }
 
@@ -45,7 +45,7 @@ namespace DotNetForHtml5.EmulatorWithoutJavascript.XamlInspection
             set
             {
                 _name = value;
-                NotifiyPropertyChanged("Name");
+                NotifyPropertyChanged("Name");
             }
         }
 
@@ -57,7 +57,7 @@ namespace DotNetForHtml5.EmulatorWithoutJavascript.XamlInspection
             set
             {
                 _children = value;
-                NotifiyPropertyChanged("Children");
+                NotifyPropertyChanged("Children");
             }
         }
 
@@ -68,7 +68,7 @@ namespace DotNetForHtml5.EmulatorWithoutJavascript.XamlInspection
             set
             {
                 _element = value;
-                NotifiyPropertyChanged("Element");
+                NotifyPropertyChanged("Element");
             }
         }
 
@@ -79,7 +79,7 @@ namespace DotNetForHtml5.EmulatorWithoutJavascript.XamlInspection
             set
             {
                 _isNodeForXamlSourcePath = value;
-                NotifiyPropertyChanged("IsNodeForXamlSourcePath");
+                NotifyPropertyChanged("IsNodeForXamlSourcePath");
             }
         }
 
@@ -90,15 +90,14 @@ namespace DotNetForHtml5.EmulatorWithoutJavascript.XamlInspection
             set
             {
                 _xamlSourcePathOrNull = value;
-                NotifiyPropertyChanged("XamlSourcePathOrNull");
+                NotifyPropertyChanged("XamlSourcePathOrNull");
             }
         }
 
 
-        void NotifiyPropertyChanged(string property)
+        void NotifyPropertyChanged(string property)
         {
-            if (PropertyChanged != null)
-                PropertyChanged(this, new PropertyChangedEventArgs(property));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
         }
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
In most cases, the possible root cause of null pointer dereferencing is event handler invocation. In practice, it's almost always safe to do a check-and-call sequence but speaking formally we have to make a local copy of the handler before making a call. The null coalescing operator does it automatically and event invocation looks much shorter in this case.