### PR TITLE
fix: set opacity for disabled state of combobox

### DIFF
--- a/src/Runtime/Runtime/DefaultStyles/INTERNAL_DefaultComboBoxStyle.xaml
+++ b/src/Runtime/Runtime/DefaultStyles/INTERNAL_DefaultComboBoxStyle.xaml
@@ -36,6 +36,11 @@
                             <VisualStateGroup Name="CommonStates">
                                 <VisualState Name="Disabled">
                                     <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
+                                                                       Storyboard.TargetName="OuterBorder">
+                                            <DiscreteObjectKeyFrame KeyTime="0"
+                                                                    Value="0.4" />
+                                        </ObjectAnimationUsingKeyFrames>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="BorderBrush"
                                                                        Storyboard.TargetName="OuterBorder">
                                             <DiscreteObjectKeyFrame KeyTime="0"


### PR DESCRIPTION
Hi difference between enabled and disabled. 
Before
![image](https://user-images.githubusercontent.com/92306865/167451973-c8b342ac-0aec-4582-9cd7-48feae4573ac.png)

After

![image](https://user-images.githubusercontent.com/92306865/167451610-3cd84b3d-b95e-439d-969e-efa28abddd6f.png)
