### PR TITLE
Fix getting item type for CollectionView

### DIFF
--- a/src/Runtime/Controls.Data/Extensions.cs
+++ b/src/Runtime/Controls.Data/Extensions.cs
@@ -131,6 +131,11 @@ namespace Windows.UI.Xaml.Controls
 
         internal static Type GetItemType(this IEnumerable list)
         {
+            if (list is ICollectionView collectionView && collectionView.SourceCollection != null)
+            {
+                list = collectionView.SourceCollection;
+            }
+
             Type listType = list.GetType();
             Type itemType = null;
 

--- a/src/Runtime/Controls.Data/Extensions.cs
+++ b/src/Runtime/Controls.Data/Extensions.cs
@@ -131,11 +131,6 @@ namespace Windows.UI.Xaml.Controls
 
         internal static Type GetItemType(this IEnumerable list)
         {
-            if (list is ICollectionView collectionView && collectionView.SourceCollection != null)
-            {
-                list = collectionView.SourceCollection;
-            }
-
             Type listType = list.GetType();
             Type itemType = null;
 
@@ -158,6 +153,15 @@ namespace Windows.UI.Xaml.Controls
                 if (en.MoveNext() && en.Current != null) 
                 {
                     return en.Current.GetType();
+                }
+
+                if (list is ICollectionView icv && icv.SourceCollection != null)
+                {
+                    listType = icv.SourceCollection.GetType();
+                    if (listType.IsEnumerableType())
+                    {
+                        itemType = listType.GetEnumerableItemType();
+                    }
                 }
             }
 


### PR DESCRIPTION
`GetItemType()` was returning null if the source list is empty `CollectionView`

In our project we use `ICollectionView` as `DataGrid ItemsSource`. In this case every time we call `ICollectionView.Refresh()` method, rows and columns are fully regenerated. Because `DataGridDataConnection.DataType` is null.

This commit fixes this and `ICollectionView.Refresh()` reloads only rows, it improves DataGrid performance