### PR TITLE
Fix: Fixed double validation tooltips showing issue

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Control.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Control.cs
@@ -1055,17 +1055,13 @@ void Control_PointerReleased(object sender, Input.PointerRoutedEventArgs e)
 
         internal void UpdateValidationState()
         {
-            if (!this._isInvalid)
-                VisualStateManager.GoToState(this, "Valid", true);
-            else
+            if (this._isInvalid)
             {
                 VisualStateManager.GoToState(this, _isFocused ? "InvalidFocused" : "InvalidUnfocused", true);
-
-                Popup popup = this.INTERNAL_ValidationErrorPopup;
-                if (popup != null)
-                {
-                    popup.IsOpen = _isFocused;
-                }
+            }                
+            else
+            {
+                VisualStateManager.GoToState(this, "Valid", true);
             }
         }
 

--- a/src/Runtime/Runtime/System.Windows.Controls/Validation.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Validation.cs
@@ -185,8 +185,6 @@ namespace Windows.UI.Xaml.Controls
                         }
                     }
 
-                    RefreshPopup(target, errors);
-
                     if (target is Control c)
                     {
                         c.HideValidationError();
@@ -271,8 +269,6 @@ namespace Windows.UI.Xaml.Controls
                     }
                 }
 
-                RefreshPopup(target, validationErrors);
-
                 if (target is Control c)
                 {
                     c.ShowValidationError();
@@ -280,91 +276,6 @@ namespace Windows.UI.Xaml.Controls
             }
 
         }
-
-        private static void RefreshPopup(UIElement target, ObservableCollection<ValidationError> errors)
-        {
-            Popup popup = target.INTERNAL_ValidationErrorPopup;
-            if (errors.Count == 0)
-            {
-                if (popup != null)
-                {
-                    popup.IsOpen = false;
-                }
-            }
-            else
-            {
-                if (popup == null)
-                {
-                    popup = new Popup();
-                    target.INTERNAL_ValidationErrorPopup = popup;
-
-                    //we define the content of the popup:
-                    Border border = new Border()
-                    {
-                        Background = new SolidColorBrush(Color.FromArgb(255, 219, 2, 12)),
-                        CornerRadius = new CornerRadius(2),
-                        Margin = new Thickness(5, 0, 0, 0),
-                    };
-                    TextBlock textBlock = new TextBlock()
-                    {
-                        Foreground = new SolidColorBrush(Colors.White),
-                        FontSize = 11.0,
-                        Margin = new Thickness(5, 3, 5, 3),
-                        TextWrapping = TextWrapping.Wrap,
-                        MaxWidth = 250,
-                    };
-                    border.Child = textBlock;
-                    popup.Child = border;
-                    popup.IsHitTestVisible = false;
-                    popup.PlacementTarget = target;
-                    popup.Placement = PlacementMode.Right;
-                }
-
-                //Point PopupAbsolutePosition = INTERNAL_PopupsManager.CalculatePopupAbsolutePositionBasedOnElementPosition(target, 0d, 0d);
-                //popup.HorizontalOffset = PopupAbsolutePosition.X;
-                //popup.VerticalOffset = PopupAbsolutePosition.Y;
-                string errorsInString = "";
-                bool isFirst = true;
-                foreach (ValidationError validationError in errors)
-                {
-                    errorsInString += Environment.NewLine;
-                    if (isFirst)
-                    {
-                        errorsInString = "";
-                        isFirst = false;
-                    }
-                    errorsInString += validationError.ErrorContent;
-                }
-
-                //Note: if the popup is not new, its Child (currently a textBlock) is already set.
-                //Todo: when we will support Templates for the validation error messages, make sure we correctly refresh the template visually.
-                ((TextBlock)((Border)popup.Child).Child).Text = errorsInString;
-                //Note: the line above will need to change when we will support templates.
-                //      At this time, we will probably use a Binding and set the Text as the DataContext of the Popup
-                //      OR we might need to set the whole errors collection as the DataContext depending on how it works in WPF and Silverlight.
-                if (INTERNAL_VisualTreeManager.IsElementInVisualTree(target))
-                    popup.IsOpen = true;
-            }
-        }
-
-        private static void Popup_PopupMoved(object sender, EventArgs e)
-        {
-            Popup popup = (Popup)sender;
-            PopupRoot popupRoot = popup.PopupRoot;
-
-            // Hide the popup if the parent element is not visible (for example, if the 
-            // user scrolls and the TextBox becomes hidden under another control, cf. ZenDesk #628):
-            if (popup.PlacementTarget is FrameworkElement && popupRoot != null)
-            {
-                bool isParentVisible = INTERNAL_PopupsManager.IsPopupParentVisibleOnScreen(popup);
-
-                popupRoot.Visibility = (isParentVisible ? Visibility.Visible : Visibility.Collapsed);
-
-            }
-        }
-
-
-
 
         #region to be implemented
 

--- a/src/Runtime/Runtime/System.Windows/UIElement.cs
+++ b/src/Runtime/Runtime/System.Windows/UIElement.cs
@@ -250,7 +250,6 @@ namespace Windows.UI.Xaml
         internal string INTERNAL_HtmlRepresentation { get; set; } // This can be used instead of overriding the "CreateDomElement" method to specify the appearance of the control.
         internal Dictionary<UIElement, INTERNAL_VisualChildInformation> INTERNAL_VisualChildrenInformation { get; set; } //todo-performance: verify that JavaScript output is a performant dictionary too, otherwise change structure.
         internal bool INTERNAL_RenderTransformOriginHasBeenApplied = false; // This is useful to ensure that the default RenderTransformOrigin is (0,0) like in normal XAML, instead of (0.5,0.5) like in CSS.
-        internal Popup INTERNAL_ValidationErrorPopup;
         //Note: the two following fields are only used in the PointerRoutedEventArgs class to determine how many clicks have been made on this UIElement in a short amount of time.
         internal int INTERNAL_clickCount; //this is used in the PointerPressed event to fill the ClickCount Property.
         internal int INTERNAL_lastClickDate; //this is used in the PointerPressed event to fill the ClickCount Property.


### PR DESCRIPTION
[This PR](https://github.com/OpenSilver/OpenSilver/pull/522) implements validation for Binding.ValidatesOnNotifyDataErrors, with the changes from there, we see double validation tooltips in a control ([try this project](https://github.com/avdynut/OpenSilverValidation.git) to see the issue, this PR fixes that issue (please review/merge this PR once done with 522).

Usually, every input control should have invalidFocused/invalidUnfocused states which has the template for validation tooltips, for example, [the TextBox style](https://github.com/OpenSilver/OpenSilver/blob/6860c819de80317d9fc3bde371ebf279f92c546b/src/Runtime/Runtime/DefaultStyles/INTERNAL_DefaultTextBoxStyle.xaml#L139) has that set which is showing/hiding from [Control.UpdateValidationState](https://github.com/OpenSilver/OpenSilver/blob/6860c819de80317d9fc3bde371ebf279f92c546b/src/Runtime/Runtime/System.Windows.Controls/Control.cs#L1062). So, we don't need this tooltips from Validation.RefreshPopup anymore.