### PR TITLE
Fix: raise LayoutUpdated event when a ChildWindow opens or closes

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/ChildWindow.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ChildWindow.cs
@@ -857,6 +857,8 @@ namespace Windows.UI.Xaml.Controls
                     {
                         Application.Current.RootVisual.GotFocus -= new RoutedEventHandler(this.RootVisual_GotFocus);
                     }
+
+                    this.OnLayoutUpdated();
                 }
             }
             else
@@ -1305,6 +1307,7 @@ namespace Windows.UI.Xaml.Controls
                 this.Focus();
             }
 #endif
+            this.OnLayoutUpdated();
         }
 
 #if SILVERLIGHT


### PR DESCRIPTION
Fixes #437.

Silverlight raises the FrameworkElevent.LayoutUpdated event anytime a ChildWindow opens or closes so I did the same by calling protected method OnLayoutUpdated from FrameworkElement which is used to fire that event from any class inheriting from FrameworkElement.