### PR TITLE
feat: new popup implementation

### DIFF
--- a/src/Runtime/Runtime/Core/Rendering/INTERNAL_PopupsManager.cs
+++ b/src/Runtime/Runtime/Core/Rendering/INTERNAL_PopupsManager.cs
@@ -42,7 +42,7 @@ namespace DotNetForHtml5.Core // Important: do not rename this class without upd
         static Dictionary<string, object> OrphanPopups = new Dictionary<string, object>();
 
         //Holds the currently opened popups that has false StayOpen
-        public static List<Popup> AutoCloseOpenedPopups { get; set; } = new List<Popup>();
+        public static List<Popup> AutoCloseOpenedPopups { get; } = new List<Popup>();
 
 #if MIGRATION
         internal static void OnClickOnPopupOrWindow(object sender, MouseButtonEventArgs e)

--- a/src/Runtime/Runtime/Core/Rendering/INTERNAL_PopupsManager.cs
+++ b/src/Runtime/Runtime/Core/Rendering/INTERNAL_PopupsManager.cs
@@ -39,7 +39,7 @@ namespace DotNetForHtml5.Core // Important: do not rename this class without upd
 {
     internal static class INTERNAL_PopupsManager // Important! DO NOT RENAME this class without updating the Simulator as well! // Note: this class is "internal" but still visible to the Emulator because of the "InternalsVisibleTo" flag in "Assembly.cs".
     {
-        static Dictionary<string, object> OrphanPopups = new Dictionary<string, object>();
+        public static List<Popup> OrphanPopups { get; } = new List<Popup>();
 
         //Holds the currently opened popups that has false StayOpen
         public static List<Popup> AutoCloseOpenedPopups { get; } = new List<Popup>();
@@ -58,11 +58,6 @@ namespace DotNetForHtml5.Core // Important: do not rename this class without upd
             AutoCloseOpenedPopups.RemoveAll(p => p != sender);
         }
 
-        internal static void TrackOrphanPopup(string uniquePopupId, Popup popup)
-        {
-            OrphanPopups.Add(uniquePopupId, popup);
-        }
-
         public static IEnumerable GetAllRootUIElements() // IMPORTANT: This is called via reflection from the "Visual Tree Inspector" of the Simulator. If you rename or remove it, be sure to update the Simulator accordingly!
         {
             // Include the main window:
@@ -73,7 +68,7 @@ namespace DotNetForHtml5.Core // Important: do not rename this class without upd
 #if BRIDGE
                 INTERNAL_BridgeWorkarounds.GetDictionaryValues_SimulatorCompatible(PopupRootIdentifierToInstance)
 #else
-                OrphanPopups.Values
+                OrphanPopups
 #endif
                 )
             {

--- a/src/Runtime/Runtime/Core/Rendering/INTERNAL_PopupsManager.cs
+++ b/src/Runtime/Runtime/Core/Rendering/INTERNAL_PopupsManager.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using CSHTML5.Internal;
+using System.Linq;
 
 #if MIGRATION
 using System.Windows;
@@ -41,168 +42,25 @@ namespace DotNetForHtml5.Core // Important: do not rename this class without upd
         static int CurrentPopupRootIndentifier = 0;
         static Dictionary<string, object> PopupRootIdentifierToInstance = new Dictionary<string, object>();
 
+        //Holds the currently opened popup that has false StayOpen, only one exists at any given time
+        public static Popup CurrentAutoCloseOpenedPopup { get; set; }
 
-        // Is called every time a click happens, the sender is the root element that has received the click
 #if MIGRATION
-        internal static void OnClickOnPopupOrWindow(object sender, MouseButtonEventArgs e)
+        internal static void OnClickOnWindow(object sender, MouseButtonEventArgs e)
 #else
-        internal static void OnClickOnPopupOrWindow(object sender, PointerRoutedEventArgs e)
+        internal static void OnClickOnWindow(object sender, PointerRoutedEventArgs e)
 #endif
         {
             // Note: If a popup has StayOpen=True, the value of "StayOpen" of its parents is ignored.
             // In other words, the parents of a popup that has StayOpen=True will always stay open
             // regardless of the value of their "StayOpen" property.
 
-            HashSet2<Popup> listOfPopupThatMustBeClosed = new HashSet2<Popup>();
-            List<PopupRoot> popupRootList = new List<PopupRoot>();
+            //check if the mouse is inside the currently opened popup
+            var mousePosition = new Point(e._pointerAbsoluteX, e._pointerAbsoluteY);
+            var clickedElements = VisualTreeHelper.FindElementsInHostCoordinates(mousePosition, CurrentAutoCloseOpenedPopup);
 
-            foreach (object obj in GetAllRootUIElements())
-            {
-                if (obj is PopupRoot)
-                {
-                    PopupRoot root = (PopupRoot)obj;
-                    popupRootList.Add(root);
-
-                    if (root.INTERNAL_LinkedPopup != null)
-                        listOfPopupThatMustBeClosed.Add(root.INTERNAL_LinkedPopup);
-                }
-            }
-
-            // We determine which popup needs to stay open after this click
-            foreach (PopupRoot popupRoot in popupRootList)
-            {
-                if (popupRoot.INTERNAL_LinkedPopup != null)
-                {
-                    // We must prevent all the parents of a popup to be closed when:
-                    // - this popup is set to StayOpen
-                    // - or the click happend in this popup
-
-                    Popup popup = popupRoot.INTERNAL_LinkedPopup;
-
-                    if (popup.StayOpen || sender == popupRoot)
-                    {
-                        do
-                        {
-                            if (!listOfPopupThatMustBeClosed.Contains(popup))
-                                break;
-
-                            listOfPopupThatMustBeClosed.Remove(popup);
-
-                            popup = popup.ParentPopup;
-
-                        } while (popup != null);
-                    }
-                }
-            }
-
-            foreach (Popup popup in listOfPopupThatMustBeClosed)
-            {
-                popup.CloseFromAnOutsideClick();
-            }
-
-        }
-
-        public static PopupRoot CreateAndAppendNewPopupRoot(Window parentWindow)
-        {
-            // Generate a unique identifier for the PopupRoot:
-            CurrentPopupRootIndentifier++;
-            string uniquePopupRootIdentifier = "INTERNAL_Cshtml5_PopupRoot_" + CurrentPopupRootIndentifier.ToString();
-
-            //--------------------------------------
-            // Create a DIV for the PopupRoot in the DOM tree:
-            //--------------------------------------
-
-            CSHTML5.Interop.ExecuteJavaScriptAsync(
-@"
-var popupRoot = document.createElement('div');
-popupRoot.setAttribute('id', $0);
-popupRoot.style.position = 'absolute';
-popupRoot.style.width = '100%';
-popupRoot.style.height = '100%';
-popupRoot.style.overflowX = 'hidden';
-popupRoot.style.overflowY = 'hidden';
-popupRoot.style.pointerEvents = 'none';
-$1.appendChild(popupRoot);
-", uniquePopupRootIdentifier, parentWindow.INTERNAL_RootDomElement);
-
-            //--------------------------------------
-            // Get the PopupRoot DIV:
-            //--------------------------------------
-
-            object popupRootDiv;
-
-#if OPENSILVER
-            if (true)
-#elif BRIDGE
-            if (Interop.IsRunningInTheSimulator)
-#endif
-                popupRootDiv = new INTERNAL_HtmlDomElementReference(uniquePopupRootIdentifier, null);
-            else
-                popupRootDiv = Interop.ExecuteJavaScriptAsync("document.getElementByIdSafe($0)", uniquePopupRootIdentifier);
-
-            //--------------------------------------
-            // Create the C# class that points to the PopupRoot DIV:
-            //--------------------------------------
-
-            var popupRoot = new PopupRoot(uniquePopupRootIdentifier, parentWindow);
-            popupRoot.INTERNAL_OuterDomElement
-                = popupRoot.INTERNAL_InnerDomElement
-                = popupRootDiv;
-
-            //--------------------------------------
-            // Listen to clicks anywhere in the popup (this is used to close other popups that are not supposed to stay open):
-            //--------------------------------------
-
-#if MIGRATION
-            popupRoot.AddHandler(UIElement.MouseLeftButtonDownEvent, new MouseButtonEventHandler(INTERNAL_PopupsManager.OnClickOnPopupOrWindow), true);
-#else
-            popupRoot.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(INTERNAL_PopupsManager.OnClickOnPopupOrWindow), true);
-#endif
-
-            //--------------------------------------
-            // Remember the PopupRoot for later use:
-            //--------------------------------------
-
-            PopupRootIdentifierToInstance.Add(uniquePopupRootIdentifier, popupRoot);
-
-            return popupRoot;
-        }
-
-        public static void RemovePopupRoot(PopupRoot popupRoot)
-        {
-            string uniquePopupRootIdentifier = popupRoot.INTERNAL_UniqueIndentifier;
-            if (PopupRootIdentifierToInstance.ContainsKey(uniquePopupRootIdentifier))
-            {
-                Window parentWindow = popupRoot.INTERNAL_ParentWindow;
-
-                //--------------------------------------
-                // Stop listening to clicks anywhere in the popup (this was used to close other popups that are not supposed to stay open):
-                //--------------------------------------
-
-#if MIGRATION
-                popupRoot.RemoveHandler(UIElement.MouseLeftButtonDownEvent, new MouseButtonEventHandler(INTERNAL_PopupsManager.OnClickOnPopupOrWindow));
-#else
-                popupRoot.RemoveHandler(UIElement.PointerPressedEvent, new PointerEventHandler(INTERNAL_PopupsManager.OnClickOnPopupOrWindow));
-#endif
-
-                //--------------------------------------
-                // Remove from the DOM:
-                //--------------------------------------
-
-                CSHTML5.Interop.ExecuteJavaScriptAsync(
-@"
-var popupRoot = document.getElementByIdSafe($0);
-$1.removeChild(popupRoot);
-", uniquePopupRootIdentifier, parentWindow.INTERNAL_RootDomElement);
-
-                //--------------------------------------
-                // Remove from the list of popups:
-                //--------------------------------------
-
-                PopupRootIdentifierToInstance.Remove(uniquePopupRootIdentifier);
-            }
-            else
-                throw new Exception("No PopupRoot with the following identifier was found: " + uniquePopupRootIdentifier + ". Please contact support.");
+            if (CurrentAutoCloseOpenedPopup != null && clickedElements.Count() == 0)
+                CurrentAutoCloseOpenedPopup.CloseFromAnOutsideClick();
         }
 
         public static IEnumerable GetAllRootUIElements() // IMPORTANT: This is called via reflection from the "Visual Tree Inspector" of the Simulator. If you rename or remove it, be sure to update the Simulator accordingly!
@@ -263,11 +121,11 @@ $1.removeChild(popupRoot);
         public static void EnsurePopupStaysWithinScreenBounds(Popup popup, double forcedWidth = double.NaN, double forcedHeight = double.NaN)
         {
             if (popup.IsOpen
-                && popup.PopupRoot != null
-                && popup.PopupRoot.Content is FrameworkElement)
+                && popup.Child != null
+                )
             {
                 // Determine the size of the popup:
-                FrameworkElement content = (FrameworkElement)popup.PopupRoot.Content;
+                FrameworkElement content = (FrameworkElement)popup.Child;
                 double popupActualWidth = !double.IsNaN(forcedWidth) ? forcedWidth : content.ActualWidth;
                 double popupActualHeight = !double.IsNaN(forcedHeight) ? forcedHeight : content.ActualHeight;
                 if (!double.IsNaN(popupActualWidth)
@@ -276,7 +134,7 @@ $1.removeChild(popupRoot);
                     && popupActualHeight > 0)
                 {
                     Point popupPosition = new Point(0, 0);
-                    if (popup.IsConnectedToLiveTree)
+                    if (!popup._isOrphan)
                     {
                         popupPosition = popup.TransformToVisual(Application.Current.RootVisual).Transform(popupPosition);
                     }
@@ -298,22 +156,22 @@ $1.removeChild(popupRoot);
                     //Arbitrary decision here: If the popup is too big to fit on screen, we align it with the left and the top of the screen (depending on whether it is too wide, too high, or both), and generally give priority to fixing left and top overflow.
                     Point positionFixing = new Point();
                     // Adjust the position of the popup to remain on-screen:
-                    if(totalWidthOverflow > 0 || widthOfLeftOverflow > 0)
+                    if (totalWidthOverflow > 0 || widthOfLeftOverflow > 0)
                     {
                         //align to the left:
                         positionFixing.X = widthOfLeftOverflow;
                     }
                     else if (widthOfRightOverflow > 0)
                     {
-                        positionFixing.X = - widthOfRightOverflow;
+                        positionFixing.X = -widthOfRightOverflow;
                     }
-                    if(totalHeightOverflow > 0 || heightOfTopOverflow > 0)
+                    if (totalHeightOverflow > 0 || heightOfTopOverflow > 0)
                     {
                         positionFixing.Y = heightOfTopOverflow;
                     }
                     else if (heightOfBottomOverflow > 0)
                     {
-                        positionFixing.Y = - heightOfBottomOverflow; //todo: same as for HorizontalOffset.
+                        positionFixing.Y = -heightOfBottomOverflow; //todo: same as for HorizontalOffset.
                     }
 
                     popup.PositionFixing = positionFixing;

--- a/src/Runtime/Runtime/Core/Rendering/INTERNAL_VisualTreeManager.cs
+++ b/src/Runtime/Runtime/Core/Rendering/INTERNAL_VisualTreeManager.cs
@@ -780,7 +780,7 @@ if(nextSibling != undefined) {
 
         public static bool IsElementInVisualTree(UIElement child)
         {
-            return (child.IsConnectedToLiveTree || child is Window || child is PopupRoot); //todo: replace "INTERNAL_VisualParent" with a check of the "_isLoaded" property? (it may work better with bindings, see for example the issue on March 22, where a "Binding" on ListBox.ItemsSource caused the selection to not work properly: it was fixed with a workaround to avoid possible regressions)
+            return (child.IsConnectedToLiveTree || child is Window || child is Popup); //todo: replace "INTERNAL_VisualParent" with a check of the "_isLoaded" property? (it may work better with bindings, see for example the issue on March 22, where a "Binding" on ListBox.ItemsSource caused the selection to not work properly: it was fixed with a workaround to avoid possible regressions)
         }
 
         static void RenderElementsAndRaiseChangedEventOnAllDependencyProperties(DependencyObject dependencyObject)

--- a/src/Runtime/Runtime/Core/Rendering/INTERNAL_VisualTreeManager.cs
+++ b/src/Runtime/Runtime/Core/Rendering/INTERNAL_VisualTreeManager.cs
@@ -317,7 +317,6 @@ if(nextSibling != undefined) {
             }
         }
 
-
         public static void AttachVisualChildIfNotAlreadyAttached(UIElement child, UIElement parent, int index = -1)
         {
             // Modify the visual tree only if the parent element is itself in the visual tree:
@@ -556,7 +555,9 @@ if(nextSibling != undefined) {
             child.IsConnectedToLiveTree = true;
 
             // Set the "ParentWindow" property so that the element knows where to display popups:
-            child.INTERNAL_ParentWindow = parent.INTERNAL_ParentWindow;
+            // I don't like it but the check for popup is specific to an orphan popup that has a Window parent that has a null ParentWindow
+            if (!(child is Popup && (child as Popup)._isOrphan))
+                child.INTERNAL_ParentWindow = parent.INTERNAL_ParentWindow;
 
             // Create and append the DOM structure of the Child:
             object domElementWhereToPlaceGrandChildren = null;

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
@@ -20,7 +20,7 @@ using CSHTML5.Internal;
 using DotNetForHtml5.Core;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using CSHTML5;
+
 
 #if MIGRATION
 using System.Windows.Media;

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
@@ -206,6 +206,15 @@ namespace Windows.UI.Xaml.Controls.Primitives
             var newContent = (UIElement)e.NewValue;
             var oldContent = (UIElement)e.OldValue;
 
+            if (oldContent != null)
+            {
+                popup.RemoveLogicalChild(oldContent);
+            }
+            if (newContent != null)
+            {
+                popup.AddLogicalChild(newContent);
+            }
+
             // Create a surrounding wrapper to enable positioning and alignment: //add once and keep empty until popup opened
             if (popup._childWrapper == null)
             {

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
@@ -853,7 +853,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
             INTERNAL_OuterDomElement = INTERNAL_InnerDomElement = popupDiv;
 
-            INTERNAL_PopupsManager.TrackOrphanPopup(uniquePopupId, this);
+            INTERNAL_PopupsManager.OrphanPopups.Add(this);
         }
     }
 }

--- a/src/Runtime/Runtime/System.Windows.Controls/Validation.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Validation.cs
@@ -347,21 +347,22 @@ namespace Windows.UI.Xaml.Controls
             }
         }
 
-        private static void Popup_PopupMoved(object sender, EventArgs e)
-        {
-            Popup popup = (Popup)sender;
-            PopupRoot popupRoot = popup.PopupRoot;
+        //ams->
+        //private static void Popup_PopupMoved(object sender, EventArgs e)
+        //{
+        //    Popup popup = (Popup)sender;
+        //    PopupRoot popupRoot = popup.PopupRoot;
 
-            // Hide the popup if the parent element is not visible (for example, if the 
-            // user scrolls and the TextBox becomes hidden under another control, cf. ZenDesk #628):
-            if (popup.PlacementTarget is FrameworkElement && popupRoot != null)
-            {
-                bool isParentVisible = INTERNAL_PopupsManager.IsPopupParentVisibleOnScreen(popup);
+        //    // Hide the popup if the parent element is not visible (for example, if the 
+        //    // user scrolls and the TextBox becomes hidden under another control, cf. ZenDesk #628):
+        //    if (popup.PlacementTarget is FrameworkElement && popupRoot != null)
+        //    {
+        //        bool isParentVisible = INTERNAL_PopupsManager.IsPopupParentVisibleOnScreen(popup);
 
-                popupRoot.Visibility = (isParentVisible ? Visibility.Visible : Visibility.Collapsed);
+        //        popupRoot.Visibility = (isParentVisible ? Visibility.Visible : Visibility.Collapsed);
 
-            }
-        }
+        //    }
+        //}
 
 
 

--- a/src/Runtime/Runtime/System.Windows.Controls/Validation.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Validation.cs
@@ -347,25 +347,20 @@ namespace Windows.UI.Xaml.Controls
             }
         }
 
-        //ams->
-        //private static void Popup_PopupMoved(object sender, EventArgs e)
-        //{
-        //    Popup popup = (Popup)sender;
-        //    PopupRoot popupRoot = popup.PopupRoot;
+        private static void Popup_PopupMoved(object sender, EventArgs e)
+        {
+            Popup popup = (Popup)sender;
 
-        //    // Hide the popup if the parent element is not visible (for example, if the 
-        //    // user scrolls and the TextBox becomes hidden under another control, cf. ZenDesk #628):
-        //    if (popup.PlacementTarget is FrameworkElement && popupRoot != null)
-        //    {
-        //        bool isParentVisible = INTERNAL_PopupsManager.IsPopupParentVisibleOnScreen(popup);
+            // Hide the popup if the parent element is not visible (for example, if the 
+            // user scrolls and the TextBox becomes hidden under another control, cf. ZenDesk #628):
+            if (popup.PlacementTarget is FrameworkElement && popup.Child != null)
+            {
+                bool isParentVisible = INTERNAL_PopupsManager.IsPopupParentVisibleOnScreen(popup);
 
-        //        popupRoot.Visibility = (isParentVisible ? Visibility.Visible : Visibility.Collapsed);
+                popup.IsOpen = isParentVisible;
 
-        //    }
-        //}
-
-
-
+            }
+        }
 
         #region to be implemented
 

--- a/src/Runtime/Runtime/System.Windows/Application.cs
+++ b/src/Runtime/Runtime/System.Windows/Application.cs
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml
 
                 // Listen to clicks anywhere in the window (this is used to close the popups that are not supposed to stay open):
 #if MIGRATION
-                _mainWindow.AddHandler(UIElement.MouseLeftButtonDownEvent, new MouseButtonEventHandler(INTERNAL_PopupsManager.OnClickOnWindow), true);
+                _mainWindow.AddHandler(UIElement.MouseLeftButtonDownEvent, new MouseButtonEventHandler(INTERNAL_PopupsManager.OnClickOnPopupOrWindow), true);
 #else
                 _mainWindow.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(INTERNAL_PopupsManager.OnClickOnWindow), true);
 #endif

--- a/src/Runtime/Runtime/System.Windows/Application.cs
+++ b/src/Runtime/Runtime/System.Windows/Application.cs
@@ -131,7 +131,7 @@ namespace Windows.UI.Xaml
 #if MIGRATION
                 _mainWindow.AddHandler(UIElement.MouseLeftButtonDownEvent, new MouseButtonEventHandler(INTERNAL_PopupsManager.OnClickOnPopupOrWindow), true);
 #else
-                _mainWindow.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(INTERNAL_PopupsManager.OnClickOnWindow), true);
+                _mainWindow.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(INTERNAL_PopupsManager.OnClickOnPopupOrWindow), true);
 #endif
 
 #if !CSHTML5NETSTANDARD

--- a/src/Runtime/Runtime/System.Windows/Application.cs
+++ b/src/Runtime/Runtime/System.Windows/Application.cs
@@ -129,9 +129,9 @@ namespace Windows.UI.Xaml
 
                 // Listen to clicks anywhere in the window (this is used to close the popups that are not supposed to stay open):
 #if MIGRATION
-                _mainWindow.AddHandler(UIElement.MouseLeftButtonDownEvent, new MouseButtonEventHandler(INTERNAL_PopupsManager.OnClickOnPopupOrWindow), true);
+                _mainWindow.AddHandler(UIElement.MouseLeftButtonDownEvent, new MouseButtonEventHandler(INTERNAL_PopupsManager.OnClickOnWindow), true);
 #else
-                _mainWindow.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(INTERNAL_PopupsManager.OnClickOnPopupOrWindow), true);
+                _mainWindow.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(INTERNAL_PopupsManager.OnClickOnWindow), true);
 #endif
 
 #if !CSHTML5NETSTANDARD


### PR DESCRIPTION
new implementation for the Popup which excludes PopupRoot entirely (class itself needs be removed)
Popup now acts itself a a content control for it's child, so child placed in it's logical place in the tree
and using a movable div that's defined with position 'fixed'