### PR TITLE
fix: enable closing AutoCompleteBox dropdown with the Tab key

### DIFF
--- a/src/Runtime/Controls.Input/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Runtime/Controls.Input/AutoCompleteBox/AutoCompleteBox.cs
@@ -2572,6 +2572,17 @@ namespace Windows.UI.Xaml.Controls
                     e.Handled = true;
                     break;
 
+                // Until tabbing sets focus to next element outside of ACB (instead of to the first
+                // item inside the dropdown) and closes the dropdown, completion is manually called below.
+#if MIGRATION
+                case Key.Tab:
+#else
+                case VirtualKey.Tab:
+#endif
+                    OnAdapterSelectionComplete(this, new RoutedEventArgs());
+                    e.Handled = false;
+                    break;
+
                 default:
                     break;
             }


### PR DESCRIPTION
This can be tested on the TestApplication -> AutoCompleteBox.

Leaving a comment to signal that if tab order/behavior matches Silverlight in the browser, this manual handling of the Tab key might be able to be removed.