### PR TITLE
fix: copy source stream on BitmapImage source as it could be disposed...

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Media.Imaging/BitmapSource.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Imaging/BitmapSource.cs
@@ -34,7 +34,7 @@ namespace Windows.UI.Xaml.Media.Imaging
             {
                 if (!_isStreamAsBase64StringValid)
                 {
-                    byte[] bytes = new byte[INTERNAL_StreamSource.Length + 10];//note: if s.Length is longer than int.MaxValue, that's a problem... But that means they have a stream of more than 2 Go...
+                    byte[] bytes = new byte[INTERNAL_StreamSource.Length];//note: if s.Length is longer than int.MaxValue, that's a problem... But that means they have a stream of more than 2 Go...
                     if (INTERNAL_StreamSource.Length > int.MaxValue)
                     {
                         throw new InvalidOperationException("The Stream set as the BitmapSource's Source is too big (more than int.MaxValue (2,147,483,647) bytes).");
@@ -86,7 +86,13 @@ namespace Windows.UI.Xaml.Media.Imaging
         /// <param name="streamSource">The stream source that sets the image source value.</param>
         public void SetSource(Stream streamSource) //note: this is supposed to be a IRandomAccessStream
         {
-            INTERNAL_StreamSource = streamSource;
+            // Copying the original stream because it could be disposed by the user before it is consumed
+            // by the target image
+            MemoryStream streamCopy = new MemoryStream();
+            streamSource.CopyTo(streamCopy);
+            streamCopy.Seek(0, SeekOrigin.Begin);
+
+            INTERNAL_StreamSource = streamCopy;
             _isStreamAsBase64StringValid = false; //in case we set the source after having already set it and used it.
         }
 

--- a/src/Tests/Runtime.OpenSilver.Tests/System.Windows.Media.Imaging/BitmapImageTest.cs
+++ b/src/Tests/Runtime.OpenSilver.Tests/System.Windows.Media.Imaging/BitmapImageTest.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+
+#if MIGRATION
+using System.Windows.Controls;
+#else
+using System;
+using Windows.UI.Xaml.Controls;
+#endif
+
+#if MIGRATION
+namespace System.Windows.Media.Imaging.Tests
+#else
+namespace Windows.UI.Xaml.Media.Imaging.Tests
+#endif
+{
+    [TestClass]
+    public class BitmapImageTest
+    {
+        private static readonly string Base64ImageExample = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+
+        [TestMethod]
+        public void BitmapImage_SetStreamSource_ShouldConsumeAsSoonAsSet()
+        {
+            BitmapImage bitmapImage = new BitmapImage();
+            MemoryStream ms = new MemoryStream(Convert.FromBase64String(Base64ImageExample));
+            bitmapImage.SetSource(ms);
+            // In Silverlight it is possible to dispose original source before consuming it elsewhere
+            ms.Dispose();
+
+            Image image = new Image();
+            // BitmapImage should still contain data stream even though original MemoryStream
+            // has been disposed of
+            image.Source = bitmapImage;
+
+            (image.Source as BitmapImage).INTERNAL_StreamAsBase64String
+                .Should()
+                .Be(Base64ImageExample);
+        }
+    }
+}

--- a/src/Tests/Runtime.OpenSilver.Tests/TestSetup.cs
+++ b/src/Tests/Runtime.OpenSilver.Tests/TestSetup.cs
@@ -1,0 +1,47 @@
+﻿using DotNetForHtml5;
+using DotNetForHtml5.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+#if MIGRATION
+using System.Windows;
+#else
+using Windows.UI.Xaml;
+#endif
+
+namespace Runtime.OpenSilver.Tests.Setup
+{
+    [TestClass]
+    public class TestSetup
+    {
+        /// <summary>
+        /// This method will be executed whenever the assembly is loaded,
+        /// so before any number of tests being run.
+        /// </summary>
+        /// <param name="testContext"></param>
+        [AssemblyInitialize]
+        public static void AssemblyInitialize(TestContext testContext)
+        {
+            Mock<IJavaScriptExecutionHandler> javaScriptExecutionHandlerMock = new Mock<IJavaScriptExecutionHandler>();
+            javaScriptExecutionHandlerMock
+                .Setup(x => x.ExecuteJavaScriptWithResult(It.IsAny<string>()))
+                .Returns<string>(param =>
+                {
+                    // JS code example is: document.callScriptSafe("14","document.isGridSupported",9)
+                    if (Regex.Matches(param, @"document.callScriptSafe\(""\d+"",""document.isGridSupported"",\d+\)").Count == 1)
+                    {
+                        return JsonDocument.Parse("false").RootElement;
+                    }
+                    return new JsonElement();
+                });
+
+            IJavaScriptExecutionHandler javaScriptExecutionHandler = javaScriptExecutionHandlerMock.Object;
+            INTERNAL_Simulator.JavaScriptExecutionHandler = javaScriptExecutionHandler;
+
+            // Instantiating Application because it sets itself as Application.Current
+            new Application();
+        }
+    }
+}


### PR DESCRIPTION
… before consumed

This also introduces a TestSetup class with AssemblyInitialize to gradually put the necessary mocks to unit test controls.