### PR TITLE
Pass focus to TextBoxView in the TextBox

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
@@ -14,6 +14,7 @@
 using System;
 using System.Linq;
 using System.Windows.Markup;
+using CSHTML5.Internal;
 using OpenSilver.Internal.Controls;
 
 #if MIGRATION
@@ -610,6 +611,17 @@ namespace Windows.UI.Xaml.Controls
         {
             INTERNAL_OptionalSpecifyDomElementConcernedByFocus = contentEditableDiv;
             UpdateTabIndex(IsTabStop, TabIndex);
+        }
+
+        protected override void OnGotFocus(RoutedEventArgs e)
+        {
+            base.OnGotFocus(e);
+
+            var view = _textViewHost?.View;
+            if (view != null)
+            {
+                INTERNAL_HtmlDomManager.SetFocus(view);
+            }
         }
 
         private void ClearContentElement()


### PR DESCRIPTION
When there is a ScrollViewer in the template of component, then editable div does not fill all space. If a user clicks on the ScrollViewer then the component does not get focus.

For example, if the template looks like:
```
<Style TargetType="TextBox">
    <Setter Property="BorderThickness" Value="1"/>
    <Setter Property="Background" Value="#FFFFFFFF"/>
    <Setter Property="Foreground" Value="#FF000000"/>
    <Setter Property="Padding" Value="2"/>
    <Setter Property="BorderBrush" Value="#FF718597" />
    <Setter Property="Template">
        <Setter.Value>
            <ControlTemplate TargetType="TextBox">
                <Border x:Name="OuterBorder"
                        Background="{TemplateBinding Background}"
                        BorderBrush="{TemplateBinding BorderBrush}"
                        BorderThickness="{TemplateBinding BorderThickness}">
                    <ScrollViewer>
                        <ContentPresenter x:Name="ContentElement" Margin="{TemplateBinding Padding}"/>
                    </ScrollViewer>
                </Border>
            </ControlTemplate>
        </Setter.Value>
    </Setter>
</Style>
```

and `<TextBox Text="" Height="200" />`