### PR TITLE
Fixed mouse/pointer capture issue in mouse/pointer up event

### DIFF
--- a/src/Runtime/Runtime/System.Windows/UIElement.EventManager.cs
+++ b/src/Runtime/Runtime/System.Windows/UIElement.EventManager.cs
@@ -189,6 +189,18 @@ namespace Windows.UI.Xaml
                     ProcessOnMouseRightButtonUp(jsEventArg);
                     break;
             }
+
+#if MIGRATION
+            if (IsMouseCaptured)
+            {
+                ReleaseMouseCapture();
+            }
+#else 
+            if (IsPointerCaptured)
+            {
+                ReleasePointerCapture();
+            }
+#endif
         }
 
         private void ProcessMouseButtonEvent(


### PR DESCRIPTION
In Silverlight, if mouse is captured before mouse up event, it is released on mouse up and thus fires LostMouseCapture but OSF does not. This PR fixes that.