### PR TITLE
Custom layout: fix alignment when parent size is smaller than the child.

### DIFF
--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
@@ -1261,7 +1261,8 @@ namespace Windows.UI.Xaml
                 alignedLeft = container.Left + container.Width - alignedRectSize.Width;
             }
 
-            if (horizontalAlignment == HorizontalAlignment.Center || horizontalAlignment == HorizontalAlignment.Stretch)
+            if (horizontalAlignment == HorizontalAlignment.Center ||
+                (horizontalAlignment == HorizontalAlignment.Stretch && container.Width > alignedRectSize.Width))
             {
                 alignedLeft = container.Left + (container.Width - alignedRectSize.Width) / 2;
             }
@@ -1271,7 +1272,8 @@ namespace Windows.UI.Xaml
                 alignedTop = container.Top + container.Height - alignedRectSize.Height;
             }
 
-            if (verticalAlignment == VerticalAlignment.Center || verticalAlignment == VerticalAlignment.Stretch)
+            if (verticalAlignment == VerticalAlignment.Center ||
+                (verticalAlignment == VerticalAlignment.Stretch && container.Height > alignedRectSize.Height))
             {
                 alignedTop = container.Top + (container.Height - alignedRectSize.Height) / 2;
             }


### PR DESCRIPTION
When parent width is narrow than the child, HorizontalAlignment=Stretch  should work as Left alignment.
Similarly, VerticalAlignment=Stretch should same with Top Alignment.