### PR TITLE
fix: handle JsonElement parameters for callbacks

### DIFF
--- a/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_InteropImplementation.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_InteropImplementation.cs
@@ -50,7 +50,7 @@ namespace CSHTML5
 #if BRIDGE
         [Bridge.Template("null")]
 #endif
-        internal static object ExecuteJavaScript_SimulatorImplementation(string javascript, bool runAsynchronously, bool noImpactOnPendingJSCode = false, params object[] variables)
+        internal static INTERNAL_JSObjectReference ExecuteJavaScript_SimulatorImplementation(string javascript, bool runAsynchronously, bool noImpactOnPendingJSCode = false, params object[] variables)
         {
             //---------------
             // Due to the fact that it is not possible to pass JavaScript objects between the simulator JavaScript context
@@ -210,20 +210,14 @@ namespace CSHTML5
             object value = null;
             if (!runAsynchronously)
             {
-                value = CastFromJsValue(INTERNAL_HtmlDomManager.ExecuteJavaScriptWithResult(javascript, noImpactOnPendingJSCode: noImpactOnPendingJSCode));
+                value = INTERNAL_HtmlDomManager.ExecuteJavaScriptWithResult(javascript, noImpactOnPendingJSCode: noImpactOnPendingJSCode);
             }
             else
             {
                 INTERNAL_HtmlDomManager.ExecuteJavaScript(javascript);
             }
 
-            var objectReference = new INTERNAL_JSObjectReference()
-            {
-                Value = value,
-                ReferenceId = referenceId.ToString()
-            };
-
-            return objectReference;
+            return new INTERNAL_JSObjectReference(value, referenceId.ToString());
         }
 
         internal static void ResetLoadedFilesDictionaries()
@@ -255,54 +249,6 @@ namespace CSHTML5
 {1}
 ", str, errorMessage);
                 Console.WriteLine(message);
-            }
-        }
-
-#if BRIDGE
-        [Bridge.Template("null")]
-#endif
-        internal static object CastFromJsValue(object obj)
-        {
-#if OPENSILVER
-            if (!Interop.IsRunningInTheSimulator_WorkAround)
-            {
-                if (obj != null && (obj is string || obj.GetType().IsPrimitive))
-                {
-                    return obj;
-                }
-
-                JsonElement jsonElement = (JsonElement)obj;
-                object res;
-                switch (jsonElement.ValueKind)
-                {
-                    case JsonValueKind.Object:
-                    case JsonValueKind.Array:
-                        res = obj;
-                        break;
-                    case JsonValueKind.String:
-                        res = jsonElement.GetString();
-                        break;
-                    case JsonValueKind.Number:
-                        res = jsonElement.GetSingle();
-                        break;
-                    case JsonValueKind.True:
-                    case JsonValueKind.False:
-                        res = jsonElement.GetBoolean();
-                        break;
-                    case JsonValueKind.Undefined:
-                    case JsonValueKind.Null:
-                        res = null;
-                        break;
-                    default:
-                        res = null;
-                        break;
-                }
-                return res;
-            }
-            else
-#endif
-            {
-                return DotNetForHtml5.Core.INTERNAL_Simulator.ConvertBrowserResult(obj);
             }
         }
 

--- a/src/Runtime/Runtime/PublicAPI/Interop/OnCallBack.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/OnCallBack.cs
@@ -275,13 +275,7 @@ namespace CSHTML5.Internal
 
             for (int i = 0; i < count; i++)
             {
-                var arg = new INTERNAL_JSObjectReference()
-                {
-                    ReferenceId = idWhereCallbackArgsAreStored,
-                    IsArray = true,
-                    ArrayIndex = i,
-                    Value = callbackArgs
-                };
+                var arg = new INTERNAL_JSObjectReference(callbackArgs, idWhereCallbackArgsAreStored, i);
                 if (callbackGenericArgs != null
                     && i < callbackGenericArgs.Length
                     && callbackGenericArgs[i] != typeof(object)
@@ -337,13 +331,7 @@ namespace CSHTML5.Internal
 
             for (int i = 0; i < count; i++)
             {
-                var arg = new INTERNAL_JSObjectReference()
-                {
-                    ReferenceId = idWhereCallbackArgsAreStored,
-                    IsArray = true,
-                    ArrayIndex = i,
-                    Value = callbackArgs
-                };
+                var arg = new INTERNAL_JSObjectReference(callbackArgs, idWhereCallbackArgsAreStored, i);
                 if (callbackGenericArgs != null
                     && i < callbackGenericArgs.Length
                     && callbackGenericArgs[i] != typeof(object)
@@ -442,13 +430,7 @@ namespace CSHTML5.Internal
 
             for (int i = 0; i < count; i++)
             {
-                var arg = new INTERNAL_JSObjectReference()
-                {
-                    ReferenceId = idWhereCallbackArgsAreStored,
-                    IsArray = true,
-                    ArrayIndex = i,
-                    Value = callbackArgs
-                };
+                var arg = new INTERNAL_JSObjectReference(callbackArgs, idWhereCallbackArgsAreStored, i);
                 if (callbackGenericArgs != null
                     && i < callbackGenericArgs.Length
                     && callbackGenericArgs[i] != typeof(object)

--- a/src/Runtime/Runtime/Runtime.CSHTML5.csproj
+++ b/src/Runtime/Runtime/Runtime.CSHTML5.csproj
@@ -208,6 +208,7 @@
     <Compile Include="System.Windows.Interop\NavigationStateChangedEventArgs.cs" />
     <Compile Include="System.Windows.Markup\WORKINPROGRESS\XmlLanguage.cs" />
     <Compile Include="System.Windows.Media.Animation\BeginStoryboard.cs" />
+    <Compile Include="System.Windows.Media.Animation\ColorAnimationUsingKeyFrames.cs" />
     <Compile Include="System.Windows.Media\ImageSourceConverter.cs" />
     <Compile Include="System.Windows.Media\PointCollectionConverter.cs" />
     <Compile Include="System.Windows.Media\TransformConverter.cs" />
@@ -871,7 +872,6 @@
     <Compile Include="System.Windows.Media.Animation\AnimationTimeline.cs" />
     <Compile Include="System.Windows.Media.Animation\WORKINPROGRESS\BackEase.cs" />
     <Compile Include="System.Windows.Media.Animation\WORKINPROGRESS\ClockState.cs" />
-    <Compile Include="System.Windows.Media.Animation\WORKINPROGRESS\ColorAnimationUsingKeyFrames.cs" />
     <Compile Include="System.Windows.Media.Animation\WORKINPROGRESS\ColorKeyFrame.cs" />
     <Compile Include="System.Windows.Media.Animation\WORKINPROGRESS\ColorKeyFrameCollection.cs" />
     <Compile Include="System.Windows.Media.Animation\DoubleAnimationUsingKeyFrames.cs" />

--- a/src/Runtime/Runtime/System.Windows.Controls/Grid_InternalHelpers.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Grid_InternalHelpers.cs
@@ -43,7 +43,7 @@ namespace Windows.UI.Xaml.Controls
         {
             if (!_isGridSupported.HasValue)
             {
-                _isGridSupported = (bool)((CSHTML5.Types.INTERNAL_JSObjectReference)(CSHTML5.Interop.ExecuteJavaScript("document.isGridSupported"))).Value;
+                _isGridSupported = Convert.ToBoolean(CSHTML5.Interop.ExecuteJavaScript("document.isGridSupported"));
             }
             return _isGridSupported.Value;
         }
@@ -55,7 +55,7 @@ namespace Windows.UI.Xaml.Controls
         {
             if (!_isMSGrid.HasValue)
             {
-                _isMSGrid = (bool)((CSHTML5.Types.INTERNAL_JSObjectReference)(CSHTML5.Interop.ExecuteJavaScript("document.isMSGrid"))).Value;
+                _isMSGrid = Convert.ToBoolean(CSHTML5.Interop.ExecuteJavaScript("document.isMSGrid"));
             }
             return _isMSGrid.Value;
         }

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
@@ -986,7 +986,7 @@ var range,selection;
 #endif
         private static int CastToInt(object value)
         {
-            return Convert.ToInt32(((CSHTML5.Types.INTERNAL_JSObjectReference)value).Value);
+            return Convert.ToInt32(value);
         }
 
 #if BRIDGE

--- a/src/Simulator/Simulator/MainWindow.xaml.cs
+++ b/src/Simulator/Simulator/MainWindow.xaml.cs
@@ -47,6 +47,8 @@ using DotNetForHtml5.EmulatorWithoutJavascript.Console;
 using System.Windows.Media.Imaging;
 #if OPENSILVER
 using OpenSilver.Simulator;
+#else
+using CSHTML5.Simulator;
 #endif
 namespace DotNetForHtml5.EmulatorWithoutJavascript
 {

--- a/src/Tests/Runtime.OpenSilver.Tests/CSHTML5.Types/INTERNAL_JSObjectReferenceTest.cs
+++ b/src/Tests/Runtime.OpenSilver.Tests/CSHTML5.Types/INTERNAL_JSObjectReferenceTest.cs
@@ -1,0 +1,91 @@
+﻿using CSHTML5.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Globalization;
+using System.Text.Json;
+
+namespace Runtime.OpenSilver.Tests.CSHTML5.Types
+{
+    [TestClass]
+    public class INTERNAL_JSObjectReferenceTest
+    {
+        private static readonly JsonElement TrueJsonElement = JsonDocument.Parse("true").RootElement;
+
+        private static readonly JsonElement StrJsonElement = JsonDocument.Parse(@"""string""").RootElement;
+
+        private static readonly JsonElement IntegerNumberJsonElement = JsonDocument.Parse("7").RootElement;
+
+        private static readonly JsonElement RealNumberJsonElement = JsonDocument.Parse("7.77").RootElement;
+
+        private static readonly JsonElement NullJsonElement = JsonDocument.Parse("null").RootElement;
+
+        private static readonly JsonElement UndefinedJsonElement = default;
+
+        private const double Delta = 0.0001;
+
+        [TestMethod]
+        public void ConvertToBool()
+        {
+            var objRef = new INTERNAL_JSObjectReference(TrueJsonElement);
+            Assert.IsTrue((bool)objRef);
+            Assert.IsTrue(Convert.ToBoolean(objRef));
+        }
+
+        [TestMethod]
+        public void ConvertToString()
+        {
+            var objRef = new INTERNAL_JSObjectReference(StrJsonElement);
+            Assert.AreEqual(StrJsonElement.GetString(), (string)objRef);
+            Assert.AreEqual(StrJsonElement.GetString(), Convert.ToString(objRef, CultureInfo.InvariantCulture));
+            Assert.AreEqual(StrJsonElement.GetString(), objRef.ToString(CultureInfo.InvariantCulture));
+        }
+
+        [TestMethod]
+        public void ConvertToIntegerNumber()
+        {
+            var objRef = new INTERNAL_JSObjectReference(IntegerNumberJsonElement);
+            Assert.AreEqual(IntegerNumberJsonElement.GetByte(), (byte)objRef);
+            Assert.AreEqual(IntegerNumberJsonElement.GetByte(), Convert.ToByte(objRef));
+            Assert.AreEqual(IntegerNumberJsonElement.GetSByte(), (sbyte)objRef);
+            Assert.AreEqual(IntegerNumberJsonElement.GetSByte(), Convert.ToSByte(objRef));
+            Assert.AreEqual(IntegerNumberJsonElement.GetDecimal(), (decimal)objRef);
+            Assert.AreEqual(IntegerNumberJsonElement.GetDecimal(), Convert.ToDecimal(objRef));
+            Assert.AreEqual(IntegerNumberJsonElement.GetInt16(), (short)objRef);
+            Assert.AreEqual(IntegerNumberJsonElement.GetInt16(), Convert.ToInt16(objRef));
+            Assert.AreEqual(IntegerNumberJsonElement.GetInt32(), (int)objRef);
+            Assert.AreEqual(IntegerNumberJsonElement.GetInt32(), Convert.ToInt32(objRef));
+            Assert.AreEqual(IntegerNumberJsonElement.GetInt64(), (long)objRef);
+            Assert.AreEqual(IntegerNumberJsonElement.GetInt64(), Convert.ToInt64(objRef));
+            Assert.AreEqual(IntegerNumberJsonElement.GetUInt16(), (ushort)objRef);
+            Assert.AreEqual(IntegerNumberJsonElement.GetUInt16(), Convert.ToUInt16(objRef));
+            Assert.AreEqual(IntegerNumberJsonElement.GetUInt32(), (uint)objRef);
+            Assert.AreEqual(IntegerNumberJsonElement.GetUInt32(), Convert.ToUInt32(objRef));
+            Assert.AreEqual(IntegerNumberJsonElement.GetUInt64(), (ulong)objRef);
+            Assert.AreEqual(IntegerNumberJsonElement.GetUInt64(), Convert.ToUInt64(objRef));
+        }
+
+        [TestMethod]
+        public void ConvertToRealNumber()
+        {
+            var objRef = new INTERNAL_JSObjectReference(RealNumberJsonElement);
+            Assert.AreEqual(RealNumberJsonElement.GetDouble(), (double)objRef, Delta);
+            Assert.AreEqual(RealNumberJsonElement.GetDouble(), Convert.ToDouble(objRef), Delta);
+            Assert.AreEqual(RealNumberJsonElement.GetSingle(), (float)objRef, Delta);
+            Assert.AreEqual(RealNumberJsonElement.GetSingle(), Convert.ToSingle(objRef), Delta);
+        }
+
+        [TestMethod]
+        public void IsUndefined()
+        {
+            var objRef = new INTERNAL_JSObjectReference(UndefinedJsonElement);
+            Assert.IsTrue(objRef.IsUndefined());
+        }
+
+        [TestMethod]
+        public void IsNull()
+        {
+            var objRef = new INTERNAL_JSObjectReference(NullJsonElement);
+            Assert.IsTrue(objRef.IsNull());
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes passing parameters to callback. Small example:

```
OpenSilver.Interop.ExecuteJavaScript(
    "setTimeout(function () { $0(true); }, 1)",
    (Action<bool>)(par =>
    {
        Console.WriteLine("PARAMETER - " + par);
    }));
```