### PR TITLE
fix: call applytemplate

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/INTERNAL_DateTimePickerBase.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/INTERNAL_DateTimePickerBase.cs
@@ -245,6 +245,9 @@ namespace Windows.UI.Xaml.Controls
             }
             else
             {
+                if (dp._textBox == null)
+                    dp.ApplyTemplate();
+
                 if (dp._textBox != null)
                 {
                     dp._textBox.Text = newText;


### PR DESCRIPTION
DatePicker shows binded value correctly when used stand alone but inside DataForm it enters TextChanged before entering ApplyTemplate.