### PR TITLE
Fix: Invalid index issue at raising OnCollectionChanged event in DependencyObjectCollection.Add

### DIFF
--- a/src/Runtime/Runtime/System.Windows/DependencyObjectCollection_1.cs
+++ b/src/Runtime/Runtime/System.Windows/DependencyObjectCollection_1.cs
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml
         {
             this.CheckReentrancy();
             this._collection.Add(item);
-            this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, this.Count));
+            this.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, this.Count - 1));
         }
 
         /// <summary>


### PR DESCRIPTION
DependencyObjectCollection.Add was raising OnCollectionChanged with wrong index during Add