### PR TITLE
feat: Simulator support for App with constructor parameters

### DIFF
--- a/src/Simulator/Simulator/MainWindow.xaml.cs
+++ b/src/Simulator/Simulator/MainWindow.xaml.cs
@@ -1148,7 +1148,15 @@ Click OK to continue.";
             // Create a new instance of the application:
             try
             {
-                Activator.CreateInstance(_applicationType);
+                if (_simulatorLaunchParameters?.ConstructorArguments?.Length > 0)
+                {
+                    Activator.CreateInstance(_applicationType, _simulatorLaunchParameters.ConstructorArguments);
+                }
+                else
+                {
+                    Activator.CreateInstance(_applicationType);
+                }
+
                 return true;
             }
             catch (Exception ex)

--- a/src/Simulator/Simulator/SimulatorLaunchParameters.cs
+++ b/src/Simulator/Simulator/SimulatorLaunchParameters.cs
@@ -22,9 +22,13 @@ namespace CSHTML5.Simulator
         public Action AppStartedCallback { get; set; }
 
         /// <summary>
-        /// Sets or gets custom cookies to the simulator
+        /// Gets or sets custom cookies to the simulator
         /// </summary>
-        public  IList<CookieData> CookiesData { get; set; }
-    
+        public IList<CookieData> CookiesData { get; set; }
+
+        /// <summary>
+        /// Gets or sets the argument parameters for the App constructor
+        /// </summary>
+        public object[] ConstructorArguments { get; set; }
     }
 }


### PR DESCRIPTION
This would allow support for App with constructor parameters such as IConfiguration object shown below. Otherwise, we would get the exception "System.MissingMethodException: No parameterless constructor defined for this object".

```
public partial class App : Application {

#if OPENSILVER
        private readonly Microsoft.Extensions.Configuration.IConfiguration configuration;
        public App(Microsoft.Extensions.Configuration.IConfiguration configuration)

#else
        public App()
#endif
        {
```