### PR TITLE
fix: correct MouseLeftUp on AutoCompleteBox ScrollBar closing dropdown

### DIFF
--- a/src/Runtime/Controls.Input/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Runtime/Controls.Input/AutoCompleteBox/AutoCompleteBox.cs
@@ -1562,6 +1562,14 @@ namespace Windows.UI.Xaml.Controls
                     return true;
                 }
 
+                // If focus is on the selector part of this control (in the dropdown),
+                // then true is returned as to not close the dropdown when scrolling with drag
+                if (SelectionAdapter is SelectorSelectionAdapter selectorSelectionAdapter &&
+                    object.ReferenceEquals(focused, selectorSelectionAdapter.SelectorControl))
+                {
+                    return true;    
+                }
+
                 // This helps deal with popups that may not be in the same 
                 // visual tree
                 DependencyObject parent = VisualTreeHelper.GetParent(focused);

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/ScrollBar.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/ScrollBar.cs
@@ -578,6 +578,19 @@ namespace Windows.UI.Xaml.Controls.Primitives
         }
 
 #if MIGRATION
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs eventArgs)
+        {
+            base.OnMouseLeftButtonDown(eventArgs);
+#else
+        protected override void OnPointerPressed(PointerRoutedEventArgs eventArgs)
+        {
+            base.OnPointerPressed(eventArgs);
+#endif
+
+            eventArgs.Handled = true;
+        }
+
+#if MIGRATION
         protected override void OnMouseLeftButtonUp(MouseButtonEventArgs eventArgs)
         {
             base.OnMouseLeftButtonUp(eventArgs);

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/ScrollBar.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/ScrollBar.cs
@@ -14,10 +14,16 @@
 
 
 #if MIGRATION
-namespace System.Windows.Controls.Primitives
+using System.Windows.Input;
 #else
 using System;
 using Windows.Foundation;
+using Windows.UI.Xaml.Input;
+#endif
+
+#if MIGRATION
+namespace System.Windows.Controls.Primitives
+#else
 namespace Windows.UI.Xaml.Controls.Primitives
 #endif
 {
@@ -569,6 +575,20 @@ namespace Windows.UI.Xaml.Controls.Primitives
                     Canvas.SetLeft(_horizontalLargeIncrease, thumbBottomRightPosition);
                 }
             }
+        }
+
+#if MIGRATION
+        protected override void OnMouseLeftButtonUp(MouseButtonEventArgs eventArgs)
+        {
+            base.OnMouseLeftButtonUp(eventArgs);
+#else
+        protected override void OnPointerReleased(PointerRoutedEventArgs eventArgs)
+        {
+            base.OnPointerReleased(eventArgs);
+#endif
+
+            // Setting MouseLeftUp event as handled to not have it bubbled up and trigger selection on host
+            eventArgs.Handled = true;
         }
 
         /// <summary>


### PR DESCRIPTION
After https://github.com/OpenSilver/OpenSilver/pull/478 is merged, this can be tested by going to the TestApplication -> AutoCompleteBox, filtering the CustomLayout ACB to have a ScrollBar appear and do a scroll with mouse drag.