### PR TITLE
Fix: two exceptions related to ViewBox and DatePicker

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Viewbox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Viewbox.cs
@@ -181,7 +181,10 @@ namespace Windows.UI.Xaml.Controls
             Debug.Assert(RootCanvas != null, "The required template part RootCanvas was not found!");
 
             // Create the transformation to scale the container
-            ChildElement.RenderTransform = Scale = new ScaleTransform();
+            if (ChildElement != null)
+            {
+                ChildElement.RenderTransform = Scale = new ScaleTransform();
+            }
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)

--- a/src/Runtime/Runtime/System.Windows.Controls/WORKINPROGRESS/DatePicker.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/WORKINPROGRESS/DatePicker.cs
@@ -95,7 +95,6 @@ namespace Windows.UI.Xaml.Controls
             DependencyObject d,
             DependencyPropertyChangedEventArgs e)
         {
-            throw new NotImplementedException();
         }
 
         /// <summary>


### PR DESCRIPTION
In ALY project, we are getting these two exceptions
1) DatePicker : Not necessarily needed to throw.
2) ViewBox: ChildElement was not sometime and was causing exception in applytemplate.