### PR TITLE
Add support for "IncomingMessageHeaders" in OpenSilver for synchronous calls.

### DIFF
--- a/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
+++ b/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
@@ -1488,7 +1488,7 @@ EndOperationDelegate endDelegate, SendOrPostCallback completionCallback)
                             // complicated and not necessarily more efficient).
                             // this is a method with no return type, there is no need to read the response 
                             // after checking that there was no FaultException.
-                            return null;
+                            return string.Empty;
                         }
                     }
 

--- a/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
+++ b/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
@@ -1488,7 +1488,7 @@ EndOperationDelegate endDelegate, SendOrPostCallback completionCallback)
                             // complicated and not necessarily more efficient).
                             // this is a method with no return type, there is no need to read the response 
                             // after checking that there was no FaultException.
-                            return string.Empty;
+                            return null;
                         }
                     }
 

--- a/src/Runtime/Runtime/System.ServiceModel/INTERNAL_WebMethodsCaller.cs
+++ b/src/Runtime/Runtime/System.ServiceModel/INTERNAL_WebMethodsCaller.cs
@@ -84,9 +84,10 @@ namespace System.ServiceModel
         public static RETURN_TYPE CallWebMethod<RETURN_TYPE, INTERFACE_TYPE>(
             string endpointAddress,
             string webMethodName,
-            IEnumerable<Channels.MessageHeader> messageHeaders,
+            IEnumerable<Channels.MessageHeader> outgoingMessageHeaders,
             IDictionary<string, object> requestParameters,
-            string soapVersion) where INTERFACE_TYPE : class
+            string soapVersion,
+            out Channels.MessageHeaders incomingMessageHeaders) where INTERFACE_TYPE : class
         {
             var webMethodsCaller = new CSHTML5_ClientBase<INTERFACE_TYPE>.WebMethodsCaller(endpointAddress);
 
@@ -94,9 +95,10 @@ namespace System.ServiceModel
                 webMethodName,
                 typeof(INTERFACE_TYPE),
                 typeof(RETURN_TYPE),
-                messageHeaders,
+                outgoingMessageHeaders,
                 requestParameters,
-                soapVersion);
+                soapVersion,
+                out incomingMessageHeaders);
         }
 #endif
 
@@ -258,16 +260,18 @@ namespace System.ServiceModel
         public static void CallWebMethod_WithoutReturnValue<INTERFACE_TYPE>(
             string endpointAddress,
             string webMethodName,
-            IEnumerable<Channels.MessageHeader> messageHeaders,
+            IEnumerable<Channels.MessageHeader> outgoingMessageHeaders,
             IDictionary<string, object> requestParameters,
-            string soapVersion) where INTERFACE_TYPE : class
+            string soapVersion,
+            out Channels.MessageHeaders incomingMessageHeaders) where INTERFACE_TYPE : class
         {
             CallWebMethod<object, INTERFACE_TYPE>(
                 endpointAddress,
                 webMethodName,
-                messageHeaders,
+                outgoingMessageHeaders,
                 requestParameters,
-                soapVersion);
+                soapVersion,
+                out incomingMessageHeaders);
         }
 #endif
 


### PR DESCRIPTION
- Add support for "IncomingMessageHeaders" in OpenSilver for synchronous calls.
- Fix message headers XML serialization by making use of the actual Soap Version.
- Remove the unused “RemoveUnparsableStrings” method.