### PR TITLE
ToolTip switches to states when IsOpen is changed

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/ToolTip.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ToolTip.cs
@@ -35,6 +35,8 @@ namespace Windows.UI.Xaml.Controls
     /// <summary>
     /// Represents a control that creates a pop-up window that displays information for an element in the UI.
     /// </summary>
+    [TemplateVisualState(Name = VisualStates.StateToolTipOpen, GroupName = VisualStates.GroupToolTip)]
+    [TemplateVisualState(Name = VisualStates.StateToolTipClosed, GroupName = VisualStates.GroupToolTip)]
     public partial class ToolTip : ContentControl
     {
         private Popup _parentPopup;
@@ -111,6 +113,8 @@ namespace Windows.UI.Xaml.Controls
 
                 toolTip._parentPopup.IsOpen = true;
 
+                VisualStateManager.GoToState(toolTip, VisualStates.StateToolTipOpen, true);
+
                 if (toolTip.Opened != null)
                 {
                     toolTip.Opened(toolTip, new RoutedEventArgs
@@ -123,6 +127,7 @@ namespace Windows.UI.Xaml.Controls
             {
                 if (toolTip._parentPopup != null && toolTip._parentPopup.IsOpen == true)
                 {
+                    VisualStateManager.GoToState(toolTip, VisualStates.StateToolTipClosed, true);
                     toolTip._parentPopup.IsOpen = false;
 
                     // Raise the "Closed" event:

--- a/src/Runtime/Runtime/System.Windows.Controls/VisualStates.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/VisualStates.cs
@@ -395,6 +395,20 @@ namespace Windows.UI.Xaml.Controls
 
         #endregion GroupDescription
 
+        #region GroupTooltip
+        public const string GroupToolTip = "OpenStates";
+
+        /// <summary>
+        /// Opened state of the Tooltip state group.
+        /// </summary>
+        public const string StateToolTipOpen = "Open";
+
+        /// <summary>
+        /// Closed state of the Tooltip state group.
+        /// </summary>
+        public const string StateToolTipClosed = "Closed";
+        #endregion
+
         /// <summary>
         /// Use VisualStateManager to change the visual state of the control.
         /// </summary>


### PR DESCRIPTION
ToolTip is now handling the visual state changes for the cases in ContentControl (INTERNAL_DefaultContentControlStyle.xaml), TextBox (INTERNAL_DefaultTextBoxStyle.xaml), ListBox (INTERNAL_DefaultListBoxStyle.xaml), TreeView/TreeViewItem (INTERNAL_DefaultTreeViewItemStyle.xaml/INTERNAL_DefaultTreeViewStyle.xaml), Common Error validation (first ToolTip style in common.xaml) and if specified in custom-style in client projects.