### PR TITLE
Disable css layout of the grid when CustomLayout is enabled

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Grid.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Grid.cs
@@ -631,6 +631,9 @@ namespace Windows.UI.Xaml.Controls
 
         internal void LocallyManageChildrenChanged()
         {
+            if (this.IsCustomLayoutRoot || this.IsUnderCustomLayout)
+                return;
+
 #if PERFSTAT
             var t0 = Performance.now();
 #endif


### PR DESCRIPTION
Currently it's disabled under Custom Layout.
For CSS style layout, please check line 158.