### PR TITLE
Fix CustomLayout ScrollBar background overlapping with navigation buttons

### DIFF
--- a/src/Runtime/Runtime/DefaultStyles/INTERNAL_DefaultScrollBarStyle.xaml
+++ b/src/Runtime/Runtime/DefaultStyles/INTERNAL_DefaultScrollBarStyle.xaml
@@ -175,27 +175,27 @@
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <Canvas x:Name="HorizontalRoot" Visibility="Collapsed" ClipToBounds="True"  Background="{TemplateBinding Background}">
+                            <Button  Style="{StaticResource ScrollButton}"  x:Name="HorizontalLargeDecrease" Padding="0" Cursor="Arrow" />
+                            <Button  Style="{StaticResource ScrollButton}"  x:Name="HorizontalLargeIncrease" Padding="0" Cursor="Arrow" />
                             <Button x:Name="HorizontalSmallDecrease" Padding="0" Cursor="Arrow">
                                 <Path x:Name="ArrowLeft" Fill="#FF555555" Width="9" Height="9" Margin="0,0,3,0" StrokeThickness="3" HorizontalAlignment="Center" VerticalAlignment="Center" Stretch="Fill" Data="M 2,4.5 L 5.5,1 L 5.5,8"/>
                             </Button>
                             <Button x:Name="HorizontalSmallIncrease" Padding="0" Cursor="Arrow">
                                 <Path x:Name="ArrowRight" Fill="#FF555555" Width="9" Height="9" Margin="0,0,3,0" StrokeThickness="3" HorizontalAlignment="Center" VerticalAlignment="Center" Stretch="Fill" Data="M 2,1 L 5.5,4.5 L 2,8"/>
                             </Button>
-                            <Button  Style="{StaticResource ScrollButton}"  x:Name="HorizontalLargeDecrease" Padding="0" Cursor="Arrow" />
-                            <Button  Style="{StaticResource ScrollButton}"  x:Name="HorizontalLargeIncrease" Padding="0" Cursor="Arrow" />
                             <Thumb x:Name="HorizontalThumb" Cursor="Arrow" Style="{StaticResource ScrollThumb}" />
 
 
                         </Canvas>
                         <Canvas x:Name="VerticalRoot" Visibility="Collapsed" ClipToBounds="True" Background="{TemplateBinding Background}">
+                            <Button  Style="{StaticResource ScrollButton}"  x:Name="VerticalLargeDecrease" Padding="0" Cursor="Arrow" />
+                            <Button  Style="{StaticResource ScrollButton}"  x:Name="VerticalLargeIncrease" Padding="0" Cursor="Arrow" />
                             <Button x:Name="VerticalSmallDecrease" Padding="0" Cursor="Arrow">
                                 <Path x:Name="ArrowTop" Fill="#FF555555" Width="9" Height="9" Margin="0,0,3,0" StrokeThickness="3" HorizontalAlignment="Center" VerticalAlignment="Center" Stretch="Fill" Data="M 4.5,2 L 1,5.5 L 8,5.5"/>
                             </Button>
                             <Button x:Name="VerticalSmallIncrease" Padding="0" Cursor="Arrow">
                                 <Path x:Name="ArrowBottom" Fill="#FF555555" Width="9" Height="9" Margin="0,0,3,0" StrokeThickness="3" HorizontalAlignment="Center" VerticalAlignment="Center" Stretch="Fill" Data="M 1,2 L 4.5,5.5 L 8,2"/>
                             </Button>
-                            <Button  Style="{StaticResource ScrollButton}"  x:Name="VerticalLargeDecrease" Padding="0" Cursor="Arrow" />
-                            <Button  Style="{StaticResource ScrollButton}"  x:Name="VerticalLargeIncrease" Padding="0" Cursor="Arrow" />
                             <Thumb x:Name="VerticalThumb"  Style="{StaticResource ScrollThumb}" Cursor="Arrow" />
 
                         </Canvas>

--- a/src/Tests/TestApplication/TestApplication/Tests/AutoCompleteBoxTest.xaml
+++ b/src/Tests/TestApplication/TestApplication/Tests/AutoCompleteBoxTest.xaml
@@ -10,7 +10,7 @@
         <StackPanel Orientation="Vertical">
             <!--SLDISABLED-->
             <TextBlock Text="Items are 'Initial item #X', and 'Item #X' if added:"/>
-            <sdk:AutoCompleteBox x:Name="AutoCompleteBox1" Width="250"/>
+            <sdk:AutoCompleteBox x:Name="AutoCompleteBox1" ItemsSource="{Binding Items}" Width="250"/>
             <Button Content="Items.Add" Click="ButtonTestAutoCompleteBox1_ItemsAdd_Click"/>
             <Button Content="Items.Clear" Click="ButtonTestAutoCompleteBox1_ItemsClear_Click"/>
             <Button Content="Items.Remove First" Click="ButtonTestAutoCompleteBox1_ItemsRemoveFirst_Click"/>
@@ -28,7 +28,11 @@
         </StackPanel>
         <StackPanel Orientation="Vertical" Margin="0,50,0,0">
             <TextBlock Text="CustomLayout and VirtualizingStackPanel:"/>
-            <sdk:AutoCompleteBox x:Name="AutoCompleteVirtualized" Width="250" Height="22"/>
+            <sdk:AutoCompleteBox x:Name="AutoCompleteVirtualized" ItemsSource="{Binding Items}" Width="250" Height="22"/>
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="SelectedItem:"/>
+                <TextBlock Margin="5,0,0,0" Text="{Binding ElementName=AutoCompleteVirtualized, Path=SelectedItem}"/>
+            </StackPanel>
         </StackPanel>
     </StackPanel>
 </sdk:Page>

--- a/src/Tests/TestApplication/TestApplication/Tests/AutoCompleteBoxTest.xaml.cs
+++ b/src/Tests/TestApplication/TestApplication/Tests/AutoCompleteBoxTest.xaml.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Windows.Markup;
 using System.Reflection;
 using System.Windows.Controls.Primitives;
+using System.ComponentModel;
 
 #if OPENSILVER
 using OpenSilver.Internal.Xaml.Context;
@@ -25,6 +26,14 @@ namespace TestApplication.Tests
     public partial class AutoCompleteBoxTest : Page
     {
         private ObservableCollection<string> _items = new ObservableCollection<string>();
+
+        public ObservableCollection<string> Items
+        {
+            get
+            {
+                return _items;
+            }
+        }
 
         public AutoCompleteBoxTest()
         {


### PR DESCRIPTION
When scrolling on a CustomLayout ScrollBar (especially with higher speeds), the background buttons (LargeDecrease and LargeIncrease) can overflow and overlap with the navigation buttons (SmallDecrease and SmallIncrease), until they rendered again by the layout update.

This change moves the background buttons to the back in the ScrollBar style order, to guarantee that they will always have a higher VisualLevel then the Thumb and the navigation buttons.

To test this, go to the TestApplication -> AutoCompleteBox and filter the CustomLayout ACB to make the dropdown have a CustomLayout ScrollBar.