### PR TITLE
Allow adding text if there was a selection

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
@@ -681,8 +681,10 @@ element_OutsideEventHandler.addEventListener('keydown', function(e) {{
         }}
         if(text.length + correctionDueToNewLines >= maxLength)
         {{
-            e.preventDefault();
-            return false;
+            if (!window.getSelection().toString()) {{
+                e.preventDefault();
+                return false;
+            }}
         }}
     }}
 


### PR DESCRIPTION
The check prevents entering text when MaxLength is set and the text is selected.  It just needs to remove the selected part and add a new entered symbols instead.