### PR TITLE
Define 'unsupported' constant

### DIFF
--- a/src/Runtime/Runtime/Runtime.OpenSilver.csproj
+++ b/src/Runtime/Runtime/Runtime.OpenSilver.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">
-		<DefineConstants>TRACE;CSHTML5BLAZOR;CSHTML5NETSTANDARD;MIGRATION;OPENSILVER;GD_WIP</DefineConstants>
+		<DefineConstants>TRACE;CSHTML5BLAZOR;CSHTML5NETSTANDARD;MIGRATION;OPENSILVER;GD_WIP;unsupported</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' ">

--- a/src/Runtime/Runtime/Runtime.OpenSilver.csproj
+++ b/src/Runtime/Runtime/Runtime.OpenSilver.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'SL|AnyCPU' ">
-		<DefineConstants>TRACE;CSHTML5BLAZOR;CSHTML5NETSTANDARD;MIGRATION;OPENSILVER;GD_WIP;unsupported</DefineConstants>
+		<DefineConstants>TRACE;CSHTML5BLAZOR;CSHTML5NETSTANDARD;MIGRATION;OPENSILVER;GD_WIP</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'UWP|AnyCPU' ">

--- a/src/Runtime/Runtime/System.Windows.Controls/DragDropEffects.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/DragDropEffects.cs
@@ -28,7 +28,6 @@ namespace System.Windows
     [Flags]
     public enum DragDropEffects
     {
-#if unsupported
         /// <summary>
         /// Scrolling is about to start or is currently occurring in the drop target.
         /// </summary>
@@ -39,12 +38,12 @@ namespace System.Windows
         /// target.
         /// </summary>
         All = -2147483645,
-#endif
+
         /// <summary>
         /// The drop target does not accept the data.
         /// </summary>
         None = 0,
-#if unsupported
+
         /// <summary>
         /// The data is copied to the drop target.
         /// </summary>
@@ -59,6 +58,5 @@ namespace System.Windows
         /// The data from the drag source is linked to the drop target.
         /// </summary>
         Link = 4,
-#endif
     }
 }

--- a/src/Runtime/Runtime/System.Windows.Controls/DragDropKeyStates.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/DragDropKeyStates.cs
@@ -13,7 +13,6 @@
 \*====================================================================================*/
 
 
-#if unsupported
 using System;
 
 #if MIGRATION
@@ -65,4 +64,3 @@ namespace System.Windows
         AltKey = 32,
     }
 }
-#endif

--- a/src/Runtime/Runtime/System.Windows.Controls/DragDropTarget_2.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/DragDropTarget_2.cs
@@ -100,11 +100,7 @@ namespace Windows.UI.Xaml.Controls
                 "AllowedSourceEffects",
                 typeof(DragDropEffects),
                 typeof(DragDropTarget<TItemsControlType, TItemContainerType>),
-#if unsupported
                 new PropertyMetadata(DragDropEffects.Link | DragDropEffects.Move | DragDropEffects.Scroll));
-#else
-                new PropertyMetadata(DragDropEffects.None));
-#endif
         #endregion public DragDropEffects AllowedSourceEffects
 
 

--- a/src/Runtime/Runtime/System.Windows.Controls/DragEventArgs.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/DragEventArgs.cs
@@ -106,12 +106,10 @@ namespace System.Windows
         }
 #endif
 
-#if unsupported
         /// <summary>
         /// Gets a member of the System.Windows.DragDropEffects enumeration that specifies
         /// which operations are allowed by the originator of the drag event.
         /// </summary>
         public DragDropEffects AllowedEffects { get; internal set; }
-#endif
     }
 }

--- a/src/Runtime/Runtime/System.Windows.Controls/ItemDragEventArgs.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ItemDragEventArgs.cs
@@ -71,7 +71,6 @@ namespace Windows.UI.Xaml.Controls
         /// </summary>
         public bool Cancel { get; set; }
 
-#if unsupported
         /// <summary>
         /// Gets a value indicating whether removing data
         /// from the source is handled by the target.
@@ -147,6 +146,5 @@ namespace Windows.UI.Xaml.Controls
             this.RemoveDataFromDragSourceAction = args.RemoveDataFromDragSourceAction;
             this.DataRemovedFromDragSource = args.DataRemovedFromDragSource;
         }
-#endif
     }
 }


### PR DESCRIPTION
I need to use package with 'unsupported' constant to successfully compile a project. For example to use all values from DragDropEffects enum.

Anyway what is the purpose of this constant? 