### PR TITLE
Optimize progressive rendering - attach children by chunks

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Panel.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Panel.cs
@@ -138,10 +138,10 @@ namespace Windows.UI.Xaml.Controls
         private bool _enableProgressiveRendering;
         public bool EnableProgressiveRendering
         {
-            get { return this._enableProgressiveRendering || INTERNAL_ApplicationWideEnableProgressiveRendering; }
+            get { return this._enableProgressiveRendering || Children.Count >= INTERNAL_ApplicationWideProgressiveRenderingMinChildrenCount; }
             set { this._enableProgressiveRendering = value; }
         }
-        internal static bool INTERNAL_ApplicationWideEnableProgressiveRendering;
+        internal static int INTERNAL_ApplicationWideProgressiveRenderingMinChildrenCount;
 
         private void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
@@ -574,17 +574,21 @@ namespace Windows.UI.Xaml.Controls
 
         private async void ProgressivelyAttachChildren(IList<UIElement> newChildren)
         {
+            var sw = Stopwatch.StartNew();
             for (int i = 0; i < newChildren.Count; ++i)
             {
                 await Task.Delay(1);
                 if (!INTERNAL_VisualTreeManager.IsElementInVisualTree(this))
                 {
                     //this can happen if the Panel is detached during the delay.
+                    Trace.WriteLine($"ProgressivelyAttachChildren is not in visual tree {this}");
                     break;
                 }
                 INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(newChildren[i], this);
                 INTERNAL_OnChildProgressivelyLoaded();
             }
+            sw.Stop();
+            Trace.WriteLine($"ProgressivelyAttachChildren end {this} {newChildren.Count} {sw.ElapsedMilliseconds}ms");
         }
 
         protected virtual void INTERNAL_OnChildProgressivelyLoaded()

--- a/src/Runtime/Runtime/System.Windows.Controls/Panel.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Panel.cs
@@ -586,8 +586,9 @@ namespace Windows.UI.Xaml.Controls
             {
                 chunk = 1;
             }
+
             int from = 0;
-            int to = chunk;
+            int to = (chunk * 2 > newChildren.Count) ? newChildren.Count : chunk; // do not process less number of items than chunk
             while (true)
             {
                 await Task.Delay(1);
@@ -610,7 +611,7 @@ namespace Windows.UI.Xaml.Controls
                 else
                 {
                     from = to;
-                    to += Math.Min(chunk, remaining);
+                    to += (chunk * 2 > remaining) ? remaining : chunk;
                 }
             }
         }

--- a/src/Runtime/Runtime/System.Windows/Settings.cs
+++ b/src/Runtime/Runtime/System.Windows/Settings.cs
@@ -53,6 +53,7 @@ namespace System
             EnableBindingErrorsThrowing = false;
             EnableInvalidPropertyMetadataDefaultValueExceptions = true;
             ScrollDebounce = TimeSpan.Zero;
+            ProgressiveRenderingMinChildrenCount = int.MaxValue; // disable progressive rendering
         }
 
         public TimeSpan ScrollDebounce { get; set; }
@@ -117,10 +118,15 @@ namespace System
             set { INTERNAL_VisualTreeManager.EnableOptimizationWhereCollapsedControlsAreLoadedLast = value; }
         }
 
-        public bool EnableProgressiveRendering
+        /// <summary>
+        /// Gets or sets the minimum number of children in a Panel to apply progressive loading.
+        /// Setting this option can improve performance, but value close to 0 can break UI in some cases.
+        /// Progressive loading is disabled by default.
+        /// </summary>
+        public int ProgressiveRenderingMinChildrenCount
         {
-            get { return Panel.INTERNAL_ApplicationWideEnableProgressiveRendering; }
-            set { Panel.INTERNAL_ApplicationWideEnableProgressiveRendering = value; }
+            get { return Panel.INTERNAL_ApplicationWideProgressiveRenderingMinChildrenCount; }
+            set { Panel.INTERNAL_ApplicationWideProgressiveRenderingMinChildrenCount = value; }
         }
 
         public bool EnableInvalidPropertyMetadataDefaultValueExceptions { get; set; }

--- a/src/Runtime/Runtime/System.Windows/Settings.cs
+++ b/src/Runtime/Runtime/System.Windows/Settings.cs
@@ -123,7 +123,7 @@ namespace System
         /// Value with 0 or less than 0 means disabled progressive loading. Value close to 1 can break UI in some cases.
         /// Progressive loading is disabled by default.
         /// </summary>
-        public int ProgressiveRenderingChunk
+        public int ProgressiveRenderingChunkSize
         {
             get { return Panel.INTERNAL_ApplicationWideProgressiveRenderingChunk; }
             set { Panel.INTERNAL_ApplicationWideProgressiveRenderingChunk = value; }

--- a/src/Runtime/Runtime/System.Windows/Settings.cs
+++ b/src/Runtime/Runtime/System.Windows/Settings.cs
@@ -120,13 +120,24 @@ namespace System
         /// <summary>
         /// Gets or sets the number of children in a Panel to render progressively in a batch.
         /// Setting this option can improve performance.
-        /// Value with 0 or less than 0 means disabled progressive loading. Value close to 1 can break UI in some cases.
-        /// Progressive loading is disabled by default.
+        /// Value of 0 or less means progressive rendering is disabled.
+        /// The default value is 0.
         /// </summary>
+        /// <remarks>
+        /// A value close to 1 can break UI in some cases.
+        /// </remarks>
         public int ProgressiveRenderingChunkSize
         {
-            get { return Panel.INTERNAL_ApplicationWideProgressiveRenderingChunk; }
-            set { Panel.INTERNAL_ApplicationWideProgressiveRenderingChunk = value; }
+            get { return Panel.GlobalProgressiveRenderingChunkSize; }
+            set { Panel.GlobalProgressiveRenderingChunkSize = value; }
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use ProgressiveRenderingChunkSize instead.")]
+        public bool EnableProgressiveRendering
+        {
+            get => Panel.GlobalProgressiveRenderingChunkSize > 0;
+            set => Panel.GlobalProgressiveRenderingChunkSize = 1;
         }
 
         public bool EnableInvalidPropertyMetadataDefaultValueExceptions { get; set; }

--- a/src/Runtime/Runtime/System.Windows/Settings.cs
+++ b/src/Runtime/Runtime/System.Windows/Settings.cs
@@ -53,7 +53,6 @@ namespace System
             EnableBindingErrorsThrowing = false;
             EnableInvalidPropertyMetadataDefaultValueExceptions = true;
             ScrollDebounce = TimeSpan.Zero;
-            ProgressiveRenderingMinChildrenCount = int.MaxValue; // disable progressive rendering
         }
 
         public TimeSpan ScrollDebounce { get; set; }
@@ -119,14 +118,15 @@ namespace System
         }
 
         /// <summary>
-        /// Gets or sets the minimum number of children in a Panel to apply progressive loading.
-        /// Setting this option can improve performance, but value close to 0 can break UI in some cases.
+        /// Gets or sets the number of children in a Panel to render progressively in a batch.
+        /// Setting this option can improve performance.
+        /// Value with 0 or less than 0 means disabled progressive loading. Value close to 1 can break UI in some cases.
         /// Progressive loading is disabled by default.
         /// </summary>
-        public int ProgressiveRenderingMinChildrenCount
+        public int ProgressiveRenderingChunk
         {
-            get { return Panel.INTERNAL_ApplicationWideProgressiveRenderingMinChildrenCount; }
-            set { Panel.INTERNAL_ApplicationWideProgressiveRenderingMinChildrenCount = value; }
+            get { return Panel.INTERNAL_ApplicationWideProgressiveRenderingChunk; }
+            set { Panel.INTERNAL_ApplicationWideProgressiveRenderingChunk = value; }
         }
 
         public bool EnableInvalidPropertyMetadataDefaultValueExceptions { get; set; }


### PR DESCRIPTION
EnableProgressiveRendering in application-wide was not usable in most cases, because can break UI.
But if load progressively by chunks, for example by 10 elements, it's significantly improves UI responsivness