### PR TITLE
fix: simulator refresh properties pane

### DIFF
--- a/src/Simulator/Simulator/XamlInspection/XamlPropertiesPane.xaml.cs
+++ b/src/Simulator/Simulator/XamlInspection/XamlPropertiesPane.xaml.cs
@@ -93,7 +93,7 @@ namespace DotNetForHtml5.EmulatorWithoutJavascript.XamlInspection
             }
 
             var writablePropertyElements = WritablesPanel.Children.Cast<XamlSinglePropertyEditor>();
-            foreach (var element in readonlyPropertyElements)
+            foreach (var element in writablePropertyElements)
             {
                 element.Refresh();
             }


### PR DESCRIPTION
fix bug of refreshing readonly twice