### PR TITLE
remove "sealed" modifier from ControlTemplate class

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/ControlTemplate.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ControlTemplate.cs
@@ -30,7 +30,7 @@ namespace Windows.UI.Xaml.Controls
     /// Defines the element tree that is applied as the control template for a control.
     /// </summary>
     [ContentProperty("ContentPropertyUsefulOnlyDuringTheCompilation")]
-    public sealed partial class ControlTemplate : FrameworkTemplate
+    public partial class ControlTemplate : FrameworkTemplate
     {
         /// <summary>
         /// Initializes a new instance of the ControlTemplate class.


### PR DESCRIPTION
that "sealed" modifier prevents LT project to compile, there is a line:
Template = (ControlTemplate)XamlReader.Load( viewBaseText );
in file
\src\LISA\Client\Lundalogik.Lisa.Controls\Containers\ViewBase.cs
error text: error CS0509: '___Lundalogik__Lisa__Controls__Component__Containers__Viewbase__Xaml': cannot derive from sealed type 'ControlTemplate'