### PR TITLE
Fix content scrolling if there is default style for text control with VerticalAlignment

### DIFF
--- a/src/Runtime/Runtime/System.Windows/TextMeasurementService.cs
+++ b/src/Runtime/Runtime/System.Windows/TextMeasurementService.cs
@@ -87,7 +87,11 @@ namespace Windows.UI.Xaml
                 INTERNAL_VisualTreeManager.DetachVisualChildIfNotNull(associatedTextBox, parent);
             }
 
-            associatedTextBox = new TextBox { Style = null };
+            associatedTextBox = new TextBox
+            {
+                // Prevent the TextBox from using an implicit style that could mess up the layout
+                Style = null
+            };
             INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(associatedTextBox, parent);
 
             bool hasMarginDiv = false;
@@ -120,7 +124,11 @@ namespace Windows.UI.Xaml
                 INTERNAL_VisualTreeManager.DetachVisualChildIfNotNull(associatedTextBlock, parent);
             }
 
-            associatedTextBlock = new TextBlock { Style = null };
+            associatedTextBlock = new TextBlock
+            {
+                // Prevent the TextBlock from using an implicit style that could mess up the layout
+                Style = null
+            };
             INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(associatedTextBlock, parent);
 
             hasMarginDiv = false;

--- a/src/Runtime/Runtime/System.Windows/TextMeasurementService.cs
+++ b/src/Runtime/Runtime/System.Windows/TextMeasurementService.cs
@@ -87,7 +87,7 @@ namespace Windows.UI.Xaml
                 INTERNAL_VisualTreeManager.DetachVisualChildIfNotNull(associatedTextBox, parent);
             }
 
-            associatedTextBox = new TextBox();
+            associatedTextBox = new TextBox { Style = null };
             INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(associatedTextBox, parent);
 
             bool hasMarginDiv = false;
@@ -120,7 +120,7 @@ namespace Windows.UI.Xaml
                 INTERNAL_VisualTreeManager.DetachVisualChildIfNotNull(associatedTextBlock, parent);
             }
 
-            associatedTextBlock = new TextBlock();
+            associatedTextBlock = new TextBlock { Style = null };
             INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(associatedTextBlock, parent);
 
             hasMarginDiv = false;

--- a/src/Runtime/Runtime/System.Windows/Window.cs
+++ b/src/Runtime/Runtime/System.Windows/Window.cs
@@ -43,6 +43,8 @@ namespace Windows.UI.Xaml
     public partial class Window : FrameworkElement
 #endif
     {
+        private readonly UIElement _textMeasurementElement = new Control();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Window"/> class.
         /// </summary>
@@ -282,7 +284,8 @@ namespace Windows.UI.Xaml
                     }
                 }
 
-                Application.Current.TextMeasurementService.CreateMeasurementText(this);
+                INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(_textMeasurementElement, this);
+                Application.Current.TextMeasurementService.CreateMeasurementText(_textMeasurementElement);
 
                 /*
                 // Invalidate when content changed

--- a/src/Runtime/Runtime/System.Windows/Window.cs
+++ b/src/Runtime/Runtime/System.Windows/Window.cs
@@ -43,8 +43,6 @@ namespace Windows.UI.Xaml
     public partial class Window : FrameworkElement
 #endif
     {
-        private readonly UIElement _textMeasurementElement = new Control();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Window"/> class.
         /// </summary>
@@ -284,8 +282,7 @@ namespace Windows.UI.Xaml
                     }
                 }
 
-                INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(_textMeasurementElement, this);
-                Application.Current.TextMeasurementService.CreateMeasurementText(_textMeasurementElement);
+                Application.Current.TextMeasurementService.CreateMeasurementText(this);
 
                 /*
                 // Invalidate when content changed


### PR DESCRIPTION
Some pages in our project contain a lot of UI controls, so they are placed inside ScrollViewer. But scrolling is not working properly.

The root div of OpenSilver html page contains style with `display:table` property. If remove it, scrolling is working.
This property is set in `FrameworkElement.INTERNAL_ApplyVerticalAlignmentAndHeight()`, because there are hidden TextBlock and TextBox elements inside the main div and we have default styles for these controls with
`<Setter Property="VerticalAlignment" Value="Center" />`
The issue also can be reproduced with value `Bottom`.