### PR TITLE
fix: return -1 on IndexOf of DependencyObjectCollection when item does not exist

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Media.Effects/WORKINPROGRESS/ShaderEffect.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Effects/WORKINPROGRESS/ShaderEffect.cs
@@ -15,6 +15,7 @@
 
 #if !MIGRATION
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
 #endif
 
 namespace System.Windows.Media.Effects
@@ -53,12 +54,12 @@ namespace System.Windows.Media.Effects
 		[OpenSilver.NotImplemented]
         protected static DependencyProperty RegisterPixelShaderSamplerProperty(string @dpName, Type @ownerType, int @samplerRegisterIndex)
         {
-            return null;
+            return DependencyProperty.Register(dpName, typeof(Brush), ownerType, new PropertyMetadata());
         }
 		[OpenSilver.NotImplemented]
         protected static DependencyProperty RegisterPixelShaderSamplerProperty(string @dpName, Type @ownerType, int @samplerRegisterIndex, SamplingMode @samplingMode)
         {
-            return null;
+            return DependencyProperty.Register(dpName, typeof(Brush), ownerType, new PropertyMetadata());
         }
     }
 }

--- a/src/Runtime/Runtime/System.Windows/DependencyObjectCollection_1.cs
+++ b/src/Runtime/Runtime/System.Windows/DependencyObjectCollection_1.cs
@@ -242,12 +242,12 @@ namespace Windows.UI.Xaml
 
         private static DependencyObject AsDependencyObject(object item)
         {
-            if (!(item is DependencyObject depObj))
+            if (!(item is DependencyObject) && item != null)
             {
                 throw new ArgumentException("item is not a DependencyObject.");
             }
 
-            return depObj;
+            return (DependencyObject)item;
         }
 
         private static T AsT(object item)

--- a/src/Tests/Runtime.OpenSilver.Tests/System.Windows/DependencyObjectCollectionTest.cs
+++ b/src/Tests/Runtime.OpenSilver.Tests/System.Windows/DependencyObjectCollectionTest.cs
@@ -1,0 +1,53 @@
+﻿
+/*===================================================================================
+* 
+*   Copyright (c) Userware/OpenSilver.net
+*      
+*   This file is part of the OpenSilver Runtime (https://opensilver.net), which is
+*   licensed under the MIT license: https://opensource.org/licenses/MIT
+*   
+*   As stated in the MIT license, "the above copyright notice and this permission
+*   notice shall be included in all copies or substantial portions of the Software."
+*  
+\*====================================================================================*/
+
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#if !MIGRATION
+using System;
+#endif
+
+#if MIGRATION
+namespace System.Windows.Tests
+#else
+namespace Windows.UI.Xaml.Tests
+#endif
+{
+    [TestClass]
+    public class DependencyObjectCollectionTest
+    {
+        [TestMethod]
+        public void DependencyObjectCollection_IndexOf_ItemNotFound_ReturnsMinusOne()
+        {
+            DependencyObjectCollection<DependencyObject> dependencyObjectCollection =
+                new DependencyObjectCollection<DependencyObject>();
+
+            dependencyObjectCollection.IndexOf(new DependencyObject())
+                .Should()
+                .Be(-1);
+        }
+
+        [TestMethod]
+        public void DependencyObjectCollection_IndexOf_NotDependencyObject_Throws()
+        {
+            DependencyObjectCollection<object> dependencyObjectCollection =
+                new DependencyObjectCollection<object>();
+
+            dependencyObjectCollection.Invoking(c => c.IndexOf("Some item"))
+                .Should()
+                .Throw<ArgumentException>()
+                .WithMessage("item is not a DependencyObject.");
+        }
+    }
+}


### PR DESCRIPTION
Registered a DependencyProperty on ShaderEffect to solve a null reference, and handled the case where IndexOf should return -1 on DependencyObjectCollection (added a unit test for this).