### PR TITLE
fix: solve VirtualizingStackPanel scrolling offset persisting between…

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/VirtualizingStackPanel.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/VirtualizingStackPanel.cs
@@ -487,11 +487,6 @@ namespace Windows.UI.Xaml.Controls
                         // items have been added earlier in the list than what is viewable
                         offset += args.ItemCount;
                     }
-
-                    if (Orientation == Orientation.Horizontal)
-                        SetHorizontalOffset(offset);
-                    else
-                        SetVerticalOffset(offset);
                     break;
                 case NotifyCollectionChangedAction.Remove:
                     // The following logic is meant to keep the current viewable items in view

--- a/src/Runtime/Runtime/System.Windows.Controls/VirtualizingStackPanel.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/VirtualizingStackPanel.cs
@@ -466,32 +466,17 @@ namespace Windows.UI.Xaml.Controls
         /// </param>
         protected override void OnItemsChanged(object sender, ItemsChangedEventArgs args)
         {
-            base.OnItemsChanged(sender, args);
-            IItemContainerGenerator generator = ItemContainerGenerator;
-            ItemsControl owner = ItemsControl.GetItemsOwner(this);
-            int index, offset, viewable;
+            base.OnItemsChanged(sender, args);            
 
             switch (args.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    // The following logic is meant to keep the current viewable items in view
-                    // after adjusting for added items.
-                    index = generator.IndexFromGeneratorPosition(args.Position);
-                    if (Orientation == Orientation.Horizontal)
-                        offset = (int)HorizontalOffset;
-                    else
-                        offset = (int)VerticalOffset;
-
-                    if (index <= offset)
-                    {
-                        // items have been added earlier in the list than what is viewable
-                        offset += args.ItemCount;
-                    }
                     break;
                 case NotifyCollectionChangedAction.Remove:
                     // The following logic is meant to keep the current viewable items in view
                     // after adjusting for removed items.
-                    index = generator.IndexFromGeneratorPosition(args.Position);
+                    ItemsControl owner = ItemsControl.GetItemsOwner(this);
+                    int offset, viewable;
                     if (Orientation == Orientation.Horizontal)
                     {
                         offset = (int)HorizontalOffset;
@@ -501,12 +486,6 @@ namespace Windows.UI.Xaml.Controls
                     {
                         viewable = (int)ViewportHeight;
                         offset = (int)VerticalOffset;
-                    }
-
-                    if (index < offset)
-                    {
-                        // items earlier in the list than what is viewable have been removed
-                        offset = Math.Max(offset - args.ItemCount, 0);
                     }
 
                     // adjust for items removed in the current view and/or beyond the current view


### PR DESCRIPTION
… item changes

This removes the offset increment when items are added,
because e.g. on AutoCompleteBox, when scrolling the dropdown then
filtering items further, the offset would persist as greater than
the new number of items and the dropdown would display empty as a result.

To test this, after pull request https://github.com/OpenSilver/OpenSilver/pull/478 has been merged, you can go to the Simulator TestApplication -> AutoCompleteBox, filter the CustomLayout ACB until it has a ScrollBar, scroll so that the offset is greater than zero, then keep filtering until the scrollbar disappears. If the new number of filtered items is lesset than the previous offset that was scrolled, the dropdown will show up empty.