### PR TITLE
Add repository url to nuspec

### DIFF
--- a/build/build-nuget-package-OpenSilver-private.bat
+++ b/build/build-nuget-package-OpenSilver-private.bat
@@ -34,7 +34,7 @@ msbuild slnf/OpenSilver.slnf -p:Configuration=SL -clp:ErrorsOnly -restore
 echo. 
 echo %ESC%[95mPacking %ESC%[0mOpenSilver %ESC%[95mNuGet package%ESC%[0m
 echo. 
-nuget.exe pack nuspec\OpenSilver.nuspec -OutputDirectory "output/OpenSilver" -Properties "PackageId=OpenSilver;PackageVersion=1.0.0-private-%PackageVersion%;Configuration=SL;Target=OpenSilver"
+nuget.exe pack nuspec\OpenSilver.nuspec -OutputDirectory "output/OpenSilver" -Properties "PackageId=OpenSilver;PackageVersion=1.0.0-private-%PackageVersion%;Configuration=SL;Target=OpenSilver;RepositoryUrl=https://github.com/OpenSilver/OpenSilver"
 
 echo. 
 echo %ESC%[95mBuilding %ESC%[0mUWP %ESC%[95mconfiguration%ESC%[0m
@@ -43,7 +43,7 @@ msbuild slnf/OpenSilver.slnf -p:Configuration=UWP -clp:ErrorsOnly -restore
 echo. 
 echo %ESC%[95mPacking %ESC%[0mOpenSilver.UWPCompatible %ESC%[95mNuGet package%ESC%[0m
 echo. 
-nuget.exe pack nuspec\OpenSilver.nuspec -OutputDirectory "output/OpenSilver" -Properties "PackageId=OpenSilver.UWPCompatible;PackageVersion=1.0.0-private-%PackageVersion%;Configuration=UWP;Target=OpenSilver.UwpCompatible"
+nuget.exe pack nuspec\OpenSilver.nuspec -OutputDirectory "output/OpenSilver" -Properties "PackageId=OpenSilver.UWPCompatible;PackageVersion=1.0.0-private-%PackageVersion%;Configuration=UWP;Target=OpenSilver.UwpCompatible;RepositoryUrl=https://github.com/OpenSilver/OpenSilver"
 
 explorer "output\OpenSilver"
 

--- a/build/build-nuget-package-OpenSilver.Simulator-private.bat
+++ b/build/build-nuget-package-OpenSilver.Simulator-private.bat
@@ -34,8 +34,8 @@ nuget restore ../src/OpenSilver.sln -v quiet
 echo. 
 echo %ESC%[95mBuilding and packaging %ESC%[0mOpenSilver.Simulator %ESC%[0m
 echo. 
-msbuild slnf/OpenSilver.Simulator.slnf -p:Configuration=SL -clp:ErrorsOnly -p:PackageOutputPath="%batDirectory%/output/OpenSilver" -p:NuspecFile="%batDirectory%/nuspec/OpenSilver.Simulator.nuspec" -p:NuspecBasePath="%batDirectory%" -p:NuspecProperties=PackageVersion=1.0.0-private-%PackageVersion%
-msbuild -t:pack slnf/OpenSilver.Simulator.slnf -p:Configuration=SL -clp:ErrorsOnly -p:PackageOutputPath="%batDirectory%/output/OpenSilver" -p:NuspecFile="%batDirectory%/nuspec/OpenSilver.Simulator.nuspec" -p:NuspecBasePath="%batDirectory%" -p:NuspecProperties=PackageVersion=1.0.0-private-%PackageVersion%
+msbuild slnf/OpenSilver.Simulator.slnf -p:Configuration=SL -clp:ErrorsOnly
+nuget.exe pack nuspec\OpenSilver.Simulator.nuspec -OutputDirectory "output/OpenSilver" -BasePath "%batDirectory%" -Properties "PackageVersion=1.0.0-private-%PackageVersion%;RepositoryUrl=https://github.com/OpenSilver/OpenSilver"
 
 explorer "output\OpenSilver"
 

--- a/build/build-nuget-package-OpenSilver.Simulator.bat
+++ b/build/build-nuget-package-OpenSilver.Simulator.bat
@@ -34,8 +34,8 @@ nuget restore ../src/OpenSilver.sln -v quiet
 echo. 
 echo %ESC%[95mBuilding and packaging %ESC%[0mOpenSilver.Simulator %ESC%[0m
 echo. 
-msbuild slnf/OpenSilver.Simulator.slnf -p:Configuration=SL -clp:ErrorsOnly -p:PackageOutputPath="%batDirectory%/output/OpenSilver" -p:NuspecFile="%batDirectory%/nuspec/OpenSilver.Simulator.nuspec" -p:NuspecBasePath="%batDirectory%" -p:NuspecProperties=PackageVersion=1.0.%PackageVersion%
-msbuild -t:pack slnf/OpenSilver.Simulator.slnf -p:Configuration=SL -clp:ErrorsOnly -p:PackageOutputPath="%batDirectory%/output/OpenSilver" -p:NuspecFile="%batDirectory%/nuspec/OpenSilver.Simulator.nuspec" -p:NuspecBasePath="%batDirectory%" -p:NuspecProperties=PackageVersion=1.0.%PackageVersion%
+msbuild slnf/OpenSilver.Simulator.slnf -p:Configuration=SL -clp:ErrorsOnly
+nuget.exe pack nuspec\OpenSilver.Simulator.nuspec -OutputDirectory "output/OpenSilver" -BasePath "%batDirectory%" -Properties "PackageVersion=1.0.%PackageVersion%;RepositoryUrl=https://github.com/OpenSilver/OpenSilver"
 
 explorer "output\OpenSilver"
 

--- a/build/build-nuget-package-OpenSilver.bat
+++ b/build/build-nuget-package-OpenSilver.bat
@@ -34,7 +34,7 @@ msbuild slnf/OpenSilver.slnf -p:Configuration=SL -clp:ErrorsOnly -restore
 echo. 
 echo %ESC%[95mPacking %ESC%[0mOpenSilver %ESC%[95mNuGet package%ESC%[0m
 echo. 
-nuget.exe pack nuspec\OpenSilver.nuspec -OutputDirectory "output/OpenSilver" -Properties "PackageId=OpenSilver;PackageVersion=%PackageVersion%;Configuration=SL;Target=OpenSilver"
+nuget.exe pack nuspec\OpenSilver.nuspec -OutputDirectory "output/OpenSilver" -Properties "PackageId=OpenSilver;PackageVersion=%PackageVersion%;Configuration=SL;Target=OpenSilver;RepositoryUrl=https://github.com/OpenSilver/OpenSilver"
 
 echo. 
 echo %ESC%[95mBuilding %ESC%[0mUWP %ESC%[95mconfiguration%ESC%[0m
@@ -43,7 +43,7 @@ msbuild slnf/OpenSilver.slnf -p:Configuration=UWP -clp:ErrorsOnly -restore
 echo. 
 echo %ESC%[95mPacking %ESC%[0mOpenSilver.UWPCompatible %ESC%[95mNuGet package%ESC%[0m
 echo. 
-nuget.exe pack nuspec\OpenSilver.nuspec -OutputDirectory "output/OpenSilver" -Properties "PackageId=OpenSilver.UWPCompatible;PackageVersion=%PackageVersion%;Configuration=UWP;Target=OpenSilver.UwpCompatible"
+nuget.exe pack nuspec\OpenSilver.nuspec -OutputDirectory "output/OpenSilver" -Properties "PackageId=OpenSilver.UWPCompatible;PackageVersion=%PackageVersion%;Configuration=UWP;Target=OpenSilver.UwpCompatible;RepositoryUrl=https://github.com/OpenSilver/OpenSilver"
 
 explorer "output\OpenSilver"
 

--- a/build/nuspec/OpenSilver.Simulator.nuspec
+++ b/build/nuspec/OpenSilver.Simulator.nuspec
@@ -5,6 +5,7 @@
     <version>$PackageVersion$</version>
     <authors>Userware</authors>
     <projectUrl>http://www.opensilver.net</projectUrl>
+    <repository type="git" url="$RepositoryUrl$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>OpenSilver is an open-source reimplementation of Silverlight that runs on current browsers via WebAssembly.</description>
     <copyright>Copyright (c) 2021, Userware. All rights reserved.</copyright>

--- a/build/nuspec/OpenSilver.nuspec
+++ b/build/nuspec/OpenSilver.nuspec
@@ -5,6 +5,7 @@
     <version>$PackageVersion$</version>
     <authors>Userware</authors>
     <projectUrl>http://www.opensilver.net</projectUrl>
+    <repository type="git" url="$RepositoryUrl$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>OpenSilver is an open-source reimplementation of Silverlight that runs on current browsers via WebAssembly.</description>
     <copyright>Copyright (c) 2021, Userware. All rights reserved.</copyright>


### PR DESCRIPTION
Add repository URL as a parameter to the nuspec file.
Adjust building process to use nuget.exe for the simulator.