### PR TITLE
Fix DataForm buttons visibility

### DIFF
--- a/src/Runtime/DataForm.Toolkit/themes/generic.xaml
+++ b/src/Runtime/DataForm.Toolkit/themes/generic.xaml
@@ -280,13 +280,13 @@
                                                                        Storyboard.TargetProperty="Visibility"
                                                                        Duration="0">
                                             <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="Visible" />
+                                                                    Value="{TemplateBinding CommitButton.Visibility}" />
                                         </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="CancelButton"
                                                                        Storyboard.TargetProperty="Visibility"
                                                                        Duration="0">
                                             <DiscreteObjectKeyFrame KeyTime="0"
-                                                                    Value="Visible" />
+                                                                    Value="{TemplateBinding CancelButton.Visibility}" />
                                         </ObjectAnimationUsingKeyFrames>
                                     </Storyboard>
                                 </VisualState>


### PR DESCRIPTION
Storyboard starts the animation when the page is fully loaded. So setting CommitButton or CancelButton visibility to Collapsed never works because storyboard set's the visibility back to Visible.