### PR TITLE
Throw exception if enum value is not found in xaml

### DIFF
--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/ReflectionOnSeparateAppDomainHandler.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/ReflectionOnSeparateAppDomainHandler.cs
@@ -1802,7 +1802,7 @@ namespace DotNetForHtml5.Compiler
                     field = type.GetField(fieldNameIgnoreCase, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Static);
                 }
 
-                return field.Name ?? throw new XamlParseException($"Field '{fieldNameIgnoreCase}' not found in type: '{type.FullName}'.");
+                return field?.Name ?? throw new XamlParseException($"Field '{fieldNameIgnoreCase}' not found in type: '{type.FullName}'.");
             }
 
             // note: this method has been abandonned because fieldInfo.GetValue(null) can 


### PR DESCRIPTION
There was a NullReferenceException if compiling XAML with non-existing value in a enum property