### PR TITLE
fix: make Popup.OnOpened trigger after opening

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
@@ -294,9 +294,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
                 // Show the popup if it was not already visible, or hide it if it was visible:
                 if (isOpen)
                 {
-                    popup.OnOpened();
                     // Show the popup:
                     popup.ShowPopupRootIfNotAlreadyVisible();
+                    popup.OnOpened();
                 }
                 else
                 {


### PR DESCRIPTION
The callback was triggering before the popup actually opened which is not the way it works on Silverlight and caused issues with 3rd party libraries (specifically with Telerik's RadComboBox)