### PR TITLE
Implement CheckAccess() for simulator

### DIFF
--- a/src/Runtime/Runtime/Core/Main/INTERNAL_Simulator.cs
+++ b/src/Runtime/Runtime/Core/Main/INTERNAL_Simulator.cs
@@ -72,6 +72,11 @@ namespace DotNetForHtml5.Core
             internal get;
         }
 
+        /// <summary>
+        /// CheckAccess() of WebControl's Dispatcher.
+        /// </summary>
+        public static Func<bool> WebControlDispatcherCheckAccess { get; internal set; }
+
 #if CSHTML5NETSTANDARD
         public static IJavaScriptExecutionHandler JavaScriptExecutionHandler
         {

--- a/src/Runtime/Runtime/System.Windows.Threading/CoreDispatcher.cs
+++ b/src/Runtime/Runtime/System.Windows.Threading/CoreDispatcher.cs
@@ -265,10 +265,9 @@ namespace Windows.UI.Core
             return null;
         }
 
-		[OpenSilver.NotImplemented]
         public bool CheckAccess()
         {
-            return true;
+            return INTERNAL_Simulator.IsRunningInTheSimulator_WorkAround ? INTERNAL_Simulator.WebControlDispatcherCheckAccess() : true;
         }
     }
 }

--- a/src/Simulator/Simulator/Interop/InteropHelpers.cs
+++ b/src/Simulator/Simulator/Interop/InteropHelpers.cs
@@ -53,6 +53,11 @@ namespace DotNetForHtml5.EmulatorWithoutJavascript
             InjectPropertyValue("WebControlDispatcherInvoke", new Action<Action, TimeSpan>((method, timeout) => webControl.Dispatcher.Invoke(method, timeout)), coreAssembly);
         }
 
+        internal static void InjectWebControlDispatcherCheckAccess(WPFBrowserView webControl, Assembly coreAssembly)
+        {
+            InjectPropertyValue("WebControlDispatcherCheckAccess", new Func<bool>(() => webControl.Dispatcher.CheckAccess()), coreAssembly);
+        }
+
         internal static void InjectConvertBrowserResult(Func<object, object> func, Assembly coreAssembly)
         {
             InjectPropertyValue("ConvertBrowserResult", func, coreAssembly);

--- a/src/Simulator/Simulator/MainWindow.xaml.cs
+++ b/src/Simulator/Simulator/MainWindow.xaml.cs
@@ -1012,6 +1012,7 @@ Click OK to continue.";
                 InteropHelpers.InjectHtmlDocument(htmlDocument, _coreAssembly);//no need for this line right ?
                 InteropHelpers.InjectWebControlDispatcherBeginInvoke(MainWebBrowser, _coreAssembly);
                 InteropHelpers.InjectWebControlDispatcherInvoke(MainWebBrowser, _coreAssembly);
+                InteropHelpers.InjectWebControlDispatcherCheckAccess(MainWebBrowser, _coreAssembly);
                 InteropHelpers.InjectConvertBrowserResult(BrowserResultConverter.CastFromJsValue, _coreAssembly);
                 InteropHelpers.InjectJavaScriptExecutionHandler(_javaScriptExecutionHandler, _coreAssembly);
                 InteropHelpers.InjectWpfMediaElementFactory(_coreAssembly);


### PR DESCRIPTION
Dispatcher.CheckAccess() now returns actual value if run under Simulator.
Setting UI controls from others threads than the main thread, caused javascript errors in simulator.