### PR TITLE
Add ability to set value of IsRunningOutOfBrowser property

### DIFF
--- a/src/Runtime/Runtime/System.Windows/Settings.cs
+++ b/src/Runtime/Runtime/System.Windows/Settings.cs
@@ -15,6 +15,7 @@
 
 using CSHTML5.Internal;
 using System;
+using System.ComponentModel;
 using System.Net;
 
 #if MIGRATION
@@ -128,6 +129,7 @@ namespace System
         /// Gets or sets a value that indicates whether the application was launched from the out-of-browser state.
         /// Specified value can be received from <see cref="Application.IsRunningOutOfBrowser"/> property.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsRunningOutOfBrowser { get; set; }
     }
 }

--- a/src/Runtime/Runtime/System.Windows/Settings.cs
+++ b/src/Runtime/Runtime/System.Windows/Settings.cs
@@ -123,5 +123,11 @@ namespace System
         public bool EnableAutoZoom { get; set; }
         [OpenSilver.NotImplemented]
         public bool Windowless { get; private set; }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether the application was launched from the out-of-browser state.
+        /// Specified value can be received from <see cref="Application.IsRunningOutOfBrowser"/> property.
+        /// </summary>
+        public bool IsRunningOutOfBrowser { get; set; }
     }
 }

--- a/src/Runtime/Runtime/System.Windows/WORKINPROGRESS/Application.cs
+++ b/src/Runtime/Runtime/System.Windows/WORKINPROGRESS/Application.cs
@@ -77,7 +77,10 @@ namespace Windows.UI.Xaml
         //        }
 
         [OpenSilver.NotImplemented]
-        public bool IsRunningOutOfBrowser { get; set; }
+        public bool IsRunningOutOfBrowser
+        {
+            get { return Application.Current.Host.Settings.IsRunningOutOfBrowser; }
+        }
 
         /// <summary>Gets the current out-of-browser installation state of the application.</summary>
         /// <returns>The out-of-browser installation state of the application.</returns>

--- a/src/Runtime/Runtime/System.Windows/WORKINPROGRESS/Application.cs
+++ b/src/Runtime/Runtime/System.Windows/WORKINPROGRESS/Application.cs
@@ -77,10 +77,7 @@ namespace Windows.UI.Xaml
         //        }
 
         [OpenSilver.NotImplemented]
-        public bool IsRunningOutOfBrowser
-        {
-            get { return false; }
-        }
+        public bool IsRunningOutOfBrowser { get; set; }
 
         /// <summary>Gets the current out-of-browser installation state of the application.</summary>
         /// <returns>The out-of-browser installation state of the application.</returns>


### PR DESCRIPTION
`IsRunningOutOfBrowser` property is not implemented and always returns `false`. In my project, I have many places with checking the value of the property. So it would be useful to have the ability to set this property somewhere in application startup as I can do for `HasElevatedPermissions `property