### PR TITLE
feat: Added support for two size units in grid row

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Grid_InternalHelpers.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Grid_InternalHelpers.cs
@@ -120,7 +120,12 @@ namespace Windows.UI.Xaml.Controls
 
         public static string ConvertGridLengthToCssString(GridLength gridLength, double minSize, string signUsedForPercentage = "%")
         {
-            if (gridLength.IsAuto)
+            if (gridLength.IsAuto && !double.IsNaN(minSize) && !double.IsInfinity(minSize) && minSize > 0)
+            {
+                string minWidthString = minSize.ToInvariantString() + "px";
+                return "minmax(" + minWidthString + ", auto)";
+            }
+            else if(gridLength.IsAuto)
             {
                 return "auto";
             }


### PR DESCRIPTION
` <RowDefinition Height="Auto" MinHeight="35" />`

Silverlight and CSS grid, both have support for multiple sizing units where we can have a row with automatic height and at the same time, it respects a minimum height.

