### PR TITLE
Fix crashing at VirtualizingStackPanel when scroll

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/ItemContainerGenerator.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ItemContainerGenerator.cs
@@ -233,10 +233,11 @@ namespace Windows.UI.Xaml.Controls
             while (rblock != blockR || offset <= offsetR)
             {
                 DependencyObject container = rblock.ContainerAt(offset);
+                object item = rblock.ItemAt(offset);
 
                 UnlinkContainerFromItem(container, rblock.ItemAt(offset));
 
-                if (isRecycling)
+                if (isRecycling && !this.Host.IsItemItsOwnContainer(item))
                 {
                     Debug.Assert(!_recyclableContainers.Contains(container), "trying to add a container to the collection twice");
 


### PR DESCRIPTION
It's crashing with a message "trying to add a container to the collection twice".
It can be reproduced with RadListBoxItems or ComboBoxItems.