### PR TITLE
Allow ResourceDictionary to be inherited and do caching

### DIFF
--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/AssembliesInspector.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/AssembliesInspector.cs
@@ -104,6 +104,9 @@ namespace OpenSilver.Compiler
         public bool IsFrameworkTemplateTemplateProperty(string propertyName, string namespaceName, string typeName)
             => _monoCecilVersion.IsFrameworkTemplateTemplateProperty(propertyName, namespaceName, typeName);
 
+        public bool IsResourceDictionarySourcePropertyVisible( string namespaceName, string typeName)
+            => _monoCecilVersion.IsResourceDictionarySourcePropertyVisible(namespaceName, typeName);
+
         public string GetField(string fieldName, string namespaceName, string typeName, string assemblyName)
             => _monoCecilVersion.GetField(fieldName, namespaceName, typeName, assemblyName);
     }

--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/MonoCecilAssembliesInspectorImpl.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/MonoCecilAssembliesInspectorImpl.cs
@@ -101,6 +101,7 @@ namespace OpenSilver.Compiler.OtherHelpersAndHandlers.MonoCecilAssembliesInspect
         private const string StaticResExtension = "StaticResourceExtension";
         private const string DependencyObj = "DependencyObject";
         private const string FrameworkTemplateName = "FrameworkTemplate";
+        private const string ResourceDictionaryName = "ResourceDictionary";
 
         private readonly MonoCecilAssemblyStorage _storage;
         private readonly List<AssemblyData> _assemblies = new();
@@ -501,6 +502,16 @@ namespace OpenSilver.Compiler.OtherHelpersAndHandlers.MonoCecilAssembliesInspect
 
             return FindPropertyDeep(type, TemplatePropertyName, out _) is PropertyDefinition prop &&
                 prop.DeclaringType.Name == FrameworkTemplateName &&
+                prop.DeclaringType.Namespace == _metadata.SystemWindowsNS &&
+                prop.DeclaringType.Module.Assembly.Name.Name == Constants.NAME_OF_CORE_ASSEMBLY_USING_BLAZOR;
+        }
+
+        public bool IsResourceDictionarySourcePropertyVisible(string namespaceName, string typeName)
+        {
+            var type = FindType(namespaceName, typeName);
+
+            return FindPropertyDeep(type, "Source", out _) is PropertyDefinition prop &&
+                prop.DeclaringType.Name == ResourceDictionaryName &&
                 prop.DeclaringType.Namespace == _metadata.SystemWindowsNS &&
                 prop.DeclaringType.Module.Assembly.Name.Name == Constants.NAME_OF_CORE_ASSEMBLY_USING_BLAZOR;
         }

--- a/src/Tests/TestApplication/TestApplication/Registry/TestRegistry.cs
+++ b/src/Tests/TestApplication/TestApplication/Registry/TestRegistry.cs
@@ -144,6 +144,8 @@ namespace TestApplication
             Tests.Add(new Test("PopupWindow", "PopupWindow"));
 
             Tests.Add(new Test("RightToLeft", "RightToLeft"));
+
+            Tests.Add(new Test("ResourceDictionary", "ResourceDictionary/ResourceDictionary"));
         }
     }
 }

--- a/src/Tests/TestApplication/TestApplication/TestApplication.OpenSilver.csproj
+++ b/src/Tests/TestApplication/TestApplication/TestApplication.OpenSilver.csproj
@@ -221,6 +221,10 @@
     <Compile Include="Tests\RadioButtonTest.xaml.cs">
       <DependentUpon>RadioButtonTest.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Tests\ResourceDictionary\CachedResourceDictionary\CachedResourceDictionary.cs" />
+    <Compile Include="Tests\ResourceDictionary\CachedResourceDictionary\CountableInstance.cs" />
+    <Compile Include="Tests\ResourceDictionary\CustomPropertyResourceDictionary.cs" />
+    <Compile Include="Tests\ResourceDictionary\ResourceDictionaryTest.xaml.cs" />
     <Compile Include="Tests\Right ClickTest.xaml.cs">
       <DependentUpon>Right ClickTest.xaml</DependentUpon>
     </Compile>
@@ -656,6 +660,15 @@
     <Page Include="Tests\PopupZIndexTest.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Tests\ResourceDictionary\CachedResourceDictionary\CountableResourceDictionary.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Tests\ResourceDictionary\ResourceDictionaryTest.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Tests\ResourceDictionary\SomeResourceDictionary.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Tests\RightToLeftTest.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -668,6 +681,12 @@
     <Page Include="Tests\ValidationSummaryTest.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <UpToDateCheckInput Remove="Tests\ResourceDictionary\CachedResourceDictionary\CountableResourceDictionary.xaml" />
+  </ItemGroup>
+  <ItemGroup>
+    <UpToDateCheckInput Remove="Tests\ResourceDictionary\SomeResourceDictionary.xaml" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/TestApplication/TestApplication/TestApplication.Silverlight.csproj
+++ b/src/Tests/TestApplication/TestApplication/TestApplication.Silverlight.csproj
@@ -312,7 +312,7 @@
     <Compile Include="Tests\OpenFileDialogTest.xaml.cs">
       <DependentUpon>OpenFileDialogTest.xaml</DependentUpon>
     </Compile>
-	<Compile Include="Tests\PopupZIndexTest.xaml.cs">
+    <Compile Include="Tests\PopupZIndexTest.xaml.cs">
       <DependentUpon>PopupZIndexTest.xaml</DependentUpon>
     </Compile>
     <Compile Include="Tests\Paths\PathChangeTest.xaml.cs">
@@ -324,12 +324,18 @@
     <Compile Include="Tests\PrintingTest.xaml.cs">
       <DependentUpon>PrintingTest.xaml</DependentUpon>
     </Compile>
-	<Compile Include="Tests\PrintDocumentTest.xaml.cs">
+    <Compile Include="Tests\PrintDocumentTest.xaml.cs">
       <DependentUpon>PrintDocumentTest.xaml</DependentUpon>
     </Compile>
     <Compile Include="Tests\RadioButtonTest.xaml.cs">
       <DependentUpon>RadioButtonTest.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Tests\ResourceDictionary\CachedResourceDictionary\CachedResourceDictionary.cs" />
+    <Compile Include="Tests\ResourceDictionary\CachedResourceDictionary\CountableInstance.cs" />
+    <Compile Include="Tests\ResourceDictionary\ResourceDictionaryTest.xaml.cs">
+      <DependentUpon>ResourceDictionaryTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Tests\ResourceDictionary\CustomPropertyResourceDictionary.cs" />
     <Compile Include="Tests\Right ClickTest.xaml.cs">
       <DependentUpon>Right ClickTest.xaml</DependentUpon>
     </Compile>
@@ -653,7 +659,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
-	<Page Include="Tests\PopupZIndexTest.xaml">
+    <Page Include="Tests\PopupZIndexTest.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
@@ -669,13 +675,25 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-	<Page Include="Tests\PrintDocumentTest.xaml">
+    <Page Include="Tests\PrintDocumentTest.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Tests\RadioButtonTest.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Tests\ResourceDictionary\CachedResourceDictionary\CountableResourceDictionary.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Tests\ResourceDictionary\ResourceDictionaryTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Tests\ResourceDictionary\SomeResourceDictionary.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Tests\Right ClickTest.xaml">
       <SubType>Designer</SubType>

--- a/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/CachedResourceDictionary/CachedResourceDictionary.cs
+++ b/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/CachedResourceDictionary/CachedResourceDictionary.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Windows;
+
+#if OPENSILVER
+using OpenSilver.Internal.Xaml;
+#endif
+
+namespace TestApplication.Tests.ResourceDictionary.CachedResourceDictionary
+{
+    public class CachedResourceDictionary : System.Windows.ResourceDictionary
+    {
+        private Uri _source;
+        public new Uri Source
+        {
+            get
+            {
+                return _source;
+            }
+            set
+            {
+                string source = value.OriginalString;
+                if (!source.Contains(";"))
+                {
+#if OPENSILVER
+                    source = "/TestApplication.OpenSilver;component" + source;
+#else
+                    source = "/TestApplication.Silverlight;component" + source;
+#endif
+                }
+                _source = new Uri(source, UriKind.Relative);
+                if (Application.Current.Resources.MergedDictionaries.Any(d => d.Source == _source))
+                {
+                    return;
+                }
+
+                System.Windows.ResourceDictionary resourceDictionary = new System.Windows.ResourceDictionary
+                {
+                    Source = _source
+                };
+#if OPENSILVER
+                Application.LoadComponent(resourceDictionary, _source);
+#endif
+                Application.Current.Resources.MergedDictionaries.Add(resourceDictionary);
+            }
+        }
+    }
+}

--- a/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/CachedResourceDictionary/CountableInstance.cs
+++ b/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/CachedResourceDictionary/CountableInstance.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows.Controls;
+
+namespace TestApplication.Tests.ResourceDictionary.CachedResourceDictionary
+{
+    public class CountableInstance : UserControl
+    {
+        public CountableInstance()
+        {
+            Count++;
+        }
+
+        public static int Count { get; private set; }
+    }
+}

--- a/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/CachedResourceDictionary/CountableResourceDictionary.xaml
+++ b/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/CachedResourceDictionary/CountableResourceDictionary.xaml
@@ -1,0 +1,7 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:crd="clr-namespace:TestApplication.Tests.ResourceDictionary.CachedResourceDictionary">
+
+    <crd:CountableInstance x:Key="SomeCountableInstance"/>
+</ResourceDictionary>

--- a/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/CustomPropertyResourceDictionary.cs
+++ b/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/CustomPropertyResourceDictionary.cs
@@ -1,0 +1,7 @@
+﻿namespace TestApplication.Tests.ResourceDictionary
+{
+    public class CustomPropertyResourceDictionary : System.Windows.ResourceDictionary
+    {
+        public string CustomProperty { get; set; }
+    }
+}

--- a/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/ResourceDictionaryTest.xaml
+++ b/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/ResourceDictionaryTest.xaml
@@ -1,0 +1,35 @@
+﻿<sdk:Page x:Class="TestApplication.Tests.ResourceDictionaryTest" 
+           xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+           mc:Ignorable="d"
+           xmlns:sdk="http://schemas.microsoft.com/winfx/2006/xaml/presentation/sdk"
+           xmlns:crd="clr-namespace:TestApplication.Tests.ResourceDictionary.CachedResourceDictionary"
+           xmlns:rd="clr-namespace:TestApplication.Tests.ResourceDictionary">
+    <sdk:Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <crd:CachedResourceDictionary Source="/Tests/ResourceDictionary/CachedResourceDictionary/CountableResourceDictionary.xaml"/>
+                <crd:CachedResourceDictionary Source="/Tests/ResourceDictionary/CachedResourceDictionary/CountableResourceDictionary.xaml"/>
+                <crd:CachedResourceDictionary Source="/Tests/ResourceDictionary/CachedResourceDictionary/CountableResourceDictionary.xaml"/>
+
+                <!-- This tests whether Compiler handles a ResourceDictionary subclass that defines a custom property. -->
+                <rd:CustomPropertyResourceDictionary CustomProperty="Test" Source="SomeResourceDictionary.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </sdk:Page.Resources>
+
+    <StackPanel Orientation="Vertical">
+        <TextBlock Text="Cached ResourceDictionary:"/>
+        <Button Name="CachedResourceDictionaryLoadButton" Content="Load" Width="100" Click="CachedResourceDictionaryLoadButton_Click"/>
+        <TextBox Name="CachedResourceDictionaryTextBox" IsReadOnly="True" Width="700" Height="100"/>
+
+        <TextBlock Margin="0,20,0,0" Text="ResourceDictionary with custom property:"/>
+        <TextBlock Text="This tests whether Compiler handles a ResourceDictionary subclass that defines a custom property. CustomPropertyResourceDictionary is defined on Page.Resources MergedDictionaries of this Page."/>
+        <StackPanel Orientation="Horizontal">
+            <TextBlock Text="CustomProperty value:"/>
+            <TextBlock Margin="5,0,0,0" Name="CustomPropertyValue"/>
+        </StackPanel>
+    </StackPanel>
+</sdk:Page>

--- a/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/ResourceDictionaryTest.xaml.cs
+++ b/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/ResourceDictionaryTest.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Navigation;
+using TestApplication.Tests.ResourceDictionary;
+using TestApplication.Tests.ResourceDictionary.CachedResourceDictionary;
+
+namespace TestApplication.Tests
+{
+    public partial class ResourceDictionaryTest : Page
+    {
+        public ResourceDictionaryTest()
+        {
+            InitializeComponent();
+        }
+
+        // Executes when the user navigates to this page.
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            var customPropertyResourceDictionary = Resources.MergedDictionaries.OfType<CustomPropertyResourceDictionary>().FirstOrDefault();
+            if (customPropertyResourceDictionary != null)
+            {
+                CustomPropertyValue.Text = customPropertyResourceDictionary.CustomProperty;
+            }
+        }
+
+        private void CachedResourceDictionaryLoadButton_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            CachedResourceDictionary cachedResourceDictionary = new CachedResourceDictionary
+            {
+                Source = new Uri(
+#if OPENSILVER
+                    "/TestApplication.OpenSilver;component/Tests/ResourceDictionary/CachedResourceDictionary/CountableResourceDictionary.xaml",
+#else
+                    "/TestApplication.Silverlight;component/Tests/ResourceDictionary/CachedResourceDictionary/CountableResourceDictionary.xaml",
+#endif
+                    UriKind.Relative)
+            };
+            CachedResourceDictionaryTextBox.Text += $"There are multiple cached dict (3 in XAML and one per button click), but the content has been loaded {CountableInstance.Count} times.\r\n";
+        }
+    }
+}

--- a/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/SomeResourceDictionary.xaml
+++ b/src/Tests/TestApplication/TestApplication/Tests/ResourceDictionary/SomeResourceDictionary.xaml
@@ -1,0 +1,4 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+</ResourceDictionary>


### PR DESCRIPTION
Even if a dictionary might be referenced in XAML using a subclass
of ResourceDictionary, its definition may be a ResourceDictionary,
causing the Component factory to fail a cast to the subclass. So
we cast to ResourceDictionary to be sure.