### PR TITLE
fix: assemblyName and namespace for openria in xaml (DomainDataSource)

### DIFF
--- a/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GettingInformationAboutAXamlType.cs
+++ b/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GettingInformationAboutAXamlType.cs
@@ -287,7 +287,8 @@ namespace DotNetForHtml5.Compiler
                         assemblyName = "OpenSilver.Expression.Effects";
                         return;
                     case "System.Windows.Controls.DomainServices":
-                        assemblyName = "System.Windows.Controls.DomainServices";
+                        assemblyName = "OpenRiaServices.Controls.DomainServices";
+                        namespaceName = "OpenRiaServices.Controls";
                         return;
                     default:
                         if (assemblyName == "System" || assemblyName.StartsWith("System."))

--- a/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GettingInformationAboutAXamlType.cs
+++ b/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GettingInformationAboutAXamlType.cs
@@ -286,6 +286,9 @@ namespace DotNetForHtml5.Compiler
                     case "Microsoft.Expression.Effects":
                         assemblyName = "OpenSilver.Expression.Effects";
                         return;
+                    case "System.Windows.Controls.DomainServices":
+                        assemblyName = "System.Windows.Controls.DomainServices";
+                        return;
                     default:
                         if (assemblyName == "System" || assemblyName.StartsWith("System."))
                         {


### PR DESCRIPTION
DomainDataSource type in System.Windows.Controls.DomainServices
was being expected in the OpenSilver.dll