### PR TITLE
Fix: Polyline.Points binding was not working

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Shapes/Line.cs
+++ b/src/Runtime/Runtime/System.Windows.Shapes/Line.cs
@@ -289,7 +289,7 @@ if ($0.setLineDash)
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            return new Size(X2.Max(X1), Y2.Max(Y1));
+            return new Size(Math.Max(0, X2.Max(X1)), Math.Max(0, Y2.Max(Y1)));
         }
 
     }

--- a/src/Runtime/Runtime/System.Windows.Shapes/Polyline.cs
+++ b/src/Runtime/Runtime/System.Windows.Shapes/Polyline.cs
@@ -108,9 +108,8 @@ namespace Windows.UI.Xaml.Shapes
             if (e.NewValue != null && e.NewValue is PointCollection)
                 ((PointCollection)(e.NewValue)).SetParentShape(line);
 
-            line.SetValue(PointsProperty, e.NewValue);
 
-            if (line.IsLoaded)
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(line))
             {
                 line.InvalidateMeasure();
                 line.ScheduleRedraw();
@@ -147,7 +146,9 @@ namespace Windows.UI.Xaml.Shapes
                 return;
             }
 
-            if (Points?.Count < 2)
+            var points = (PointCollection)GetValue(PointsProperty);
+
+            if (points == null || points.Count < 2)
             {
                 return;
             }
@@ -184,7 +185,8 @@ namespace Windows.UI.Xaml.Shapes
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            if (Points?.Count < 2)
+            var points = (PointCollection)GetValue(PointsProperty);
+            if (points == null || points.Count < 2)
             {
                 return base.MeasureOverride(availableSize);
             }

--- a/src/Runtime/Runtime/System.Windows.Shapes/Shape.cs
+++ b/src/Runtime/Runtime/System.Windows.Shapes/Shape.cs
@@ -216,7 +216,7 @@ namespace Windows.UI.Xaml.Shapes
                 nameof(Stroke), 
                 typeof(Brush), 
                 typeof(Shape),
-                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, Stroke_Changed));
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.AffectsRender, Stroke_Changed));
 
         private static void Stroke_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {


### PR DESCRIPTION
1) Fixed: Polyline.Points binding was not working, 
2) Gracefully resolved Line.MeasureOverride was throwing exception (in Size) due to negative size