### PR TITLE
fix textblock measurement, arrangement

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Grid.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Grid.cs
@@ -2558,9 +2558,6 @@ namespace Windows.UI.Xaml.Controls
                     UIElement[] childrens = Children.ToArray();
                     foreach (UIElement currentChild in childrens)
                     {
-                        Size childDesiredSize = currentChild.DesiredSize;
-                        innerRect.Width = Math.Max(innerRect.Width, childDesiredSize.Width);
-                        innerRect.Height = Math.Max(innerRect.Height, childDesiredSize.Height);
                         currentChild.Arrange(innerRect);
                     }
                 }

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBlock.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBlock.cs
@@ -64,6 +64,8 @@ namespace Windows.UI.Xaml.Controls
 
         private bool _isTextChanging;
 
+        private Size _measuredSize;
+
         public TextBlock()
         {
             this.IsTabStop = false; //we want to avoid stopping on this element's div when pressing tab.
@@ -372,18 +374,23 @@ namespace Windows.UI.Xaml.Controls
 
             if (TextWrapping == TextWrapping.NoWrap || noWrapSize.Width <= availableSize.Width)
             {
+                _measuredSize = noWrapSize;
                 return noWrapSize;
             }
 
             Size TextSize = Application.Current.TextMeasurementService.MeasureTextBlock(uniqueIdentifier, TextWrapping, Padding, (availableSize.Width - BorderThicknessSize.Width).Max(0));
             TextSize = TextSize.Add(BorderThicknessSize);
 
+            _measuredSize = TextSize;
             return TextSize;
         }
 
 		protected override Size ArrangeOverride(Size finalSize)
 		{
-			return finalSize;
+            double w = Math.Max(_measuredSize.Width, finalSize.Width);
+            double h = Math.Max(_measuredSize.Height, finalSize.Height);
+
+            return new Size(w, h);
 		}
     }
 }

--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
@@ -1217,8 +1217,17 @@ namespace Windows.UI.Xaml
 
             Size arrangedSize = ArrangeOverride(finalSize);
             
-            var w = Math.Max(0, Math.Min(finalSize.Width, arrangedSize.Width));
-            var h = Math.Max(0, Math.Min(finalSize.Height, arrangedSize.Height));
+            double w, h;
+            if (this is TextBlock)
+            {
+                w = Math.Max(0, arrangedSize.Width);
+                h = Math.Max(0, arrangedSize.Height);
+            }
+            else
+            {
+                w = Math.Max(0, Math.Min(finalSize.Width, arrangedSize.Width));
+                h = Math.Max(0, Math.Min(finalSize.Height, arrangedSize.Height));
+            }
             arrangedSize = new Size(w, h);
 
             arrangedSize = size.Combine(arrangedSize).Bounds(MinSize, MaxSize);

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -547,10 +547,14 @@ document.measureTextBlock = function(uid, textWrapping, padding, width, maxWidth
         var runElement = element.firstElementChild;
         if (runElement != null) {
             var child = elToMeasure;
-            while (child.hasChildNodes()) {
-                child = child.firstChild;
+            if (child.hasChildNodes()) {
+                while (child.hasChildNodes()) {
+                    child = child.firstChild;
+                }
+                runElement.innerHTML = child.parentElement.innerHTML.length == 0 ? 'A' : child.parentElement.innerHTML;
+            } else {
+                runElement.innerHTML = 'A';
             }
-            runElement.innerHTML = child.parentElement.innerHTML.length == 0 ? 'A' : child.parentElement.innerHTML;
         }
 
         element.style.fontSize = computedStyle.fontSize;


### PR DESCRIPTION
 - textblock measurement was not correct when the text is empty
 - textblock should be centered when the parent element width is smaller than the text width