### PR TITLE
Allows to call the scriptable members

### DIFF
--- a/src/Runtime/Runtime/Runtime.CSHTML5.csproj
+++ b/src/Runtime/Runtime/Runtime.CSHTML5.csproj
@@ -100,6 +100,7 @@
     <Compile Include="System.Windows.Browser\WORKINPROGRESS\BrowserInformation.cs" />
     <Compile Include="System.Windows.Browser\WORKINPROGRESS\HtmlEventArgs.cs" />
     <Compile Include="System.Windows.Browser\WORKINPROGRESS\HtmlPopupWindowOptions.cs" />
+    <Compile Include="System.Windows.Browser\WORKINPROGRESS\ScriptableMemberAttribute.cs" />
     <Compile Include="System.Windows.Browser\WORKINPROGRESS\ScriptObjectCollection.cs" />
     <Compile Include="System.Windows.Controls.Primitives\WORKINPROGRESS\VisualTreeExtensions.cs" />
     <Compile Include="System.Windows.Controls\WORKINPROGRESS\ScrollViewerExtensions.cs" />


### PR DESCRIPTION
For now it does not cover all scenarios. For instance, we can only pass primitive types, which are supported by OpenSilver.
Also, we can not get the result of the method execution, because our execution engine is async.