### PR TITLE
feat: Simulator; Implement SaveHtmlSnapshot

### DIFF
--- a/src/Simulator/Simulator/MainWindow.xaml.cs
+++ b/src/Simulator/Simulator/MainWindow.xaml.cs
@@ -2242,7 +2242,8 @@ Click OK to continue.";
         {
             if (fileName == null)
             {
-                fileName = "HtmlSnapshot-" + DateTime.Now.ToString("yy.MM.dd.hh.mm.ss") + ".html";
+                var elementName = htmlElementId ?? xamlElementName ?? "";
+                fileName = $"HtmlSnapshot-{elementName}-" + DateTime.Now.ToString("yy.MM.dd.hh.mm.ss") + ".html";
             }
             string simulatorExePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
@@ -2251,8 +2252,6 @@ Click OK to continue.";
                 Directory.CreateDirectory(debuggingFolder);
 
             File.WriteAllText(Path.Combine(debuggingFolder, fileName), Instance.getHtmlSnapshot(osRootOnly, htmlElementId, xamlElementName));
-            //var html = Instance.getHtmlSnapshot(osRootOnly, htmlElementId, xamlElementName);
-            //Debug.WriteLine(html);
         }
     }
 }


### PR DESCRIPTION
It saves the current rendered html in a file with time stamp
can pass html id, or xaml element name to only save this element's tree
(observation) : If it's called on the same stack frame more than once, it disrupts the app threads and ends the app