### PR TITLE
fix: handle FrameworkElement alignment edge case

### DIFF
--- a/src/Runtime/Runtime/Core/Rendering/INTERNAL_VisualTreeManager.cs
+++ b/src/Runtime/Runtime/Core/Rendering/INTERNAL_VisualTreeManager.cs
@@ -23,8 +23,10 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Media;
 #else
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Documents;
@@ -519,14 +521,18 @@ if(nextSibling != undefined) {
                 var style = INTERNAL_HtmlDomManager.GetDomElementStyleForModification(additionalOutsideDivForMargins);
                 style.boxSizing = "border-box";
                 if (child is FrameworkElement &&
-                    (((FrameworkElement)child).HorizontalAlignment == HorizontalAlignment.Stretch && double.IsNaN(((FrameworkElement)child).Width)))
+                    (((FrameworkElement)child).HorizontalAlignment == HorizontalAlignment.Stretch && double.IsNaN(((FrameworkElement)child).Width)
+                    && !(child is Image && ((Image)child).Stretch == Stretch.None)))
                 {
                     if (!containsNegativeMargins)
                         style.width = "100%";
                 }
                 if (child is FrameworkElement &&
-                    (((FrameworkElement)child).VerticalAlignment == VerticalAlignment.Stretch && double.IsNaN(((FrameworkElement)child).Height)))
+                    (((FrameworkElement)child).VerticalAlignment == VerticalAlignment.Stretch && double.IsNaN(((FrameworkElement)child).Height)
+                    && !(child is Image && ((Image)child).Stretch == Stretch.None)))
+                {
                     style.height = "100%";
+                } 
             }
 
 #if PERFSTAT

--- a/src/Runtime/Runtime/System.Windows/FrameworkElement_HandlingSizeAndAlignment.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement_HandlingSizeAndAlignment.cs
@@ -415,9 +415,13 @@ namespace Windows.UI.Xaml
                         return;
                     }
 
-                    // If a size in pixels is specified AND the alignment is "Stretch", the behavior is similar to "Center":
-                    if (newHorizontalAlignment == HorizontalAlignment.Stretch && !double.IsNaN(fe.Width))
+                    // If the alignment is "Stretch" AND a size in pixels is specified, the behavior is similar to "Center".
+                    // Also, if the alignment is "Stretch" AND the element is an Image with Stretch = None this same case applies since it has a fixed size too:
+                    if (newHorizontalAlignment == HorizontalAlignment.Stretch
+                        && (!double.IsNaN(fe.Width) || (fe is Image && ((Image)fe).Stretch == Media.Stretch.None)))
+                    {
                         newHorizontalAlignment = HorizontalAlignment.Center;
+                    }
 
                     //If the element is an Image and it has Stretch = Uniform and no size, the behavior is similar to "Stretch":
                     if (fe is Image
@@ -809,9 +813,13 @@ namespace Windows.UI.Xaml
                     }
 
 
-                    // If a size in pixels is specified AND the alignment is "Stretch", the behavior is similar to "Center":
-                    if (newVerticalAlignment == VerticalAlignment.Stretch && !double.IsNaN(fe.Height))
+                    // If the alignment is "Stretch" AND a size in pixels is specified, the behavior is similar to "Center".
+                    // Also, if the alignment is "Stretch" AND the element is an Image with Stretch = None this same case applies since it has a fixed size too:
+                    if (newVerticalAlignment == VerticalAlignment.Stretch
+                        && (!double.IsNaN(fe.Height) || (fe is Image && ((Image)fe).Stretch == Media.Stretch.None)))
+                    {
                         newVerticalAlignment = VerticalAlignment.Center;
+                    }
 
                     //If the element is an Image and it has Stretch = Uniform and no size, the behavior is similar to "Stretch":
                     if (fe is Image


### PR DESCRIPTION
Handled the following special case when applying horizontal & vertical alignment to a FrameworkElement:

If Alignment = "Stretch" AND the element is an Image with Stretch = None, then the element has a fixed size (even if width and height are set to auto) and it should be handled as such so that it appears centered as it does in SilverLight, and not in the top left as it did in OpenSilver before the fix.