### PR TITLE
touchstart, wheel and touchmove events marked as passive

### DIFF
--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -295,9 +295,14 @@ document.addEventListenerSafe = function (element, method, func) {
     if (typeof element == 'string') {
         element = document.getElementById(element);
     }
-	if (element){
-		element.addEventListener(method, func);
-	}
+    if (element) {
+        if (method == "touchstart" || method == "wheel" || method == "touchmove") {
+            element.addEventListener(method, func, { passive: true });
+        }
+        else {
+            element.addEventListener(method, func);
+        }
+    }
 }
 
 document.eventCallback = function (callbackId, arguments, sync) {


### PR DESCRIPTION
Prevent generating warnings in the browser every second.