### PR TITLE
Prevent broken image icon in the browser

### DIFF
--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/Image.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/Image.cs
@@ -58,6 +58,7 @@ namespace Windows.UI.Xaml.Controls
     /// </example>
     public sealed partial class Image : FrameworkElement
     {
+        private const string TransparentGifOnePixel = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
         dynamic _imageDiv = null;
         double imgWidth = 0; //might be useless, might be useful.
         double imgHeight = 0;
@@ -170,7 +171,8 @@ namespace Windows.UI.Xaml.Controls
             }
             else
             {
-                INTERNAL_HtmlDomManager.SetDomElementAttribute(_imageDiv, "src", "");
+                //If Source == null we show empty image to prevent broken image icon
+                INTERNAL_HtmlDomManager.SetDomElementAttribute(_imageDiv, "src", TransparentGifOnePixel);
             }
             INTERNAL_HtmlDomManager.SetDomElementAttribute(_imageDiv, "alt", " "); //the text displayed when the image cannot be found. We set it as an empty string since there is nothing in Xaml
         }
@@ -601,6 +603,7 @@ $0.style.objectPosition = $2", image._imageDiv, objectFitvalue, objectPosition);
             intermediaryDomStyle.lineHeight = "0px"; //this one is to fix in Firefox the few pixels gap that appears below the image whith certain displays (table, table-cell and possibly some others)
 
             var img = INTERNAL_HtmlDomManager.CreateDomElementAndAppendIt("img", div, this);
+            INTERNAL_HtmlDomManager.SetDomElementAttribute(img, "src", TransparentGifOnePixel);
             INTERNAL_HtmlDomManager.SetDomElementAttribute(img, "alt", " "); //the text displayed when the image cannot be found. We set it as an empty string since there is nothing in Xaml
 
             var style = INTERNAL_HtmlDomManager.GetDomElementStyleForModification(img);
@@ -609,10 +612,14 @@ $0.style.objectPosition = $2", image._imageDiv, objectFitvalue, objectPosition);
             style.height = "inherit";
             style.objectPosition = "center top";
 
-            CSHTML5.Interop.ExecuteJavaScriptAsync(@"
-$0.addEventListener('mousedown', function(e) {
-e.preventDefault();
-}, false);", img);
+            CSHTML5.Interop.ExecuteJavaScriptAsync($@"
+$0.addEventListener('mousedown', function(e) {{
+    e.preventDefault();
+}}, false);
+$0.addEventListener('error', function(e) {{
+    this.src = '{TransparentGifOnePixel}';
+}});
+", img);
 
             _imageDiv = img;
             domElementWhereToPlaceChildren = null;


### PR DESCRIPTION
When Silverlight can not show an image it shows nothing. In the browser, we see a broken image icon in this case.

We have several possible reasons:
1. We did not specify the source: <Image />
2. The Source == null
3. We can not load image