### PR TITLE
Change the folder with assemblies for extracting resources

### DIFF
--- a/src/Targets/OpenSilver.Common.targets
+++ b/src/Targets/OpenSilver.Common.targets
@@ -546,14 +546,20 @@
         DestinationFolder="$(BaseIntermediateOutputPath)..\wwwroot\libs\"
         /><!-- Note: BaseIntermediateOutputPath is an absolute path to the project's obj folder.-->
 
+    <PropertyGroup>
+      <ResourcesSourceLocation>$(OutputAssemblyDirectory)</ResourcesSourceLocation>
+      <ResourcesSourceLocation Condition="'$(TargetFramework)' == 'net6.0'">$(OutputAssemblyDirectory)\wwwroot\_framework</ResourcesSourceLocation>
+      <ResourcesRootOutput>$(Cshtml5OutputRootPath)</ResourcesRootOutput>
+      <ResourcesRootOutput Condition="'$(TargetFramework)' == 'net6.0'">$(OutputAssemblyDirectory)\..\..\..\wwwroot\</ResourcesRootOutput>
+    </PropertyGroup>
 
     <!--============================================================
       ResourceExtractorAndCopier (only during Pass 2)
       ============================================================-->
     <ResourcesExtractorAndCopier
-      Condition="'$(CSharpXamlForHtml5OutputType)'!='Library' And '$(IsSecondPass)'=='True' And '$(SkipResourcesExtractorAndCopier)'!='true'"
-      SourceAssembly="$(OutputAssemblyDirectory)\$(AssemblyName).dll"
-      OutputRootPath="$(Cshtml5OutputRootPath)"
+      Condition="'$(IsBrowserProject)' == 'true' And '$(IsSecondPass)'=='True' And '$(SkipResourcesExtractorAndCopier)'!='true'"
+      SourceAssembly="$(ResourcesSourceLocation)\$(AssemblyName).dll"
+      OutputRootPath="$(ResourcesRootOutput)"
       OutputResourcesPath="$(Cshtml5OutputResourcesPath)"
       AssembliesToIgnore="mscorlib|System.Core|Microsoft.CSharp|JSIL.Meta|Bridge"
       SupportedExtensions=".js|.css|.png|.jpg|.gif|.ico|.mp4|.ogv|.webm|.3gp|.mp3|.ogg|.txt|.xml|.ttf|.woff|.cur|.config|.ClientConfig|.htm|.html|.svg"


### PR DESCRIPTION
1. .netStandard 2.1 and .net6 uses different output for browser project. There are two new properties to use different paths according to current target framework
2. Changes condition to run extracting resources only for the Browser project.