### PR TITLE
Fixed minor problems (warnings) in XML comments found by the C# compiler during the full rebuild

### DIFF
--- a/src/Runtime/Runtime/Core/Events/INTERNAL_EventManager_2.cs
+++ b/src/Runtime/Runtime/Core/Events/INTERNAL_EventManager_2.cs
@@ -177,7 +177,8 @@ namespace CSHTML5.Internal
         /// </summary>
         /// <param name="instance">The instance on which the events should be fired (normally "this").</param>
         /// <param name="callbackMethodOriginType">The type where the callback method was first defined (the method that is not an override, normally the type where the event manager was defined).</param>
-        /// <param name="callbackMethod">The name of the callback method that was potentially overriden.</param>
+        /// <param name="callbackMethodName">The name of the callback method that was potentially overriden.</param>
+        /// <param name="callbackMethodParameterTypes">The list of the callback method argument types.</param>
         public void AttachToDomEvents(object instance, Type callbackMethodOriginType, string callbackMethodName, Type[] callbackMethodParameterTypes)
         {
             bool isMethodOverridden = INTERNAL_EventsHelper.IsEventCallbackOverridden(instance, callbackMethodOriginType, callbackMethodName, callbackMethodParameterTypes);

--- a/src/Runtime/Runtime/Core/Events/INTERNAL_EventsHelper.cs
+++ b/src/Runtime/Runtime/Core/Events/INTERNAL_EventsHelper.cs
@@ -118,8 +118,10 @@ namespace CSHTML5.Internal
         /// <summary>
         /// Checks whether the method passed as parameter is an override by checking whether its DeclaringType is the same as the type passed as parameter.
         /// </summary>
+        /// <param name="instance">The instance on which the events should be fired (normally "this").</param>
         /// <param name="callbackMethodOriginType">The type where the method was originally declared.</param>
-        /// <param name="callbackMethod">The method that will be checked whether it was declared in the type passed as parameter.</param>
+        /// <param name="callbackMethodName">The method that will be checked whether it was declared in the type passed as parameter.</param>
+        /// <param name="callbackMethodParameterTypes">The list of the callback method argument types.</param>
         /// <returns>True if the method is an override (its DeclaringType is different than the type passed as parameter).</returns>
         public static bool IsEventCallbackOverridden(object instance, Type callbackMethodOriginType, string callbackMethodName, Type[] callbackMethodParameterTypes)
         {

--- a/src/Runtime/Runtime/Core/Main/INTERNAL_SimulatorExecuteJavaScript.cs
+++ b/src/Runtime/Runtime/Core/Main/INTERNAL_SimulatorExecuteJavaScript.cs
@@ -274,7 +274,7 @@ namespace CSHTML5.Internal
         /// pending aysnc JavaScript calls that were made during that action will
         /// get flushed (ie. they get executed).
         /// The goal is to greatly improve performance by reducing the number of
-        /// C# <-> JS interop calls, by aggregating the async JS calls and
+        /// C# &lt;-&gt; JS interop calls, by aggregating the async JS calls and
         /// executing them all at once at the end of the current thread execution.
         /// </summary>
         /// <param name="action">The action to execute before flushing the pending JS code.</param>

--- a/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/ContainerElement.cs
+++ b/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/ContainerElement.cs
@@ -37,7 +37,7 @@ namespace CSHTML5.Native.Html.Controls
     /// <example>
     /// You can add a Container to the XAML as follows:
     /// <code lang="XAML" xml:space="preserve">
-    /// <native:Canvas Width="1000" Height"500" xmlns:native="using:CSHTML5.Native.Html.Controls">
+    /// <native:Canvas Width="1000" Height="500" xmlns:native="using:CSHTML5.Native.Html.Controls">
     ///     <native:Container X="200" Y="42" Width="100" Height="50" FillColor="Blue">
     ///             <!-- Place children here -->
     ///     </native:Container>

--- a/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/HtmlCanvas.cs
+++ b/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/HtmlCanvas.cs
@@ -44,7 +44,7 @@ namespace CSHTML5.Native.Html.Controls
     /// <code lang="XAML" xml:space="preserve">
     /// <native:HtmlCanvas Width="100" Height="100" xmlns:native="using:CSHTML5.Native.Html.Controls">
     ///     <!-- Place children here -->
-    /// </native:Canvas>
+    /// </native:HtmlCanvas>
     /// </code>
     /// Or in C#:
     /// <code lang="C#">

--- a/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/ImageElement.cs
+++ b/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/ImageElement.cs
@@ -35,7 +35,7 @@ namespace CSHTML5.Native.Html.Controls
     /// <example>
     /// You can add an image to the XAML as follows:
     /// <code lang="XAML" xml:space="preserve">
-    /// <native:HtmlCanvas Width="1000" Height"500" xmlns:native="using:CSHTML5.Native.Html.Controls">
+    /// <native:HtmlCanvas Width="1000" Height="500" xmlns:native="using:CSHTML5.Native.Html.Controls">
     ///     <native:ImageElement Source="ms-appx:///MyAssembly/MyFolder/Image.png" X="200" Y="42" Width="100" Height="50"/>
     /// </native:HtmlCanvas>
     /// </code>

--- a/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/RectangleElement.cs
+++ b/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/RectangleElement.cs
@@ -34,7 +34,7 @@ namespace CSHTML5.Native.Html.Controls
     /// <example>
     /// You can add a rectangle to the XAML as follows:
     /// <code lang="XAML" xml:space="preserve">
-    /// <native:HtmlCanvas Width="1000" Height"500" xmlns:native="using:CSHTML5.Native.Html.Controls">
+    /// <native:HtmlCanvas Width="1000" Height="500" xmlns:native="using:CSHTML5.Native.Html.Controls">
     ///     <native:RectangleElement X="200" Y="42" Width="100" Height="50" FillColor="Blue"/>
     /// </native:HtmlCanvas>
     /// </code>

--- a/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/TextElement.cs
+++ b/src/Runtime/Runtime/PublicAPI/Native.Html.Controls/TextElement.cs
@@ -37,7 +37,7 @@ namespace CSHTML5.Native.Html.Controls
     /// <example>
     /// You can add text to the XAML as follows:
     /// <code lang="XAML" xml:space="preserve">
-    /// <native:HtmlCanvas Width="1000" Height"500" xmlns:native="using:CSHTML5.Native.Html.Controls">
+    /// <native:HtmlCanvas Width="1000" Height="500" xmlns:native="using:CSHTML5.Native.Html.Controls">
     ///     <native:TextElement X="200" Y="42" Text="I am the text" Font="20px Arial"/>
     /// </native:HtmlCanvas>
     /// </code>

--- a/src/Runtime/Runtime/System.IO.IsolatedStorage/IsolatedStorageSettings.cs
+++ b/src/Runtime/Runtime/System.IO.IsolatedStorage/IsolatedStorageSettings.cs
@@ -39,12 +39,13 @@ using Windows.UI.Xaml;
 namespace System.IO.IsolatedStorage
 {
     //Note: we remove the interfaces because they are useless for now.
-    ///
+    //
     // Exceptions:
     //   System.ArgumentNullException:
     //     key is null. This exception is thrown when you attempt to reference an instance
     //     of the class by using an indexer and the variable you pass in for the key
     //     value is null.
+
     /// <summary>
     /// Provides a System.Collections.Generic.Dictionary&lt;TKey,TValue&gt; that stores
     /// key-value pairs in isolated storage.

--- a/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
+++ b/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
@@ -1630,7 +1630,7 @@ EndOperationDelegate endDelegate, SendOrPostCallback completionCallback)
         protected class ChannelBase<T> where T : class
         {
             /// <summary>
-            /// Initializes a new instance of the System.ServiceModel.ClientBase<TChannel>.ChannelBase<T>
+            /// Initializes a new instance of the <see cref="System.ServiceModel.ClientBase{TChannel}.ChannelBase{T}"/>
             /// class from an existing instance of the class.
             /// </summary>
             /// <param name="client">The object used to initialize the new instance of the class.</param>

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Data/ListCollectionView.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Data/ListCollectionView.cs
@@ -978,7 +978,7 @@ namespace Windows.UI.Xaml.Data
         }
 
         /// <summary>
-        /// Returns true if an </seealso cref="AddNew"> transaction is in progress.
+        /// Returns true if an <seealso cref="AddNew"/> transaction is in progress.
         /// </summary>
         public bool IsAddingNew
         {
@@ -986,7 +986,7 @@ namespace Windows.UI.Xaml.Data
         }
 
         /// <summary>
-        /// When an </seealso cref="AddNew"> transaction is in progress, this property
+        /// When an <seealso cref="AddNew"/> transaction is in progress, this property
         /// returns the new item.  Otherwise it returns null.
         /// </summary>
         public object CurrentAddItem
@@ -1309,7 +1309,7 @@ namespace Windows.UI.Xaml.Data
         }
 
         /// <summary>
-        /// Returns true if an </seealso cref="EditItem"> transaction is in progress.
+        /// Returns true if an <seealso cref="EditItem"/> transaction is in progress.
         /// </summary>
         public bool IsEditingItem
         {
@@ -1317,7 +1317,7 @@ namespace Windows.UI.Xaml.Data
         }
 
         /// <summary>
-        /// When an </seealso cref="EditItem"> transaction is in progress, this property
+        /// When an <seealso cref="EditItem"/> transaction is in progress, this property
         /// returns the affected item.  Otherwise it returns null.
         /// </summary>
         public object CurrentEditItem
@@ -2565,7 +2565,6 @@ namespace Windows.UI.Xaml.Data
         /// Create, filter and sort the local index array.
         /// called from Refresh(), override in derived classes as needed.
         /// </summary>
-        /// <param name="list">new ILIst to associate this view with</param>
         /// <returns>new local array to use for this view</returns>
         private void PrepareLocalArray()
         {

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Media.Animation/RepeatBehavior.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Media.Animation/RepeatBehavior.cs
@@ -40,10 +40,11 @@ namespace Windows.UI.Xaml.Media.Animation
     {
 
         //for details on how the animations are supposed to behave depending on RepeatBehavior, see: https://msdn.microsoft.com/en-us/library/system.windows.media.animation.timeline.repeatbehavior(v=vs.100).aspx
-        ///
+        //
         // Exceptions:
         //   System.ArgumentOutOfRangeException:
         //     count evaluates to infinity, a value that is not a number, or is negative.
+
         /// <summary>
         /// Initializes a new instance of the Windows.UI.Xaml.Media.Animation.RepeatBehavior
         /// structure with the specified iteration count.
@@ -329,7 +330,7 @@ namespace Windows.UI.Xaml.Media.Animation
         }
 
         //todo: the following
-        ///
+
         ///// <summary>
         ///// Returns the hash code of this instance.
         ///// </summary>

--- a/src/Runtime/Runtime/Windows.UI.Xaml/Content.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml/Content.cs
@@ -142,14 +142,14 @@ if (requestMethod) { // Native exit full screen.
         //     mode.
         //public event EventHandler FullScreenChanged;
 
-         /// <summary>
-         /// Occurs when the System.Windows.Interop.Content.ActualHeight or the System.Windows.Interop.Content.ActualWidth 
-         /// of the Silverlight plug-in change.
-         /// </summary>
+        /// <summary>
+        /// Occurs when the System.Windows.Interop.Content.ActualHeight or the System.Windows.Interop.Content.ActualWidth 
+        /// of the Silverlight plug-in change.
+        /// </summary>
         public event EventHandler Resized;
 
         /// <summary>
-        //  Occurs when the zoom setting in the host browser window changes or is initialized.
+        /// Occurs when the zoom setting in the host browser window changes or is initialized.
         /// </summary>
         public event EventHandler Zoomed;
 

--- a/src/Runtime/Runtime/Windows.UI.Xaml/UIElement_Events.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml/UIElement_Events.cs
@@ -1601,7 +1601,7 @@ namespace Windows.UI.Xaml
 
 #if MIGRATION
             Type[] methodParameters = new Type[] { typeof(MouseEventArgs) };
-            ///
+            //
             if (_pointerMovedEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnMouseMove", methodParameters))
             {
                 var v = PointerMovedEventManager; //forces the creation of the event manager.
@@ -1610,7 +1610,7 @@ namespace Windows.UI.Xaml
             {
                 _pointerMovedEventManager.AttachToDomEvents(this, typeof(UIElement), "OnMouseMove", methodParameters);
             }
-            ///
+            //
             if (_pointerEnteredEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnMouseEnter", methodParameters))
             {
                 var v = PointerEnteredEventManager; //forces the creation of the event manager.
@@ -1619,7 +1619,7 @@ namespace Windows.UI.Xaml
             {
                 _pointerEnteredEventManager.AttachToDomEvents(this, typeof(UIElement), "OnMouseEnter", methodParameters);
             }
-            ///
+            //
             if (_pointerExitedEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnMouseLeave", methodParameters))
             {
                 var v = PointerExitedEventManager; //forces the creation of the event manager.
@@ -1628,7 +1628,7 @@ namespace Windows.UI.Xaml
             {
                 _pointerExitedEventManager.AttachToDomEvents(this, typeof(UIElement), "OnMouseLeave", methodParameters);
             }
-            ///
+            //
             methodParameters = new Type[] { typeof(TappedRoutedEventArgs) };
             if (_tappedEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnTapped", methodParameters))
             {
@@ -1638,7 +1638,7 @@ namespace Windows.UI.Xaml
             {
                 _tappedEventManager.AttachToDomEvents(this, typeof(UIElement), "OnTapped", methodParameters);
             }
-            ///
+            //
             methodParameters = new Type[] { typeof(MouseButtonEventArgs) };
             if (_pointerPressedEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnMouseLeftButtonDown", methodParameters))
             {
@@ -1648,7 +1648,7 @@ namespace Windows.UI.Xaml
             {
                 _pointerPressedEventManager.AttachToDomEvents(this, typeof(UIElement), "OnMouseLeftButtonDown", methodParameters);
             }
-            ///
+            //
             if (_pointerReleasedEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnMouseLeftButtonUp", methodParameters))
             {
                 var v = PointerReleasedEventManager; //forces the creation of the event manager.
@@ -1657,7 +1657,7 @@ namespace Windows.UI.Xaml
             {
                 _pointerReleasedEventManager.AttachToDomEvents(this, typeof(UIElement), "OnMouseLeftButtonUp", methodParameters);
             }
-            ///
+            //
             if (_rightTappedEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnMouseRightButtonUp", methodParameters))
             {
                 var v = RightTappedEventManager; //forces the creation of the event manager.
@@ -1666,7 +1666,7 @@ namespace Windows.UI.Xaml
             {
                 _rightTappedEventManager.AttachToDomEvents(this, typeof(UIElement), "OnMouseRightButtonUp", methodParameters);
             }
-            ///
+            //
             methodParameters = new Type[] { typeof(KeyEventArgs) };
             if (_keyDownEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnKeyDown", methodParameters))
             {
@@ -1676,7 +1676,7 @@ namespace Windows.UI.Xaml
             {
                 _keyDownEventManager.AttachToDomEvents(this, typeof(UIElement), "OnKeyDown", methodParameters);
             }
-            ///
+            //
             if (_keyUpEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnKeyUp", methodParameters))
             {
                 var v = KeyUpEventManager; //forces the creation of the event manager.
@@ -1685,7 +1685,7 @@ namespace Windows.UI.Xaml
             {
                 _keyUpEventManager.AttachToDomEvents(this, typeof(UIElement), "OnKeyUp", methodParameters);
             }
-            ///
+            //
             methodParameters = new Type[] { typeof(RoutedEventArgs) };
             if (_gotFocusEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnGotFocus", methodParameters))
             {
@@ -1695,7 +1695,7 @@ namespace Windows.UI.Xaml
             {
                 _gotFocusEventManager.AttachToDomEvents(this, typeof(UIElement), "OnGotFocus", methodParameters);
             }
-            ///
+            //
             if (_lostFocusEventManager == null && INTERNAL_EventsHelper.IsEventCallbackOverridden(this, typeof(UIElement), "OnLostFocus", methodParameters))
             {
                 var v = LostFocusEventManager; //forces the creation of the event manager.


### PR DESCRIPTION
Lots of easy-to-fix issues in XML comments for reducing the number of warnings generated during the full build.