### PR TITLE
fix: force to use previous version of .NET framework

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -9,12 +9,12 @@ jobs:
     if: github.repository_owner == 'OpenSilver'
     runs-on: windows-2019
     steps:
-      - uses: microsoft/setup-msbuild@v1.0.3
+      - uses: microsoft/setup-msbuild@v1.1
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.202'
       - name: Clone OpenSilver repo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -10,10 +10,10 @@ jobs:
   OpenSilver-Build:
     runs-on: windows-2019
     steps:
-      - uses: microsoft/setup-msbuild@v1.0.3
+      - uses: microsoft/setup-msbuild@v1.1
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '6.0.202'
       - name: Clone OpenSilver repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
We can not use the latest .NET 6.0.3 because it requires msbuild 17, which is not available for windows-2019 image.
I have hardcoded .NET 6.0.202 while we wait the response for this [issue](https://github.com/actions/virtual-environments/issues/5522).

BTW, We can not easily move to windows-2022 because it does not support .Net Framework 4.6, which is used by our Simulator.
For other projects I suggest to move to windows-2022.