### PR TITLE
fix-grid-row-col-sizing-when-star-and-auto-sized-ancestor

### DIFF
--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -111,6 +111,32 @@ document.getAppParams = function () {
     );
 }
 
+document.DoesElementHasAutoWidthAncestor = function(divId) {
+    var ele = document.getElementById(divId);     
+
+    while (ele) {
+        if (ele.style.width == 'auto') {
+            return true;
+        }
+        ele = ele.parentElement;
+    }
+
+    return false;
+}
+
+document.DoesElementHasAutoHeightAncestor = function(divId) {
+    var ele = document.getElementById(divId);
+
+    while (ele) {
+        if (ele.style.height == 'auto') {
+            return true;
+        }
+        ele = ele.parentElement;
+    }
+
+    return false;
+}
+
 document.ResXFiles = {};
 
 document.modifiersPressed = 0;

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -111,8 +111,8 @@ document.getAppParams = function () {
     );
 }
 
-document.DoesElementHasAutoWidthAncestor = function(divId) {
-    var ele = document.getElementById(divId);     
+document.DoesElementHasAutoWidthAncestor = function(id) {
+    var ele = document.getElementById(id);     
 
     while (ele) {
         if (ele.style.width == 'auto') {
@@ -124,8 +124,8 @@ document.DoesElementHasAutoWidthAncestor = function(divId) {
     return false;
 }
 
-document.DoesElementHasAutoHeightAncestor = function(divId) {
-    var ele = document.getElementById(divId);
+document.DoesElementHasAutoHeightAncestor = function(id) {
+    var ele = document.getElementById(id);
 
     while (ele) {
         if (ele.style.height == 'auto') {


### PR DESCRIPTION
When a grid ancestor has auto width or height and grid rows or columns has a star it should be treated as auto