### PR TITLE
fix:Added support for max width and height for image element

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Image.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Image.cs
@@ -522,6 +522,15 @@ $0.style.objectPosition = $2", image._imageDiv, objectFitvalue, objectPosition);
             style.height = "0"; // Same as above.
             style.objectPosition = "center top";
 
+            if (!double.IsNaN(this.MaxHeight) && this.MaxHeight > 0)
+            {
+                style.maxHeight = this.MaxHeight.ToString() + "px";
+            }
+            if (!double.IsNaN(this.MaxWidth) && this.MaxWidth > 0)
+            {
+                style.maxWidth = this.MaxWidth.ToString() + "px";
+            }
+
             CSHTML5.Interop.ExecuteJavaScriptAsync(@"
 $0.addEventListener('mousedown', function(e) {
     e.preventDefault();

--- a/src/Runtime/Runtime/System.Windows.Controls/Image.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Image.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 #if MIGRATION
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using OpenSilver.Internal;
 #else
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
@@ -524,11 +525,11 @@ $0.style.objectPosition = $2", image._imageDiv, objectFitvalue, objectPosition);
 
             if (!double.IsNaN(this.MaxHeight) && this.MaxHeight > 0)
             {
-                style.maxHeight = this.MaxHeight.ToString() + "px";
+                style.maxHeight = this.MaxHeight.ToInvariantString() + "px";
             }
             if (!double.IsNaN(this.MaxWidth) && this.MaxWidth > 0)
             {
-                style.maxWidth = this.MaxWidth.ToString() + "px";
+                style.maxWidth = this.MaxWidth.ToInvariantString() + "px";
             }
 
             CSHTML5.Interop.ExecuteJavaScriptAsync(@"

--- a/src/Runtime/Runtime/System.Windows.Controls/Image.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Image.cs
@@ -27,10 +27,11 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using OpenSilver.Internal;
+
 #if MIGRATION
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using OpenSilver.Internal;
 #else
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;


### PR DESCRIPTION
Adding max height and width to image elements in Open Silver has no effect on generated html, which is causing images to overflow their parent containers.