### PR TITLE
Emit "ValueChanged" on listeners also for properties of collection types even if the "Old Value" reference equals the "New Value".

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Data/PropertyPathNode.cs
+++ b/src/Runtime/Runtime/System.Windows.Data/PropertyPathNode.cs
@@ -41,7 +41,8 @@ namespace Windows.UI.Xaml.Data
         internal void UpdateValueAndIsBroken(object newValue, bool isBroken)
         {
             bool emitBrokenChanged = IsBroken != isBroken;
-            bool emitValueChanged = Value != newValue;
+            bool emitValueChanged = Value != newValue // reference equals works well for immutable types, like strings for example 
+                || Value is System.Collections.ICollection;//Partial workaround: If the Value is a collection, then we cannot asume that the collection has not been changed only by doing a reference equals.
 
             IsBroken = isBroken;
             Value = newValue;


### PR DESCRIPTION
"PropertyChanged" events can be triggered manually also for properties which depend on other properties  that are modified directly. If the property for which we manually trigger the "PropertyChanged" event is of collection type then the "ValueChanged" method is not call on listeners because there is only a reference equals check between the  "Old Collection Value" and the "New Collection Value" even though the collection has elements which have changed.