### PR TITLE
Implemented the CompositionHost and CompositionInitializer MEF classes

### DIFF
--- a/src/Runtime/Runtime/System.ComponentModel.Composition.Hosting/WORKINPROGRESS/CompositionHost.cs
+++ b/src/Runtime/Runtime/System.ComponentModel.Composition.Hosting/WORKINPROGRESS/CompositionHost.cs
@@ -1,48 +1,99 @@
-﻿using System.ComponentModel.Composition.Primitives;
+﻿
+
+/*===================================================================================
+* 
+*   Copyright (c) Userware/OpenSilver.net
+*      
+*   This file is part of the OpenSilver Runtime (https://opensilver.net), which is
+*   licensed under the MIT license: https://opensource.org/licenses/MIT
+*   
+*   As stated in the MIT license, "the above copyright notice and this permission
+*   notice shall be included in all copies or substantial portions of the Software."
+*  
+\*====================================================================================*/
+
+// UGiacobbi2000104 First implementation
+
+using System.ComponentModel.Composition.Primitives;
+using System.Globalization;
+using System.Threading;
 
 namespace System.ComponentModel.Composition.Hosting
 {
-    //
-    // Summary:
-    //     Provides static methods to control the container used by System.ComponentModel.Composition.CompositionInitializer.
-	[OpenSilver.NotImplemented]
+    /// <summary>Provides static methods to control the container used by <see cref="T:System.ComponentModel.Composition.CompositionInitializer" />.</summary>
     public static class CompositionHost
     {
-        //
-        // Summary:
-        //     Sets System.ComponentModel.Composition.CompositionInitializer to use the specified
-        //     container.
-        //
-        // Parameters:
-        //   container:
-        //     The container to use.
-        //
-        // Exceptions:
-        //   T:System.ArgumentNullException:
-        //     container is null.
-        //
-        //   T:System.InvalidOperationException:
-        //     This method has already been called.
-		[OpenSilver.NotImplemented]
+        internal static CompositionContainer _container = (CompositionContainer)null;
+        
+        // Better to add some thread safety here
+        private static object _lockObject = new object();
+
+        /// <summary>Sets <see cref="T:System.ComponentModel.Composition.CompositionInitializer" /> to use the specified container.</summary>
+        /// <param name="container">The container to use.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        /// <paramref name="container" /> is null.</exception>
+        /// <exception cref="T:System.InvalidOperationException">This method has already been called.</exception>
         public static void Initialize(CompositionContainer container)
         {
+            if (container == null)
+                throw new ArgumentNullException(nameof(container));
 
+            CompositionContainer globalContainer = (CompositionContainer)null;
+            
+            if (CompositionHost.TryGetOrCreateContainer((Func<CompositionContainer>)(() => container), out globalContainer))
+                //TODO: Localize this string
+                throw new InvalidOperationException("Global container already initialized.");
         }
-        //
-        // Summary:
-        //     Sets System.ComponentModel.Composition.CompositionInitializer to use a new container
-        //     initialized with the specified catalogs.
-        //
-        // Parameters:
-        //   catalogs:
-        //     The catalogs to load into the new container.
-        //
-        // Returns:
-        //     The new container.
-		[OpenSilver.NotImplemented]
+
+        /// <summary>Sets <see cref="T:System.ComponentModel.Composition.CompositionInitializer" /> to use a new container initialized with the specified catalogs.</summary>
+        /// <returns>The new container.</returns>
+        /// <param name="catalogs">The catalogs to load into the new container.</param>
         public static CompositionContainer Initialize(params ComposablePartCatalog[] catalogs)
         {
-            return null;
+            AggregateCatalog catalog = new AggregateCatalog(catalogs);
+            // ExportProvider exportProvider = new ExportProvider();
+            var container = new CompositionContainer(catalog, null /*exportProvider*/);
+
+            //CompositionContainer container = new CompositionContainer((ComposablePartCatalog)catalog, new ExportProvider[0]);
+            try
+            {
+                CompositionHost.Initialize(container);
+            }
+            catch
+            {
+                container.Dispose();
+                catalog.Catalogs.Clear();
+                catalog.Dispose();
+                throw;
+            }
+            return container;
         }
+
+        #region Implementation
+
+        internal static bool TryGetOrCreateContainer(Func<CompositionContainer> createContainer, out CompositionContainer globalContainer)
+        {
+            bool container = true;
+
+            if (CompositionHost._container == null)
+            {
+                CompositionContainer compositionContainer = createContainer();
+                lock (CompositionHost._lockObject)
+                {
+                    if (CompositionHost._container == null)
+                    {
+                        Thread.MemoryBarrier();
+                        CompositionHost._container = compositionContainer;
+                        container = false;
+                    }
+                }
+            }
+
+            globalContainer = CompositionHost._container;
+
+            return container;
+        }
+
+        #endregion
     }
 }

--- a/src/Runtime/Runtime/System.ComponentModel.Composition/WORKINPROGRESS/CompositionInitializer.cs
+++ b/src/Runtime/Runtime/System.ComponentModel.Composition/WORKINPROGRESS/CompositionInitializer.cs
@@ -1,61 +1,79 @@
-﻿using System.ComponentModel.Composition.Primitives;
+﻿
+
+
+/*===================================================================================
+* 
+*   Copyright (c) Userware/OpenSilver.net
+*      
+*   This file is part of the OpenSilver Runtime (https://opensilver.net), which is
+*   licensed under the MIT license: https://opensource.org/licenses/MIT
+*   
+*   As stated in the MIT license, "the above copyright notice and this permission
+*   notice shall be included in all copies or substantial portions of the Software."
+*  
+\*====================================================================================*/
+
+// UGiacobbi2000104 First implementation - SITA
+
+using System.ComponentModel.Composition.Primitives;
+using System.Collections.Generic;
+using System.ComponentModel.Composition.Hosting;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Resources;
 
 namespace System.ComponentModel.Composition
 {
-    //
-    // Summary:
-    //     Provides static access to methods for parts to satisfy imports.
-	[OpenSilver.NotImplemented]
+    /// <summary>Provides static access to methods for parts to satisfy imports.</summary>
     public static class CompositionInitializer
     {
-        //
-        // Summary:
-        //     Fills the imports of the specified attributed part.
-        //
-        // Parameters:
-        //   attributedPart:
-        //     The attributed part to fill the imports of.
-        //
-        // Exceptions:
-        //   T:System.ArgumentNullException:
-        //     attributedPart is null.
-        //
-        //   T:System.ArgumentException:
-        //     attributedPart contains exports.
-        //
-        //   T:System.ComponentModel.Composition.ChangeRejectedException:
-        //     One or more of the imports of attributedPart could not be satisfied.
-        //
-        //   T:System.ComponentModel.Composition.CompositionException:
-        //     One or more of the imports of attributedPart caused a composition error.
-		[OpenSilver.NotImplemented]
+        /// <summary>Fills the imports of the specified attributed part.</summary>
+        /// <param name="attributedPart">The attributed part to fill the imports of.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        /// <paramref name="attributedPart" /> is null.</exception>
+        /// <exception cref="T:System.ArgumentException">
+        /// <paramref name="attributedPart" /> contains exports.</exception>
+        /// <exception cref="T:System.ComponentModel.Composition.ChangeRejectedException">One or more of the imports of <paramref name="attributedPart" /> could not be satisfied.</exception>
+        /// <exception cref="T:System.ComponentModel.Composition.CompositionException">One or more of the imports of <paramref name="attributedPart" /> caused a composition error.</exception>
         public static void SatisfyImports(object attributedPart)
         {
+            // Note any object can be passed here then we will look up thru reflection what's inside
+            if (attributedPart == null)
+                throw new ArgumentNullException(nameof(attributedPart));
 
+            CompositionInitializer.SatisfyImports(AttributedModelServices.CreatePart(attributedPart));
         }
-        //
-        // Summary:
-        //     Fills the imports of the specified part.
-        //
-        // Parameters:
-        //   part:
-        //     The part to fill the imports of.
-        //
-        // Exceptions:
-        //   T:System.ArgumentNullException:
-        //     attributedPart is null.
-        //
-        //   T:System.ArgumentException:
-        //     attributedPart contains exports.
-        //
-        //   T:System.ComponentModel.Composition.ChangeRejectedException:
-        //     One or more of the imports of attributedPart could not be satisfied.
-        //
-        //   T:System.ComponentModel.Composition.CompositionException:
-        //     One or more of the imports of attributedPart caused a composition error.
-		[OpenSilver.NotImplemented]
+
+        /// <summary>Fills the imports of the specified part.</summary>
+        /// <param name="part">The part to fill the imports of.</param>
+        /// <exception cref="T:System.ArgumentNullException">
+        /// <paramref name="part" /> is null.</exception>
+        /// <exception cref="T:System.ArgumentException">
+        /// <paramref name="part" /> contains exports.</exception>
+        /// <exception cref="T:System.ComponentModel.Composition.ChangeRejectedException">One or more of the imports of <paramref name="part" /> could not be satisfied.</exception>
+        /// <exception cref="T:System.ComponentModel.Composition.CompositionException">One or more of the imports of <paramref name="part" /> caused a composition error.</exception>
         public static void SatisfyImports(ComposablePart part)
         {
+            if (part == null)
+                throw new ArgumentNullException(nameof(part));
+
+            CompositionBatch batch = new CompositionBatch();
+
+            batch.AddPart(part);
+
+            if (part.ExportDefinitions.Any<ExportDefinition>())
+                throw new ArgumentException(string.Format((IFormatProvider)CultureInfo.CurrentCulture, "Error type has export {0}", part.ToString()), nameof(part));
+
+            CompositionContainer globalContainer = (CompositionContainer)null;
+
+            // UGiacobbi 2000105 The original SL implementation allows us to pass a delegate and create a container, for now this is not support so me need a non-null container.
+
+            // For now null the delegate that should build the catalog...
+            CompositionHost.TryGetOrCreateContainer(null, out globalContainer);
+
+            globalContainer.Compose(batch);
 
         }
     }


### PR DESCRIPTION
Implemented the CompositionHost and CompositionInitializer classes necessary for navigation between MEF pages (SITA) inside a Frame. Before both classes where marked as non-implmented.

Internally uses the MSCORLIB facilities like CompositionBatch and CompostablePart to explore the application assemblies for any MEF component and then returns upon request the correct page (using a MEF loader).