### PR TITLE
Fixe: SelectionStart was always zero in TextChanged event

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
@@ -167,6 +167,12 @@ namespace Windows.UI.Xaml.Controls
                 tb._textViewHost.View.OnTextChanged((string)e.NewValue);
             }
 
+            if (tb._selectionIdxCache != null)
+            {
+                tb._textViewHost.View.NEW_SET_SELECTION(tb._selectionIdxCache.Value, tb._selectionIdxCache.Value);
+                tb._selectionIdxCache = null;
+            }
+
             tb.OnTextChanged(new TextChangedEventArgs() { OriginalSource = tb });
         }
 
@@ -422,6 +428,7 @@ namespace Windows.UI.Xaml.Controls
             tb.UpdateVisualStates();
         }
 
+        private int? _selectionIdxCache = null;
         public string SelectedText
         {
             get
@@ -442,8 +449,9 @@ namespace Windows.UI.Xaml.Controls
                 {
                     _textViewHost.View.NEW_GET_SELECTION(out selectionStartIndex, out selectionLength);
                     string text = this.Text.Substring(0, selectionStartIndex) + value + this.Text.Substring(selectionStartIndex + selectionLength);
+                    _selectionIdxCache = selectionStartIndex + value.Length;
                     this.Text = text;
-                    _textViewHost.View.NEW_SET_SELECTION(selectionStartIndex + value.Length, selectionStartIndex + value.Length);
+                    _selectionIdxCache = null;
                 }
             }
         }

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
@@ -49,6 +49,7 @@ namespace Windows.UI.Xaml.Controls
     public partial class TextBox : Control
     {
         private bool _isProcessingInput;
+        private int? _selectionIdxCache;
         private FrameworkElement _contentElement;
         private ITextBoxViewHost<TextBoxView> _textViewHost;
 
@@ -167,7 +168,7 @@ namespace Windows.UI.Xaml.Controls
                 tb._textViewHost.View.OnTextChanged((string)e.NewValue);
             }
 
-            if (tb._selectionIdxCache != null)
+            if (tb._selectionIdxCache.HasValue)
             {
                 tb._textViewHost.View.NEW_SET_SELECTION(tb._selectionIdxCache.Value, tb._selectionIdxCache.Value);
                 tb._selectionIdxCache = null;
@@ -427,8 +428,7 @@ namespace Windows.UI.Xaml.Controls
 
             tb.UpdateVisualStates();
         }
-
-        private int? _selectionIdxCache = null;
+        
         public string SelectedText
         {
             get


### PR DESCRIPTION
SelectionStart was always null if in the handler of TextChanged event.