### PR TITLE
Clear text for datepicker when the value is not a date

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/DatePicker.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/DatePicker.cs
@@ -404,6 +404,7 @@ namespace Windows.UI.Xaml.Controls
                     }
                     else
                     {
+                        _textBox.Text = string.Empty;
                         SetWaterMarkText();
                         return null;
                     }


### PR DESCRIPTION
Clearing datepicker when the value is not a date doesn't clear the textbox 

example :
xaml : 
        <DatePicker x:Name="datepicker" />
        <Button Grid.Row="1" Content="Clear" Click="Button_Click" />
c#:
     private void Button_Click(object sender, RoutedEventArgs e)
        {
            datepicker.SelectedDate = null;
        }