### PR TITLE
Embed debug info into OSF assemblies

### DIFF
--- a/build/nuspec/OpenSilver.nuspec
+++ b/build/nuspec/OpenSilver.nuspec
@@ -27,15 +27,13 @@
   <files>
     <!-- OpenSilver runtime -->
     <file src="../../src/Runtime/OpenSilver.Xaml/bin/OpenSilver/Debug/netstandard2.0/OpenSilver.Xaml.dll" target="lib/netstandard2.0/OpenSilver.Xaml.dll" />
-    <file src="../../src/Runtime/OpenSilver.Xaml/bin/OpenSilver/Debug/netstandard2.0/OpenSilver.Xaml.pdb" target="lib/netstandard2.0/OpenSilver.Xaml.pdb" />
+    <!-- <file src="../../src/Runtime/OpenSilver.Xaml/bin/OpenSilver/Debug/netstandard2.0/OpenSilver.Xaml.pdb" target="lib/netstandard2.0/OpenSilver.Xaml.pdb" /> -->
     <file src="../../src/Runtime/Runtime/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.dll" target="lib/netstandard2.0/OpenSilver.dll" />
-    <file src="../../src/Runtime/Runtime/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.pdb" target="lib/netstandard2.0/OpenSilver.pdb" />
+    <!-- <file src="../../src/Runtime/Runtime/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.pdb" target="lib/netstandard2.0/OpenSilver.pdb" /> -->
     <file src="../../src/Runtime/DataForm.Toolkit/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.dll" target="lib/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.dll" />
-    <file src="../../src/Runtime/DataForm.Toolkit/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.pdb" target="lib/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.pdb" />
+    <!-- <file src="../../src/Runtime/DataForm.Toolkit/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.pdb" target="lib/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.pdb" /> -->
     <file src="../../src/Runtime/Controls.Data.Input/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Data.Input.dll" target="lib/netstandard2.0/OpenSilver.Controls.Data.Input.dll" />
-    <file src="../../src/Runtime/Controls.Data.Input/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Data.Input.pdb" target="lib/netstandard2.0/OpenSilver.Controls.Data.Input.pdb" />
 	<file src="../../src/Runtime/Controls.Input/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Input.dll" target="lib/netstandard2.0/OpenSilver.Controls.Input.dll" />
-    <file src="../../src/Runtime/Controls.Input/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Input.pdb" target="lib/netstandard2.0/OpenSilver.Controls.Input.pdb" />
     <file src="../../src/Runtime/Controls.Navigation/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Navigation.dll" target="lib/netstandard2.0/OpenSilver.Controls.Navigation.dll" />
     <file src="../../src/Runtime/Controls.Navigation/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Navigation.pdb" target="lib/netstandard2.0/OpenSilver.Controls.Navigation.pdb" />
     <file src="../../src/Runtime/Blend/Interactivity/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Interactivity.dll" target="lib/netstandard2.0/OpenSilver.Interactivity.dll" />

--- a/build/nuspec/OpenSilver.nuspec
+++ b/build/nuspec/OpenSilver.nuspec
@@ -27,21 +27,14 @@
   <files>
     <!-- OpenSilver runtime -->
     <file src="../../src/Runtime/OpenSilver.Xaml/bin/OpenSilver/Debug/netstandard2.0/OpenSilver.Xaml.dll" target="lib/netstandard2.0/OpenSilver.Xaml.dll" />
-    <!-- <file src="../../src/Runtime/OpenSilver.Xaml/bin/OpenSilver/Debug/netstandard2.0/OpenSilver.Xaml.pdb" target="lib/netstandard2.0/OpenSilver.Xaml.pdb" /> -->
     <file src="../../src/Runtime/Runtime/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.dll" target="lib/netstandard2.0/OpenSilver.dll" />
-    <!-- <file src="../../src/Runtime/Runtime/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.pdb" target="lib/netstandard2.0/OpenSilver.pdb" /> -->
     <file src="../../src/Runtime/DataForm.Toolkit/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.dll" target="lib/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.dll" />
-    <!-- <file src="../../src/Runtime/DataForm.Toolkit/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.pdb" target="lib/netstandard2.0/OpenSilver.Controls.Data.DataForm.Toolkit.pdb" /> -->
     <file src="../../src/Runtime/Controls.Data.Input/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Data.Input.dll" target="lib/netstandard2.0/OpenSilver.Controls.Data.Input.dll" />
 	<file src="../../src/Runtime/Controls.Input/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Input.dll" target="lib/netstandard2.0/OpenSilver.Controls.Input.dll" />
     <file src="../../src/Runtime/Controls.Navigation/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Navigation.dll" target="lib/netstandard2.0/OpenSilver.Controls.Navigation.dll" />
-    <file src="../../src/Runtime/Controls.Navigation/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Controls.Navigation.pdb" target="lib/netstandard2.0/OpenSilver.Controls.Navigation.pdb" />
     <file src="../../src/Runtime/Blend/Interactivity/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Interactivity.dll" target="lib/netstandard2.0/OpenSilver.Interactivity.dll" />
-    <file src="../../src/Runtime/Blend/Interactivity/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Interactivity.pdb" target="lib/netstandard2.0/OpenSilver.Interactivity.pdb" />
     <file src="../../src/Runtime/Blend/Interactions/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Expression.Interactions.dll" target="lib/netstandard2.0/OpenSilver.Expression.Interactions.dll" />
-    <file src="../../src/Runtime/Blend/Interactions/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Expression.Interactions.pdb" target="lib/netstandard2.0/OpenSilver.Expression.Interactions.pdb" />
     <file src="../../src/Runtime/Blend/Effects/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Expression.Effects.dll" target="lib/netstandard2.0/OpenSilver.Expression.Effects.dll" />
-    <file src="../../src/Runtime/Blend/Effects/bin/OpenSilver/$Configuration$/netstandard2.0/OpenSilver.Expression.Effects.pdb" target="lib/netstandard2.0/OpenSilver.Expression.Effects.pdb" />
 
     <!-- OpenSilver targets -->
     <file src="../../src/Targets/$Target$.targets" target="build/$PackageId$.targets" />

--- a/src/Runtime/Blend/Effects/Expression.Effects.OpenSilver.csproj
+++ b/src/Runtime/Blend/Effects/Expression.Effects.OpenSilver.csproj
@@ -1,20 +1,33 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>OpenSilver.Expression.Effects</AssemblyName>
-    <RootNamespace>Microsoft.Expression.Media.Effects</RootNamespace>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Configurations>SL;UWP</Configurations>
-    <OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
-    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
-    <DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<AssemblyName>OpenSilver.Expression.Effects</AssemblyName>
+		<RootNamespace>Microsoft.Expression.Media.Effects</RootNamespace>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<Configurations>SL;UWP</Configurations>
+		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+		<DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Interactions\Expression.Interactions.OpenSilver.csproj" />
-    <ProjectReference Include="..\..\Runtime\Runtime.OpenSilver.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition="$(Optimize) != true">
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(Optimize) != true">
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Interactions\Expression.Interactions.OpenSilver.csproj" />
+		<ProjectReference Include="..\..\Runtime\Runtime.OpenSilver.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/src/Runtime/Blend/Effects/Expression.Effects.OpenSilver.csproj
+++ b/src/Runtime/Blend/Effects/Expression.Effects.OpenSilver.csproj
@@ -10,7 +10,7 @@
 		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
 		<DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
-		<Optimize>true</Optimize>
+		<Optimize>false</Optimize>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(Optimize) != true">

--- a/src/Runtime/Blend/Interactions/Expression.Interactions.OpenSilver.csproj
+++ b/src/Runtime/Blend/Interactions/Expression.Interactions.OpenSilver.csproj
@@ -1,38 +1,47 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>OpenSilver.Expression.Interactions</AssemblyName>
-    <RootNamespace>Microsoft.Expression.Interactivity</RootNamespace>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Configurations>SL;UWP</Configurations>
-    <OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
-    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
-    <DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<AssemblyName>OpenSilver.Expression.Interactions</AssemblyName>
+		<RootNamespace>Microsoft.Expression.Interactivity</RootNamespace>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<Configurations>SL;UWP</Configurations>
+		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+		<DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Interactivity\Interactivity.OpenSilver.csproj" />
-    <ProjectReference Include="..\..\Runtime\Runtime.OpenSilver.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition="$(Optimize) != true">
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Update="ExceptionStringTable.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>ExceptionStringTable.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
+	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Update="ExceptionStringTable.resx">
-      <Public>True</Public>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>ExceptionStringTable.Designer.cs</LastGenOutput>
-      <CustomToolNamespace>OpenSilver.Internal.Expression.Interactivity</CustomToolNamespace>
-    </EmbeddedResource>
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Interactivity\Interactivity.OpenSilver.csproj" />
+		<ProjectReference Include="..\..\Runtime\Runtime.OpenSilver.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Update="ExceptionStringTable.Designer.cs">
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+			<DependentUpon>ExceptionStringTable.resx</DependentUpon>
+		</Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Update="ExceptionStringTable.resx">
+			<Public>True</Public>
+			<Generator>ResXFileCodeGenerator</Generator>
+			<LastGenOutput>ExceptionStringTable.Designer.cs</LastGenOutput>
+			<CustomToolNamespace>OpenSilver.Internal.Expression.Interactivity</CustomToolNamespace>
+		</EmbeddedResource>
+	</ItemGroup>
 
 </Project>

--- a/src/Runtime/Blend/Interactions/Expression.Interactions.OpenSilver.csproj
+++ b/src/Runtime/Blend/Interactions/Expression.Interactions.OpenSilver.csproj
@@ -11,7 +11,7 @@
 		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
 		<DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
-		<Optimize>true</Optimize>
+		<Optimize>false</Optimize>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(Optimize) != true">

--- a/src/Runtime/Blend/Interactivity/Interactivity.OpenSilver.csproj
+++ b/src/Runtime/Blend/Interactivity/Interactivity.OpenSilver.csproj
@@ -11,7 +11,7 @@
 		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
 		<DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
 		<NoWarn>$(NoWarn);CS1591</NoWarn>
-		<Optimize>true</Optimize>
+		<Optimize>false</Optimize>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">

--- a/src/Runtime/Blend/Interactivity/Interactivity.OpenSilver.csproj
+++ b/src/Runtime/Blend/Interactivity/Interactivity.OpenSilver.csproj
@@ -1,37 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>OpenSilver.Interactivity</AssemblyName>
-    <RootNamespace>System.Windows.Interactivity</RootNamespace>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Configurations>SL;UWP</Configurations>
-    <OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
-    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
-    <DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<AssemblyName>OpenSilver.Interactivity</AssemblyName>
+		<RootNamespace>System.Windows.Interactivity</RootNamespace>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<Configurations>SL;UWP</Configurations>
+		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+		<DefineConstants>$(DefineConstants);TRACE</DefineConstants>
+		<DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
+		<NoWarn>$(NoWarn);CS1591</NoWarn>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Runtime\Runtime.OpenSilver.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Update="ExceptionStringTable.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>ExceptionStringTable.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Runtime\Runtime.OpenSilver.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Update="ExceptionStringTable.resx">
-      <Public>True</Public>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>ExceptionStringTable.Designer.cs</LastGenOutput>
-      <CustomToolNamespace>OpenSilver.Internal.Interactivity</CustomToolNamespace>
-    </EmbeddedResource>
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Update="ExceptionStringTable.Designer.cs">
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+			<DependentUpon>ExceptionStringTable.resx</DependentUpon>
+		</Compile>
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Update="ExceptionStringTable.resx">
+			<Public>True</Public>
+			<Generator>ResXFileCodeGenerator</Generator>
+			<LastGenOutput>ExceptionStringTable.Designer.cs</LastGenOutput>
+			<CustomToolNamespace>OpenSilver.Internal.Interactivity</CustomToolNamespace>
+		</EmbeddedResource>
+	</ItemGroup>
 
 </Project>

--- a/src/Runtime/Blend/Interactivity/Interactivity.OpenSilver.csproj
+++ b/src/Runtime/Blend/Interactivity/Interactivity.OpenSilver.csproj
@@ -14,6 +14,10 @@
 		<Optimize>false</Optimize>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="$(Optimize) != true">
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
 		<DebugType>embedded</DebugType>
 	</PropertyGroup>

--- a/src/Runtime/Controls.Data.Input/Controls.Data.Input.OpenSilver.csproj
+++ b/src/Runtime/Controls.Data.Input/Controls.Data.Input.OpenSilver.csproj
@@ -12,7 +12,7 @@
     <IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
     <OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
     <OpenSilverVersion>1.0.0</OpenSilverVersion>
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <Optimize>true</Optimize>
   </PropertyGroup>
 

--- a/src/Runtime/Controls.Data.Input/Controls.Data.Input.OpenSilver.csproj
+++ b/src/Runtime/Controls.Data.Input/Controls.Data.Input.OpenSilver.csproj
@@ -12,7 +12,7 @@
 		<IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
 		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
 		<OpenSilverVersion>1.0.0</OpenSilverVersion>
-		<Optimize>true</Optimize>
+		<Optimize>false</Optimize>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">

--- a/src/Runtime/Controls.Data.Input/Controls.Data.Input.OpenSilver.csproj
+++ b/src/Runtime/Controls.Data.Input/Controls.Data.Input.OpenSilver.csproj
@@ -1,83 +1,86 @@
 ﻿<Project>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultItems>false</EnableDefaultItems>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AssemblyName>OpenSilver.Controls.Data.Input</AssemblyName>
-    <RootNamespace>System.Windows.Controls</RootNamespace>
-    <Configurations>SL;UWP</Configurations>
-    <IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
-    <OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
-    <OpenSilverVersion>1.0.0</OpenSilverVersion>
-    <DebugType>embedded</DebugType>
-    <Optimize>true</Optimize>
-  </PropertyGroup>
+	<Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">
-    <DefineConstants>TRACE;OPENSILVER;MIGRATION</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<EnableDefaultItems>false</EnableDefaultItems>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AssemblyName>OpenSilver.Controls.Data.Input</AssemblyName>
+		<RootNamespace>System.Windows.Controls</RootNamespace>
+		<Configurations>SL;UWP</Configurations>
+		<IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
+		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+		<OpenSilverVersion>1.0.0</OpenSilverVersion>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' ">
-    <DefineConstants>TRACE;OPENSILVER</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">
+		<DefineConstants>TRACE;OPENSILVER;MIGRATION</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="$(Optimize) != true">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' ">
+		<DefineConstants>TRACE;OPENSILVER</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Runtime\Runtime.OpenSilver.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition="$(Optimize) != true">
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="Automation\DescriptionViewerAutomationPeer.cs" />
-    <Compile Include="Automation\ValidationSummaryAutomationPeer.cs" />
-    <Compile Include="Common\Extensions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Resources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Validation\DescriptionViewer.cs" />
-    <Compile Include="Validation\ValidationSummary.cs" />
-    <Compile Include="Validation\ValidationSummaryFilters.cs" />
-    <Compile Include="Validation\ValidationSummaryItem.cs" />
-    <Compile Include="Validation\ValidationSummaryItemSource.cs" />
-    <Compile Include="Validation\ValidationSummaryItemType.cs" />
-    <Compile Include="Validation\FocusingInvalidControlEventArgs.cs" />
-    <Compile Include="Validation\Label.cs" />
-    <Compile Include="Validation\ValidationItemCollection.cs" />
-    <Compile Include="Validation\ValidationHelper.cs" />
-    <Compile Include="Validation\ValidationMetadata.cs" />
-    <Compile Include="VisualStates.cs" />
-  </ItemGroup>
+	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="themes\generic.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Runtime\Runtime.OpenSilver.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="themes\generic.SL.xaml" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="Automation\DescriptionViewerAutomationPeer.cs" />
+		<Compile Include="Automation\ValidationSummaryAutomationPeer.cs" />
+		<Compile Include="Common\Extensions.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+		<Compile Include="Resources.Designer.cs">
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+			<DependentUpon>Resources.resx</DependentUpon>
+		</Compile>
+		<Compile Include="Validation\DescriptionViewer.cs" />
+		<Compile Include="Validation\ValidationSummary.cs" />
+		<Compile Include="Validation\ValidationSummaryFilters.cs" />
+		<Compile Include="Validation\ValidationSummaryItem.cs" />
+		<Compile Include="Validation\ValidationSummaryItemSource.cs" />
+		<Compile Include="Validation\ValidationSummaryItemType.cs" />
+		<Compile Include="Validation\FocusingInvalidControlEventArgs.cs" />
+		<Compile Include="Validation\Label.cs" />
+		<Compile Include="Validation\ValidationItemCollection.cs" />
+		<Compile Include="Validation\ValidationHelper.cs" />
+		<Compile Include="Validation\ValidationMetadata.cs" />
+		<Compile Include="VisualStates.cs" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Resources.resx">
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <CustomToolNamespace>OpenSilver.Internal.Controls.Data.Input</CustomToolNamespace>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="themes\generic.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Content>
+	</ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+	<ItemGroup>
+		<None Include="themes\generic.SL.xaml" />
+	</ItemGroup>
 
-  <Import Project="..\..\packages\OpenSilver.$(OpenSilverVersion)\build\OpenSilver.targets" Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' " />
-  <Import Project="..\..\packages\OpenSilver.UWPCompatible.$(OpenSilverVersion)\build\OpenSilver.UwpCompatible.targets" Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' " />
+	<ItemGroup>
+		<EmbeddedResource Include="Resources.resx">
+			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
+			<CustomToolNamespace>OpenSilver.Internal.Controls.Data.Input</CustomToolNamespace>
+			<Generator>ResXFileCodeGenerator</Generator>
+			<SubType>Designer</SubType>
+		</EmbeddedResource>
+	</ItemGroup>
+
+	<Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+	<Import Project="..\..\packages\OpenSilver.$(OpenSilverVersion)\build\OpenSilver.targets" Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' " />
+	<Import Project="..\..\packages\OpenSilver.UWPCompatible.$(OpenSilverVersion)\build\OpenSilver.UwpCompatible.targets" Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' " />
 
 </Project>

--- a/src/Runtime/Controls.Input/Controls.Input.OpenSilver.csproj
+++ b/src/Runtime/Controls.Input/Controls.Input.OpenSilver.csproj
@@ -1,113 +1,121 @@
 ﻿<Project>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+	<Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultItems>false</EnableDefaultItems>
-    <AssemblyName>OpenSilver.Controls.Input</AssemblyName>
-    <RootNamespace>System.Windows.Controls</RootNamespace>
-    <Configurations>SL;UWP</Configurations>
-    <IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
-    <OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
-    <OpenSilverVersion>1.0.0</OpenSilverVersion>
-    <Optimize>true</Optimize>
-    <DefineTrace>true</DefineTrace>
-    <DefineConstants>$(DefineConstants);SILVERLIGHT</DefineConstants>
-    <DefineConstants Condition="$(Optimize) != true">$(DefineConstants);DEBUG</DefineConstants>
-    <DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<EnableDefaultItems>false</EnableDefaultItems>
+		<AssemblyName>OpenSilver.Controls.Input</AssemblyName>
+		<RootNamespace>System.Windows.Controls</RootNamespace>
+		<Configurations>SL;UWP</Configurations>
+		<IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
+		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+		<OpenSilverVersion>1.0.0</OpenSilverVersion>
+		<Optimize>false</Optimize>
+		<DefineTrace>true</DefineTrace>
+		<DefineConstants>$(DefineConstants);SILVERLIGHT</DefineConstants>
+		<DefineConstants Condition="$(Optimize) != true">$(DefineConstants);DEBUG</DefineConstants>
+		<DefineConstants Condition=" '$(Configuration)' == 'SL' ">$(DefineConstants);MIGRATION</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Runtime\Runtime.OpenSilver.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition="$(Optimize) != true">
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="AutoCompleteBox\PopupHelper.cs" />
-    <Compile Include="Common\WeakEventListener.cs" />
-    <!--
+	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Runtime\Runtime.OpenSilver.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Compile Include="AutoCompleteBox\PopupHelper.cs" />
+		<Compile Include="Common\WeakEventListener.cs" />
+		<!--
     <Compile Include="..\Controls\Common\BindingEvaluator.cs">
       <Link>Common\BindingEvaluator.cs</Link>
     </Compile>
     -->
-    <Compile Include="Common\BindingEvaluator.cs" />
-    <!--
+		<Compile Include="Common\BindingEvaluator.cs" />
+		<!--
     <Compile Include="..\Controls\Common\InteractionHelper.cs">
       <Link>Common\InteractionHelper.cs</Link>
     </Compile>
     -->
-    <Compile Include="..\Runtime\System.Windows.Controls\InteractionHelper.cs">
-      <Link>Common\InteractionHelper.cs</Link>
-    </Compile>
-    <!--
+		<Compile Include="..\Runtime\System.Windows.Controls\InteractionHelper.cs">
+			<Link>Common\InteractionHelper.cs</Link>
+		</Compile>
+		<!--
     <Compile Include="..\Controls\Common\IUpdateVisualState.cs">
       <Link>Common\IUpdateVisualState.cs</Link>
     </Compile>
     -->
-    <Compile Include="..\Runtime\System.Windows.Controls\IUpdateVisualState.cs">
-      <Link>Common\IUpdateVisualState.cs</Link>
-    </Compile>
-    <!--
+		<Compile Include="..\Runtime\System.Windows.Controls\IUpdateVisualState.cs">
+			<Link>Common\IUpdateVisualState.cs</Link>
+		</Compile>
+		<!--
     <Compile Include="..\Controls\Common\ScrollExtensions.cs">
       <Link>Common\ScrollExtensions.cs</Link>
     </Compile>
     -->
-    <!--
+		<!--
     <Compile Include="..\Controls\Common\VisualStates.cs">
       <Link>Common\VisualStates.cs</Link>
     </Compile>
     -->
-    <Compile Include="..\Runtime\System.Windows.Controls\VisualStates.cs">
-      <Link>Common\VisualStates.cs</Link>
-    </Compile>
-    <Compile Include="AutoCompleteBox\AutoCompleteBox.cs" />
-    <Compile Include="AutoCompleteBox\AutoCompleteBoxAutomationPeer.cs" />
-    <Compile Include="AutoCompleteBox\AutoCompleteFilter.cs" />
-    <Compile Include="AutoCompleteBox\AutoCompleteFilterMode.cs" />
-    <Compile Include="AutoCompleteBox\AutoCompleteFilterPredicate.cs" />
-    <Compile Include="AutoCompleteBox\ISelectionAdapter.cs" />
-    <Compile Include="AutoCompleteBox\PopulatedEventArgs.cs" />
-    <Compile Include="AutoCompleteBox\PopulatedEventHandler.cs" />
-    <Compile Include="AutoCompleteBox\PopulatingEventArgs.cs" />
-    <Compile Include="AutoCompleteBox\PopulatingEventHandler.cs" />
-    <Compile Include="AutoCompleteBox\SelectorSelectionAdapter.cs" />
-    <Compile Include="Common\Extensions.cs" />
-    <Compile Include="Common\VisualTreeExtensions.cs" />
-    <Compile Include="GlobalSuppressions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
-      <DependentUpon>Resources.resx</DependentUpon>
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <CustomToolNamespace>OpenSilver.Controls.Input.Properties</CustomToolNamespace>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Include="Themes\generic.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="AutoCompleteBox\AutoCompleteBox.xaml" />
-    <!--
+		<Compile Include="..\Runtime\System.Windows.Controls\VisualStates.cs">
+			<Link>Common\VisualStates.cs</Link>
+		</Compile>
+		<Compile Include="AutoCompleteBox\AutoCompleteBox.cs" />
+		<Compile Include="AutoCompleteBox\AutoCompleteBoxAutomationPeer.cs" />
+		<Compile Include="AutoCompleteBox\AutoCompleteFilter.cs" />
+		<Compile Include="AutoCompleteBox\AutoCompleteFilterMode.cs" />
+		<Compile Include="AutoCompleteBox\AutoCompleteFilterPredicate.cs" />
+		<Compile Include="AutoCompleteBox\ISelectionAdapter.cs" />
+		<Compile Include="AutoCompleteBox\PopulatedEventArgs.cs" />
+		<Compile Include="AutoCompleteBox\PopulatedEventHandler.cs" />
+		<Compile Include="AutoCompleteBox\PopulatingEventArgs.cs" />
+		<Compile Include="AutoCompleteBox\PopulatingEventHandler.cs" />
+		<Compile Include="AutoCompleteBox\SelectorSelectionAdapter.cs" />
+		<Compile Include="Common\Extensions.cs" />
+		<Compile Include="Common\VisualTreeExtensions.cs" />
+		<Compile Include="GlobalSuppressions.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+		<Compile Include="Properties\Resources.Designer.cs">
+			<DependentUpon>Resources.resx</DependentUpon>
+			<AutoGen>True</AutoGen>
+			<DesignTime>True</DesignTime>
+		</Compile>
+	</ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="Properties\Resources.resx">
+			<Generator>ResXFileCodeGenerator</Generator>
+			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
+			<CustomToolNamespace>OpenSilver.Controls.Input.Properties</CustomToolNamespace>
+			<SubType>Designer</SubType>
+		</EmbeddedResource>
+	</ItemGroup>
+	<ItemGroup>
+		<Page Include="Themes\generic.xaml">
+			<SubType>Designer</SubType>
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="AutoCompleteBox\AutoCompleteBox.xaml" />
+		<!--
     <None Include="..\Controls\Common\Common.xaml">
       <Link>Common\Common.xaml</Link>
     </None>
     -->
-    <None Include="Common\Common.xaml" />
-  </ItemGroup>
+		<None Include="Common\Common.xaml" />
+	</ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+	<Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
-  <Import Project="..\..\packages\OpenSilver.$(OpenSilverVersion)\build\OpenSilver.targets" Condition=" '$(Configuration)' == 'SL' " />
-  <Import Project="..\..\packages\OpenSilver.UWPCompatible.$(OpenSilverVersion)\build\OpenSilver.UwpCompatible.targets" Condition=" '$(Configuration)' == 'UWP' " />
+	<Import Project="..\..\packages\OpenSilver.$(OpenSilverVersion)\build\OpenSilver.targets" Condition=" '$(Configuration)' == 'SL' " />
+	<Import Project="..\..\packages\OpenSilver.UWPCompatible.$(OpenSilverVersion)\build\OpenSilver.UwpCompatible.targets" Condition=" '$(Configuration)' == 'UWP' " />
 
 </Project>

--- a/src/Runtime/Controls.Navigation/Controls.Navigation.OpenSilver.csproj
+++ b/src/Runtime/Controls.Navigation/Controls.Navigation.OpenSilver.csproj
@@ -12,7 +12,7 @@
 		<IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
 		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
 		<OpenSilverVersion>1.0.0</OpenSilverVersion>
-		<Optimize>true</Optimize>
+		<Optimize>false</Optimize>
 		<DefineSilverlight>true</DefineSilverlight>
 	</PropertyGroup>
 

--- a/src/Runtime/Controls.Navigation/Controls.Navigation.OpenSilver.csproj
+++ b/src/Runtime/Controls.Navigation/Controls.Navigation.OpenSilver.csproj
@@ -1,37 +1,40 @@
 ﻿<Project>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+	<Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultItems>false</EnableDefaultItems>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AssemblyName>OpenSilver.Controls.Navigation</AssemblyName>
-    <RootNamespace>System.Windows.Navigation</RootNamespace>
-    <Configurations>SL;UWP</Configurations>
-    <IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
-    <OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
-    <OpenSilverVersion>1.0.0</OpenSilverVersion>
-    <Optimize>true</Optimize>
-    <DefineSilverlight>true</DefineSilverlight>
-    <DebugType>embedded</DebugType>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<EnableDefaultItems>false</EnableDefaultItems>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AssemblyName>OpenSilver.Controls.Navigation</AssemblyName>
+		<RootNamespace>System.Windows.Navigation</RootNamespace>
+		<Configurations>SL;UWP</Configurations>
+		<IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
+		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+		<OpenSilverVersion>1.0.0</OpenSilverVersion>
+		<Optimize>true</Optimize>
+		<DefineSilverlight>true</DefineSilverlight>
+	</PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">
-    <DefineConstants>TRACE;MIGRATION</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">
+		<DefineConstants>TRACE;MIGRATION</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' ">
-    <DefineConstants>TRACE</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' ">
+		<DefineConstants>TRACE</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="$(Optimize) != true">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition="$(Optimize) != true">
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Runtime\Runtime.OpenSilver.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Runtime\Runtime.OpenSilver.csproj" />
+	</ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\..\Compiler\Shared\XamlResourcesHelper.cs">
@@ -82,9 +85,9 @@
     </Page>
   </ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+	<Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
-  <Import Project="..\..\packages\OpenSilver.$(OpenSilverVersion)\build\OpenSilver.targets" Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' " />
-  <Import Project="..\..\packages\OpenSilver.UWPCompatible.$(OpenSilverVersion)\build\OpenSilver.UwpCompatible.targets" Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' " />
+	<Import Project="..\..\packages\OpenSilver.$(OpenSilverVersion)\build\OpenSilver.targets" Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' " />
+	<Import Project="..\..\packages\OpenSilver.UWPCompatible.$(OpenSilverVersion)\build\OpenSilver.UwpCompatible.targets" Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' " />
 
 </Project>

--- a/src/Runtime/Controls.Navigation/Controls.Navigation.OpenSilver.csproj
+++ b/src/Runtime/Controls.Navigation/Controls.Navigation.OpenSilver.csproj
@@ -14,6 +14,7 @@
     <OpenSilverVersion>1.0.0</OpenSilverVersion>
     <Optimize>true</Optimize>
     <DefineSilverlight>true</DefineSilverlight>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">

--- a/src/Runtime/DataForm.Toolkit/DataForm.Toolkit.OpenSilver.csproj
+++ b/src/Runtime/DataForm.Toolkit/DataForm.Toolkit.OpenSilver.csproj
@@ -12,7 +12,7 @@
     <IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
     <OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
     <OpenSilverVersion>1.0.0</OpenSilverVersion>
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <Optimize>true</Optimize>
   </PropertyGroup>
 

--- a/src/Runtime/DataForm.Toolkit/DataForm.Toolkit.OpenSilver.csproj
+++ b/src/Runtime/DataForm.Toolkit/DataForm.Toolkit.OpenSilver.csproj
@@ -12,7 +12,7 @@
 		<IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
 		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
 		<OpenSilverVersion>1.0.0</OpenSilverVersion>
-		<Optimize>true</Optimize>
+		<Optimize>false</Optimize>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">

--- a/src/Runtime/DataForm.Toolkit/DataForm.Toolkit.OpenSilver.csproj
+++ b/src/Runtime/DataForm.Toolkit/DataForm.Toolkit.OpenSilver.csproj
@@ -1,99 +1,102 @@
 ﻿<Project>
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+	<Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <EnableDefaultItems>false</EnableDefaultItems>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AssemblyName>OpenSilver.Controls.Data.DataForm.Toolkit</AssemblyName>
-    <RootNamespace>System.Windows.Controls</RootNamespace>
-    <Configurations>SL;UWP</Configurations>
-    <IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
-    <OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
-    <OpenSilverVersion>1.0.0</OpenSilverVersion>
-    <DebugType>embedded</DebugType>
-    <Optimize>true</Optimize>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<EnableDefaultItems>false</EnableDefaultItems>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<AssemblyName>OpenSilver.Controls.Data.DataForm.Toolkit</AssemblyName>
+		<RootNamespace>System.Windows.Controls</RootNamespace>
+		<Configurations>SL;UWP</Configurations>
+		<IntermediateOutputPath>obj\OpenSilver\$(Configuration)\</IntermediateOutputPath>
+		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+		<OpenSilverVersion>1.0.0</OpenSilverVersion>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">
-    <DefineConstants>TRACE;OPENSILVER;MIGRATION</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">
+		<DefineConstants>TRACE;OPENSILVER;MIGRATION</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' ">
-    <DefineConstants>TRACE;OPENSILVER</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' ">
+		<DefineConstants>TRACE;OPENSILVER</DefineConstants>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="$(Optimize) != true">
-    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
-  </PropertyGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\Runtime\Runtime.OpenSilver.csproj" />
-    <ProjectReference Include="..\Controls.Data.Input\Controls.Data.Input.OpenSilver.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition="$(Optimize) != true">
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="Common\Extensions.cs" />
-    <Compile Include="Common\TypeHelper.cs" />
-    <Compile Include="DataField\DataField.cs" />
-    <Compile Include="DataField\DataFieldEnums\DataFieldDescriptionViewerPosition.cs" />
-    <Compile Include="DataField\DataFieldEnums\DataFieldLabelPosition.cs" />
-    <Compile Include="DataField\DataFieldEnums\DataFieldMode.cs" />
-    <Compile Include="DataForm\Automation\DataFormAutomationPeer.cs" />
-    <Compile Include="DataForm\DataForm.cs" />
-    <Compile Include="DataForm\DataFormBindingInfo.cs" />
-    <Compile Include="DataForm\DataFormCommandButtonsVisibilityTypeConverter.cs" />
-    <Compile Include="DataForm\DataFormEnums\DataFormCommandButtonsVisibility.cs" />
-    <Compile Include="DataForm\DataFormEnums\DataFormEditAction.cs" />
-    <Compile Include="DataForm\DataFormEnums\DataFormMode.cs" />
-    <Compile Include="DataForm\DataFormEventArgs\DataFormAddingNewItemEventArgs.cs" />
-    <Compile Include="DataForm\DataFormEventArgs\DataFormAutoGeneratingFieldEventArgs.cs" />
-    <Compile Include="DataForm\DataFormEventArgs\DataFormContentLoadEventArgs.cs" />
-    <Compile Include="DataForm\DataFormEventArgs\DataFormEditEndedEventArgs.cs" />
-    <Compile Include="DataForm\DataFormEventArgs\DataFormEditEndingEventArgs.cs" />
-    <Compile Include="DataForm\DataFormToStringConverter.cs" />
-    <Compile Include="DataForm\DataFormValueConverter.cs" />
-    <Compile Include="DataForm\PathOrderPair.cs" />
-    <Compile Include="DataForm\ValidationUtil.cs" />
-    <Compile Include="DataForm\WeakEventListener.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Resources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Common\CommonResources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>CommonResources.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
+	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="themes\generic.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Runtime\Runtime.OpenSilver.csproj" />
+		<ProjectReference Include="..\Controls.Data.Input\Controls.Data.Input.OpenSilver.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="Resources.resx">
-      <Public>True</Public>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <CustomToolNamespace>OpenSilver.Internal.Controls.Data.DataForm.Toolkit</CustomToolNamespace>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Common\CommonResources.resx">
-      <Public>True</Public>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>CommonResources.Designer.cs</LastGenOutput>
-      <CustomToolNamespace>OpenSilver.Internal.Controls.Data.DataForm.Toolkit</CustomToolNamespace>
-    </EmbeddedResource>
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="Common\Extensions.cs" />
+		<Compile Include="Common\TypeHelper.cs" />
+		<Compile Include="DataField\DataField.cs" />
+		<Compile Include="DataField\DataFieldEnums\DataFieldDescriptionViewerPosition.cs" />
+		<Compile Include="DataField\DataFieldEnums\DataFieldLabelPosition.cs" />
+		<Compile Include="DataField\DataFieldEnums\DataFieldMode.cs" />
+		<Compile Include="DataForm\Automation\DataFormAutomationPeer.cs" />
+		<Compile Include="DataForm\DataForm.cs" />
+		<Compile Include="DataForm\DataFormBindingInfo.cs" />
+		<Compile Include="DataForm\DataFormCommandButtonsVisibilityTypeConverter.cs" />
+		<Compile Include="DataForm\DataFormEnums\DataFormCommandButtonsVisibility.cs" />
+		<Compile Include="DataForm\DataFormEnums\DataFormEditAction.cs" />
+		<Compile Include="DataForm\DataFormEnums\DataFormMode.cs" />
+		<Compile Include="DataForm\DataFormEventArgs\DataFormAddingNewItemEventArgs.cs" />
+		<Compile Include="DataForm\DataFormEventArgs\DataFormAutoGeneratingFieldEventArgs.cs" />
+		<Compile Include="DataForm\DataFormEventArgs\DataFormContentLoadEventArgs.cs" />
+		<Compile Include="DataForm\DataFormEventArgs\DataFormEditEndedEventArgs.cs" />
+		<Compile Include="DataForm\DataFormEventArgs\DataFormEditEndingEventArgs.cs" />
+		<Compile Include="DataForm\DataFormToStringConverter.cs" />
+		<Compile Include="DataForm\DataFormValueConverter.cs" />
+		<Compile Include="DataForm\PathOrderPair.cs" />
+		<Compile Include="DataForm\ValidationUtil.cs" />
+		<Compile Include="DataForm\WeakEventListener.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+		<Compile Include="Resources.Designer.cs">
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+			<DependentUpon>Resources.resx</DependentUpon>
+		</Compile>
+		<Compile Include="Common\CommonResources.Designer.cs">
+			<DesignTime>True</DesignTime>
+			<AutoGen>True</AutoGen>
+			<DependentUpon>CommonResources.resx</DependentUpon>
+		</Compile>
+	</ItemGroup>
 
-  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+	<ItemGroup>
+		<Content Include="themes\generic.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Content>
+	</ItemGroup>
 
-  <Import Project="..\..\packages\OpenSilver.$(OpenSilverVersion)\build\OpenSilver.targets" Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' " />
-  <Import Project="..\..\packages\OpenSilver.UWPCompatible.$(OpenSilverVersion)\build\OpenSilver.UwpCompatible.targets" Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' " />
+	<ItemGroup>
+		<EmbeddedResource Include="Resources.resx">
+			<Public>True</Public>
+			<Generator>ResXFileCodeGenerator</Generator>
+			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
+			<CustomToolNamespace>OpenSilver.Internal.Controls.Data.DataForm.Toolkit</CustomToolNamespace>
+		</EmbeddedResource>
+		<EmbeddedResource Include="Common\CommonResources.resx">
+			<Public>True</Public>
+			<Generator>ResXFileCodeGenerator</Generator>
+			<LastGenOutput>CommonResources.Designer.cs</LastGenOutput>
+			<CustomToolNamespace>OpenSilver.Internal.Controls.Data.DataForm.Toolkit</CustomToolNamespace>
+		</EmbeddedResource>
+	</ItemGroup>
+
+	<Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+	<Import Project="..\..\packages\OpenSilver.$(OpenSilverVersion)\build\OpenSilver.targets" Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' " />
+	<Import Project="..\..\packages\OpenSilver.UWPCompatible.$(OpenSilverVersion)\build\OpenSilver.UwpCompatible.targets" Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' " />
 
 </Project>

--- a/src/Runtime/OpenSilver.Xaml/OpenSilver.Xaml.csproj
+++ b/src/Runtime/OpenSilver.Xaml/OpenSilver.Xaml.csproj
@@ -3,6 +3,9 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
 		<DebugType>embedded</DebugType>
 	</PropertyGroup>
 

--- a/src/Runtime/OpenSilver.Xaml/OpenSilver.Xaml.csproj
+++ b/src/Runtime/OpenSilver.Xaml/OpenSilver.Xaml.csproj
@@ -3,6 +3,11 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+		<Optimize>false</Optimize>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(Optimize) != true">
+		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">

--- a/src/Runtime/OpenSilver.Xaml/OpenSilver.Xaml.csproj
+++ b/src/Runtime/OpenSilver.Xaml/OpenSilver.Xaml.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
+		<DebugType>embedded</DebugType>
 	</PropertyGroup>
 
 </Project>

--- a/src/Runtime/Runtime/Runtime.OpenSilver.csproj
+++ b/src/Runtime/Runtime/Runtime.OpenSilver.csproj
@@ -13,7 +13,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
 		<NoWarn>1591</NoWarn>
-		<DebugType>full</DebugType>
+		<DebugType>embedded</DebugType>
 		<Optimize>true</Optimize>
 		<NoCSHTML5Reference>true</NoCSHTML5Reference>
 		<EnableDefaultItems>false</EnableDefaultItems>

--- a/src/Runtime/Runtime/Runtime.OpenSilver.csproj
+++ b/src/Runtime/Runtime/Runtime.OpenSilver.csproj
@@ -13,8 +13,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<OutputPath>bin\OpenSilver\$(Configuration)\</OutputPath>
 		<NoWarn>1591</NoWarn>
-		<DebugType>embedded</DebugType>
-		<Optimize>true</Optimize>
+		<Optimize>false</Optimize>
 		<NoCSHTML5Reference>true</NoCSHTML5Reference>
 		<EnableDefaultItems>false</EnableDefaultItems>
 		<!-- This emluates the behavior of NET Framework, which excludes every files by default -->
@@ -31,6 +30,10 @@
 
 	<PropertyGroup Condition="$(Optimize) != true">
 		<DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(DefineConstants.Contains('DEBUG'))">
+		<DebugType>embedded</DebugType>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This would save the hassle of synchronizing PDBs and improve the debugging experience a bit.
This technique is applied only to the Runtime assemblies. 
