### PR TITLE
Fix: TexBox.TextAlignement is not setting on creation

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
@@ -603,29 +603,13 @@ namespace Windows.UI.Xaml.Controls
             {
                 TextBoxView view = CreateView();
                 _textViewHost.AttachView(view);
-                view.Loaded += OnTexBoxtViewLoaded;
             }
-        }
-
-        private void OnTexBoxtViewLoaded(object sender, RoutedEventArgs e)
-        {
-            _textViewHost.View.OnAcceptsReturnChanged(AcceptsReturn);
-            _textViewHost.View.OnTextChanged(Text);
-            _textViewHost.View.OnTextAlignmentChanged(TextAlignment);
-            _textViewHost.View.OnTextWrappingChanged(TextWrapping);
-            _textViewHost.View.OnHorizontalScrollBarVisibilityChanged(HorizontalScrollBarVisibility);
-            _textViewHost.View.OnVerticalScrollBarVisibilityChanged(VerticalScrollBarVisibility);
-            _textViewHost.View.OnMaxLengthChanged(MaxLength);
-            _textViewHost.View.OnTextDecorationsChanged(TextDecorations);
-            _textViewHost.View.OnIsReadOnlyChanged(IsReadOnly);
-            UpdateVisualStates();
         }
 
         private void ClearContentElement()
         {
             if (_textViewHost != null)
             {
-                _textViewHost.View.Loaded += OnTexBoxtViewLoaded;
                 _textViewHost.DetachView();
                 _textViewHost = null;
             }

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
@@ -603,13 +603,29 @@ namespace Windows.UI.Xaml.Controls
             {
                 TextBoxView view = CreateView();
                 _textViewHost.AttachView(view);
+                view.Loaded += OnTexBoxtViewLoaded;
             }
+        }
+
+        private void OnTexBoxtViewLoaded(object sender, RoutedEventArgs e)
+        {
+            _textViewHost.View.OnAcceptsReturnChanged(AcceptsReturn);
+            _textViewHost.View.OnTextChanged(Text);
+            _textViewHost.View.OnTextAlignmentChanged(TextAlignment);
+            _textViewHost.View.OnTextWrappingChanged(TextWrapping);
+            _textViewHost.View.OnHorizontalScrollBarVisibilityChanged(HorizontalScrollBarVisibility);
+            _textViewHost.View.OnVerticalScrollBarVisibilityChanged(VerticalScrollBarVisibility);
+            _textViewHost.View.OnMaxLengthChanged(MaxLength);
+            _textViewHost.View.OnTextDecorationsChanged(TextDecorations);
+            _textViewHost.View.OnIsReadOnlyChanged(IsReadOnly);
+            UpdateVisualStates();
         }
 
         private void ClearContentElement()
         {
             if (_textViewHost != null)
             {
+                _textViewHost.View.Loaded += OnTexBoxtViewLoaded;
                 _textViewHost.DetachView();
                 _textViewHost = null;
             }

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
@@ -187,7 +187,11 @@ element.setAttribute(""data-acceptsreturn"", ""{acceptsReturn.ToString().ToLower
             UpdateTextAlignment(INTERNAL_HtmlDomManager.GetFrameworkElementOuterStyleForModification(this), alignment);
         }
 
-        private void UpdateTextAlignment(INTERNAL_HtmlDomStyleReference style, TextAlignment alignment)
+#if OPENSILVER
+        private static void UpdateTextAlignment(INTERNAL_HtmlDomStyleReference style, TextAlignment alignment)
+#elif BRIDGE
+        private static void UpdateTextAlignment(dynamic style, TextAlignment alignment)
+#endif
         {
             switch (alignment)
             {

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
@@ -184,19 +184,24 @@ element.setAttribute(""data-acceptsreturn"", ""{acceptsReturn.ToString().ToLower
 
         internal void OnTextAlignmentChanged(TextAlignment alignment)
         {
+            UpdateTextAlignment(INTERNAL_HtmlDomManager.GetFrameworkElementOuterStyleForModification(this), alignment);
+        }
+
+        private void UpdateTextAlignment(INTERNAL_HtmlDomStyleReference style, TextAlignment alignment)
+        {
             switch (alignment)
             {
                 case TextAlignment.Center:
-                    INTERNAL_HtmlDomManager.GetFrameworkElementOuterStyleForModification(this).textAlign = "center";
+                    style.textAlign = "center";
                     break;
                 case TextAlignment.Left:
-                    INTERNAL_HtmlDomManager.GetFrameworkElementOuterStyleForModification(this).textAlign = "left";
+                    style.textAlign = "left";
                     break;
                 case TextAlignment.Right:
-                    INTERNAL_HtmlDomManager.GetFrameworkElementOuterStyleForModification(this).textAlign = "right";
+                    style.textAlign = "right";
                     break;
                 case TextAlignment.Justify:
-                    INTERNAL_HtmlDomManager.GetFrameworkElementOuterStyleForModification(this).textAlign = "justify";
+                    style.textAlign = "justify";
                     break;
                 default:
                     break;
@@ -418,6 +423,9 @@ sel.addRange(range);
             contentEditableDivStyle.outline = "solid transparent"; // Note: this is to avoind having the weird border when it has the focus. I could have used outlineWidth = "0px" but or some reason, this causes the caret to not work when there is no text.
             contentEditableDivStyle.background = "solid transparent";
             contentEditableDivStyle.cursor = "text";
+
+            // Apply TextAlignment
+            UpdateTextAlignment(contentEditableDivStyle, Host.TextAlignment);
 
             string isContentEditable = (!isReadOnly).ToString().ToLower();
             INTERNAL_HtmlDomManager.SetDomElementAttribute(contentEditableDiv, "contentEditable", isContentEditable);


### PR DESCRIPTION
`var textbox = new TextBox() {Text = "Test", TextAlignment = TextAlignment.Right};`

For example,  in the above sample, text-alignment would not take effect. This PR is about fixing that.