### PR TITLE
Inherits FontSize for textmeasurement, update CheckBox Template

### DIFF
--- a/src/Runtime/Runtime/DefaultStyles/INTERNAL_DefaultContentControlStyle.xaml
+++ b/src/Runtime/Runtime/DefaultStyles/INTERNAL_DefaultContentControlStyle.xaml
@@ -563,10 +563,16 @@
                                       Margin="0,-4,-4,0"
                                       VerticalAlignment="Top"
                                       Background="Transparent">
-                                    <Path Margin="0,3,0,0"
+                                    <Path 
+                                          Width="10"
+                                          Height="7"
+                                          Margin="0,3,0,0"
                                           Data="M 1,0 L5,0 A 2,2 90 0 1 7,2 L7,6 z"
                                           Fill="#FFDC000C" />
-                                    <Path Margin="0,3,0,0"
+                                    <Path 
+                                          Width="10"
+                                          Height="7"
+                                          Margin="0,3,0,0"
                                           Data="M 0,0 L2,0 L 7,5 L7,7"
                                           Fill="#ffffff" />
                                 </Grid>

--- a/src/Runtime/Runtime/Windows.UI.Xaml.Controls/Control.cs
+++ b/src/Runtime/Runtime/Windows.UI.Xaml.Controls/Control.cs
@@ -384,6 +384,7 @@ namespace Windows.UI.Xaml.Controls
                 typeof(Control),
                 new FrameworkPropertyMetadata(11d, FrameworkPropertyMetadataOptions.AffectsMeasure)
                 { 
+                    Inherits = true,
                     GetCSSEquivalent = (instance) => new CSSEquivalent
                     {
                         Value = (inst, value) =>


### PR DESCRIPTION
 - Set Inherits=True for Control FontSize to measure TextBlock size correctly
 - Update CheckBox template to avoid interop calls for GetActualWidthAndHeight