### PR TITLE
Limit IsAutoWidth/HeightOnCustomLayout to Window boundaries

### DIFF
--- a/src/Runtime/Controls.Input/AutoCompleteBox/PopupHelper.cs
+++ b/src/Runtime/Controls.Input/AutoCompleteBox/PopupHelper.cs
@@ -170,7 +170,8 @@ namespace Windows.UI.Xaml.Controls
             double popupContentWidth = PopupChild.ActualWidth;
             double popupContentHeight = PopupChild.ActualHeight;
 
-            if (rootHeight == 0 || rootWidth == 0 || popupContentWidth == 0 || popupContentHeight == 0)
+            // In CustomLayout, ActualWidth/Height might be 0 because they have not been calculated yet
+            if (rootHeight == 0 || rootWidth == 0 || (!PopupChild.CustomLayout && (popupContentWidth == 0 || popupContentHeight == 0)))
             {
                 return;
             }

--- a/src/Runtime/Controls.Input/Themes/generic.xaml
+++ b/src/Runtime/Controls.Input/Themes/generic.xaml
@@ -187,7 +187,10 @@
                             </Grid>
                         </Border>
                         <Popup x:Name="Popup">
-                            <Grid Opacity="{TemplateBinding Opacity}">
+                            <Grid Opacity="{TemplateBinding Opacity}"
+                                    CustomLayout="{TemplateBinding CustomLayout}"
+                                    IsAutoHeightOnCustomLayout="{TemplateBinding IsAutoHeightOnCustomLayout}"
+                                    IsAutoWidthOnCustomLayout="{TemplateBinding IsAutoWidthOnCustomLayout}">
                                 <Border x:Name="PopupBorder"
                                         HorizontalAlignment="Stretch"
                                         Opacity="0"

--- a/src/Runtime/Runtime/System.Windows/FrameworkElement_HandlingSizeAndAlignment.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement_HandlingSizeAndAlignment.cs
@@ -90,12 +90,34 @@ namespace Windows.UI.Xaml
         /// <summary>
         /// Gets or sets the Auto Width to the root of CustomLayout
         /// </summary>
-        public bool IsAutoWidthOnCustomLayout { get; set; }
+        public bool IsAutoWidthOnCustomLayout
+        {
+            get { return (bool)GetValue(IsAutoWidthOnCustomLayoutProperty); }
+            set { SetValue(IsAutoWidthOnCustomLayoutProperty, value); }
+        }
+
+        public static readonly DependencyProperty IsAutoWidthOnCustomLayoutProperty =
+            DependencyProperty.Register(
+                nameof(IsAutoWidthOnCustomLayout),
+                typeof(bool),
+                typeof(FrameworkElement),
+                new PropertyMetadata(false));
 
         /// <summary>
         /// Gets or sets the Auto Height to the root of CustomLayout
         /// </summary>
-        public bool IsAutoHeightOnCustomLayout { get; set; }
+        public bool IsAutoHeightOnCustomLayout
+        {
+            get { return (bool)GetValue(IsAutoHeightOnCustomLayoutProperty); }
+            set { SetValue(IsAutoHeightOnCustomLayoutProperty, value); }
+        }
+
+        public static readonly DependencyProperty IsAutoHeightOnCustomLayoutProperty =
+            DependencyProperty.Register(
+                nameof(IsAutoHeightOnCustomLayout),
+                typeof(bool),
+                typeof(FrameworkElement),
+                new PropertyMetadata(false));
 
         /// <summary>
         /// Enable or disable measure/arrange layout system in a sub part

--- a/src/Tests/TestApplication/TestApplication/Tests/AutoCompleteBoxTest.xaml
+++ b/src/Tests/TestApplication/TestApplication/Tests/AutoCompleteBoxTest.xaml
@@ -4,31 +4,31 @@
            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
            mc:Ignorable="d"
-           xmlns:sdk="http://schemas.microsoft.com/winfx/2006/xaml/presentation/sdk">
+           xmlns:sdk="http://schemas.microsoft.com/winfx/2006/xaml/presentation/sdk"
+           xmlns:system="clr-namespace:System;assembly=mscorlib">
     <StackPanel Orientation="Vertical">
-        <!--SLDISABLED-->
-        <!--<sdk:AutoCompleteBox x:Name="AutoCompleteBox1" Width="250"/>
-        <Button Content="Items.Add UI element" Click="ButtonTestAutoCompleteBox1_ItemsAddUIElement_Click"/>
-        <Button Content="Items.Add string" Click="ButtonTestAutoCompleteBox1_ItemsAddString_Click"/>
-        <Button Content="Items.Add" Click="ButtonTestAutoCompleteBox1_ItemsAdd_Click"/>
-        <Button Content="Items.Clear" Click="ButtonTestAutoCompleteBox1_ItemsClear_Click"/>
-        <Button Content="Items.Remove First" Click="ButtonTestAutoCompleteBox1_ItemsRemoveFirst_Click"/>
-        <Button Content="Set new ItemsSource" Click="ButtonTestAutoCompleteBox1_SetNewItemsSource_Click"/>
-        <Button Content="ItemsSource.Add" Click="ButtonTestAutoCompleteBox1_ItemsSourceAdd_Click"/>
-        <Button Content="ItemsSource.Clear" Click="ButtonTestAutoCompleteBox1_ItemsSourceClear_Click"/>
-        <Button Content="ItemsSource.Remove first" Click="ButtonTestAutoCompleteBox1_ItemsSourceRemove_Click"/>
-        <Button Content="Set ItemsSource to null" Click="ButtonTestAutoCompleteBox1_SetItemsSourceToNull_Click"/>
-        <Button Content="Select second item" Click="ButtonTestAutoCompleteBox1_SelectSecondItem_Click"/>
-        <Button Content="Select second index" Click="ButtonTestAutoCompleteBox1_SelectSecondIndex_Click"/>
-        <Button Content="SelectedItem=null" Click="ButtonTestAutoCompleteBox1_SelectItemNull_Click"/>
-        <Button Content="SelectedIndex=-1" Click="ButtonTestAutoCompleteBox1_SelectedIndexMinusOne_Click"/>
-        <StackPanel Orientation="Horizontal">
-            <TextBlock Text="SelectedIndex:"/>
-            <TextBlock Margin="5,0,0,0" Text="{Binding ElementName=AutoCompleteBox1, Path=SelectedIndex}"/>
+        <StackPanel Orientation="Vertical">
+            <!--SLDISABLED-->
+            <TextBlock Text="Items are 'Initial item #X', and 'Item #X' if added:"/>
+            <sdk:AutoCompleteBox x:Name="AutoCompleteBox1" Width="250"/>
+            <Button Content="Items.Add" Click="ButtonTestAutoCompleteBox1_ItemsAdd_Click"/>
+            <Button Content="Items.Clear" Click="ButtonTestAutoCompleteBox1_ItemsClear_Click"/>
+            <Button Content="Items.Remove First" Click="ButtonTestAutoCompleteBox1_ItemsRemoveFirst_Click"/>
+            <Button Content="Set new ItemsSource" Click="ButtonTestAutoCompleteBox1_SetNewItemsSource_Click"/>
+            <Button Content="ItemsSource.Add" Click="ButtonTestAutoCompleteBox1_ItemsSourceAdd_Click"/>
+            <Button Content="ItemsSource.Clear" Click="ButtonTestAutoCompleteBox1_ItemsSourceClear_Click"/>
+            <Button Content="ItemsSource.Remove first" Click="ButtonTestAutoCompleteBox1_ItemsSourceRemove_Click"/>
+            <Button Content="Set ItemsSource to null" Click="ButtonTestAutoCompleteBox1_SetItemsSourceToNull_Click"/>
+            <Button Content="Select second item" Click="ButtonTestAutoCompleteBox1_SelectSecondItem_Click"/>
+            <Button Content="SelectedItem=null" Click="ButtonTestAutoCompleteBox1_SelectItemNull_Click"/>
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="SelectedItem:"/>
+                <TextBlock Margin="5,0,0,0" Text="{Binding ElementName=AutoCompleteBox1, Path=SelectedItem}"/>
+            </StackPanel>
         </StackPanel>
-        <StackPanel Orientation="Horizontal">
-            <TextBlock Text="SelectedItem:"/>
-            <TextBlock Margin="5,0,0,0" Text="{Binding ElementName=AutoCompleteBox1, Path=SelectedItem}"/>
-        </StackPanel>-->
+        <StackPanel Orientation="Vertical" Margin="0,50,0,0">
+            <TextBlock Text="CustomLayout and VirtualizingStackPanel:"/>
+            <sdk:AutoCompleteBox x:Name="AutoCompleteVirtualized" Width="250" Height="22"/>
+        </StackPanel>
     </StackPanel>
 </sdk:Page>

--- a/src/Tests/TestApplication/TestApplication/Tests/AutoCompleteBoxTest.xaml.cs
+++ b/src/Tests/TestApplication/TestApplication/Tests/AutoCompleteBoxTest.xaml.cs
@@ -11,22 +11,72 @@ using System.Windows.Media.Animation;
 using System.Windows.Shapes;
 using System.Windows.Navigation;
 using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows.Markup;
+using System.Reflection;
+using System.Windows.Controls.Primitives;
+
+#if OPENSILVER
+using OpenSilver.Internal.Xaml.Context;
+#endif
 
 namespace TestApplication.Tests
 {
     public partial class AutoCompleteBoxTest : Page
     {
+        private ObservableCollection<string> _items = new ObservableCollection<string>();
+
         public AutoCompleteBoxTest()
         {
             InitializeComponent();
+
+#if OPENSILVER
+            // Virtualizing the ListBox of the ACB dropdown by giving it a custom template
+            AutoCompleteVirtualized.Loaded += (s, e) =>
+            {
+                IList<DependencyObject> acbDescendants = AutoCompleteVirtualized.GetVisualDescendants().ToList();
+                Popup popup = acbDescendants.OfType<Popup>().First();
+
+                IList<DependencyObject> popupDescendants = popup.Child.GetVisualDescendants().ToList();
+                Grid popupGrid = popupDescendants.OfType<Grid>().First();
+                popupGrid.CustomLayout = true;
+                popupGrid.IsAutoHeightOnCustomLayout = true;
+                popupGrid.IsAutoWidthOnCustomLayout = true;
+
+                ListBox listBox = popupDescendants.OfType<ListBox>().First();
+
+                var xamlContext = global::OpenSilver.Internal.Xaml.RuntimeHelpers.Create_XamlContext();
+                var itemsPanelTemplate = new ItemsPanelTemplate();
+                global::OpenSilver.Internal.Xaml.RuntimeHelpers.SetTemplateContent(itemsPanelTemplate, xamlContext, CreateItemsPanelTemplate);
+                listBox.ItemsPanel = itemsPanelTemplate;
+            };
         }
+
+        private FrameworkElement CreateItemsPanelTemplate(FrameworkElement templateOwner_ItemsPanelTemplate,
+            XamlContext xamlContext)
+        {
+            var virtualizingStackPanel = new VirtualizingStackPanel();
+            global::OpenSilver.Internal.Xaml.RuntimeHelpers.SetTemplatedParent(virtualizingStackPanel, templateOwner_ItemsPanelTemplate);
+            return virtualizingStackPanel;
+        }
+#else
+        }
+#endif
 
         // Executes when the user navigates to this page.
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            //AutoCompleteBox1.Items.Add("Initial item 1");
-            //AutoCompleteBox1.Items.Add("Initial item 2");
-            //AutoCompleteBox1.SelectedIndex = 1;
+            CreateNewItemsSource();
+        }
+
+        private void CreateNewItemsSource()
+        {
+            _items = new ObservableCollection<string>(Enumerable.Range(1, 50).Select(i => $"Initial item {i}").ToList());
+            AutoCompleteBox1.ItemsSource = _items;
+            AutoCompleteBox1.SelectedItem = _items[0];
+
+            AutoCompleteVirtualized.ItemsSource = _items;
+            AutoCompleteVirtualized.SelectedItem = _items[0];
         }
 
         string RandomId()
@@ -34,77 +84,54 @@ namespace TestApplication.Tests
             return (new Random()).Next(1000).ToString();
         }
 
-        //private void ButtonTestAutoCompleteBox1_ItemsAddUIElement_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.Items.Add(new TextBlock() { Text = "This is a UI element", Foreground = new SolidColorBrush(Colors.Red) });
-        //}
+        private void ButtonTestAutoCompleteBox1_ItemsAdd_Click(object sender, RoutedEventArgs e)
+        {
+            _items.Add("Item #" + RandomId());
+        }
 
-        //private void ButtonTestAutoCompleteBox1_ItemsAddString_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.Items.Add("Test String");
-        //}
+        private void ButtonTestAutoCompleteBox1_ItemsClear_Click(object sender, RoutedEventArgs e)
+        {
+            _items.Clear();
+        }
 
-        //private void ButtonTestAutoCompleteBox1_ItemsAdd_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.Items.Add("Item #" + RandomId());
-        //}
+        private void ButtonTestAutoCompleteBox1_ItemsRemoveFirst_Click(object sender, RoutedEventArgs e)
+        {
+            _items.Remove(_items[0]);
+        }
 
-        //private void ButtonTestAutoCompleteBox1_ItemsClear_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.Items.Clear();
-        //}
+        private void ButtonTestAutoCompleteBox1_SetNewItemsSource_Click(object sender, RoutedEventArgs e)
+        {
+            CreateNewItemsSource();
+        }
 
-        //private void ButtonTestAutoCompleteBox1_ItemsRemoveFirst_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.Items.Remove(AutoCompleteBox1.Items[0]);
-        //}
+        private void ButtonTestAutoCompleteBox1_ItemsSourceAdd_Click(object sender, RoutedEventArgs e)
+        {
+            ((ObservableCollection<string>)AutoCompleteBox1.ItemsSource).Add("Item #" + RandomId());
+        }
 
-        //private void ButtonTestAutoCompleteBox1_SetNewItemsSource_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.ItemsSource = new ObservableCollection<string>()
-        //    {
-        //        "One", "Two", "Three"
-        //    };
-        //}
+        private void ButtonTestAutoCompleteBox1_ItemsSourceClear_Click(object sender, RoutedEventArgs e)
+        {
+            ((ObservableCollection<string>)AutoCompleteBox1.ItemsSource).Clear();
+        }
 
-        //private void ButtonTestAutoCompleteBox1_ItemsSourceAdd_Click(object sender, RoutedEventArgs e)
-        //{
-        //    ((ObservableCollection<string>)AutoCompleteBox1.ItemsSource).Add("Item #" + RandomId());
-        //}
+        private void ButtonTestAutoCompleteBox1_ItemsSourceRemove_Click(object sender, RoutedEventArgs e)
+        {
+            ((ObservableCollection<string>)AutoCompleteBox1.ItemsSource).Remove(((ObservableCollection<string>)AutoCompleteBox1.ItemsSource).FirstOrDefault());
+        }
 
-        //private void ButtonTestAutoCompleteBox1_ItemsSourceClear_Click(object sender, RoutedEventArgs e)
-        //{
-        //    ((ObservableCollection<string>)AutoCompleteBox1.ItemsSource).Clear();
-        //}
+        private void ButtonTestAutoCompleteBox1_SetItemsSourceToNull_Click(object sender, RoutedEventArgs e)
+        {
+            AutoCompleteBox1.ItemsSource = null;
+        }
 
-        //private void ButtonTestAutoCompleteBox1_ItemsSourceRemove_Click(object sender, RoutedEventArgs e)
-        //{
-        //    ((ObservableCollection<string>)AutoCompleteBox1.ItemsSource).Remove(((ObservableCollection<string>)AutoCompleteBox1.ItemsSource).FirstOrDefault());
-        //}
+        private void ButtonTestAutoCompleteBox1_SelectSecondItem_Click(object sender, RoutedEventArgs e)
+        {
+            AutoCompleteBox1.SelectedItem = _items[1];
+        }
 
-        //private void ButtonTestAutoCompleteBox1_SetItemsSourceToNull_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.ItemsSource = null;
-        //}
-
-        //private void ButtonTestAutoCompleteBox1_SelectSecondItem_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.SelectedItem = AutoCompleteBox1.Items[1];
-        //}
-
-        //private void ButtonTestAutoCompleteBox1_SelectSecondIndex_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.SelectedIndex = 1;
-        //}
-
-        //private void ButtonTestAutoCompleteBox1_SelectItemNull_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.SelectedItem = null;
-        //}
-
-        //private void ButtonTestAutoCompleteBox1_SelectedIndexMinusOne_Click(object sender, RoutedEventArgs e)
-        //{
-        //    AutoCompleteBox1.SelectedIndex = -1;
-        //}
+        private void ButtonTestAutoCompleteBox1_SelectItemNull_Click(object sender, RoutedEventArgs e)
+        {
+            AutoCompleteBox1.SelectedItem = null;
+        }
     }
 }


### PR DESCRIPTION
When using IsAutoWidthOnCustomLayout or IsAutoHeightOnCustomLayout=True, controls can have sizes that are larger than the Window boundaries. This will lead to poor performance, since ScrollViewers are not triggered. This change takes the Window ActualHeight and ActualWidth into account on the available size for Measure().

This also makes  IsAutoWidthOnCustomLayout and IsAutoHeightOnCustomLayout DependencyProperties, and add them (along with CustomLayout) as Template Binding for AutoCompleteBox. This way, setting these properties on the ACB will reflect on the Selector part of the ControlTemplate (the ListBox on the DropDown).

To test, you can open the TestApplication and go to the AutoCompleteBox section. There will be a CustomLayout ACB. Before this change, the dropdown would not have a ScrollBar, rendering all 50 items (even though they don't all appear). After the change, the ScrollBar appears.