### PR TITLE
Validation for INotifyDataErrorInfo entities

### DIFF
--- a/src/Runtime/Runtime/OpenSilver/Internal/Data/StandardPropertyPathNode.cs
+++ b/src/Runtime/Runtime/OpenSilver/Internal/Data/StandardPropertyPathNode.cs
@@ -29,7 +29,7 @@ namespace OpenSilver.Internal.Data
     internal class StandardPropertyPathNode : PropertyPathNode
     {
         private readonly Type _resolvedType;
-        private readonly string _propertyName;
+        internal readonly string _propertyName;
 
         private IPropertyChangedListener _dpListener;
         private DependencyProperty _dp;

--- a/src/Runtime/Runtime/System.Windows.Data/Binding.cs
+++ b/src/Runtime/Runtime/System.Windows.Data/Binding.cs
@@ -94,7 +94,7 @@ namespace Windows.UI.Xaml.Data
         private bool _validatesOnExceptions;
         private bool _notifyOnValidationError;
         private bool _bindsDirectlyToSource;
-        private bool _validatesOnNotifyDataErrors;
+        private bool _validatesOnNotifyDataErrors = true;
         private bool _validatesOnDataErrors;
 
         /// <summary>
@@ -370,7 +370,6 @@ namespace Windows.UI.Xaml.Data
         /// true if the binding engine will report System.ComponentModel.INotifyDataErrorInfo
         /// validation errors; otherwise, false. The default is true.
         /// </returns>
-        [OpenSilver.NotImplemented]
         public bool ValidatesOnNotifyDataErrors
         {
             get { return _validatesOnNotifyDataErrors; }


### PR DESCRIPTION
OpenRIA Services uses `INotifyDataErrorInfo` interface to validate entities. But corresposponding `Binding.ValidatesOnNotifyDataErrors` property is not implemented