### PR TITLE
fix: set Accordion ExpandableContentControl size to ActualWidth/Height

### DIFF
--- a/src/Runtime/Controls.Layout.Toolkit/Accordion/ExpandableContentControl.cs
+++ b/src/Runtime/Controls.Layout.Toolkit/Accordion/ExpandableContentControl.cs
@@ -383,7 +383,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
                 if (Double.IsNaN(targetWidth))
                 {
                     // NaN has the same meaning as autosize, which in this context means the desired size
-                    targetWidth = ContentSite.DesiredSize.Width;
+                    targetWidth = ContentSite.ActualWidth;
                 }
 
                 Width = Percentage * targetWidth;
@@ -395,7 +395,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
                 if (Double.IsNaN(targetHeight))
                 {
                     // NaN has the same meaning as autosize, which in this context means the desired size
-                    targetHeight = ContentSite.DesiredSize.Height;
+                    targetHeight = ContentSite.ActualHeight;
                 }
 
                 Height = Percentage * targetHeight;

--- a/src/Tests/TestApplication/TestApplication/Registry/TestRegistry.cs
+++ b/src/Tests/TestApplication/TestApplication/Registry/TestRegistry.cs
@@ -18,6 +18,7 @@ namespace TestApplication
             Tests.Add(new Test("ItemsControl", "ItemsControl"));
             Tests.Add(new Test("ComboBox", "ComboBox"));
             Tests.Add(new Test("AutoCompleteBox", "AutoCompleteBox"));
+            Tests.Add(new Test("Accordion", "Accordion"));
             Tests.Add(new Test("Negative Margin", "Negative Margin"));
             Tests.Add(new Test("LinQ", "LinQ"));
             Tests.Add(new Test("Opacity", "IsHitTestVisible Opacity"));

--- a/src/Tests/TestApplication/TestApplication/TestApplication.OpenSilver.csproj
+++ b/src/Tests/TestApplication/TestApplication/TestApplication.OpenSilver.csproj
@@ -17,6 +17,7 @@
     <Compile Include="Converters\BooleanVisibilityConverter.cs" />
     <Compile Include="HintBehavior.cs" />
     <Compile Include="LinqSamples.cs" />
+    <Compile Include="Tests\AccordionTest.xaml.cs" />
     <Compile Include="Tests\Events\TextInputTest.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -308,6 +309,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Content>
     <Content Include="Tests\AsyncAwaitTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Content>
+    <Content Include="Tests\AccordionTest.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Content>

--- a/src/Tests/TestApplication/TestApplication/TestApplication.Silverlight.csproj
+++ b/src/Tests/TestApplication/TestApplication/TestApplication.Silverlight.csproj
@@ -63,6 +63,7 @@
     <Reference Include="System.Windows.Controls.Data.Input, Version=5.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
     <Reference Include="System.Windows.Controls.Input, Version=5.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Windows.Controls.Input.Toolkit, Version=5.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Windows.Controls.Layout.Toolkit, Version=5.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Windows.Controls.Navigation, Version=5.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Windows.Controls.Toolkit, Version=5.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Windows.Interactivity">
@@ -92,6 +93,9 @@
     </Compile>
     <Compile Include="TestingChildWindow\LoginWindow.xaml.cs">
       <DependentUpon>LoginWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Tests\AccordionTest.xaml.cs">
+      <DependentUpon>AccordionTest.xaml</DependentUpon>
     </Compile>
     <Compile Include="Tests\Alignments\BottomRightTest.xaml.cs">
       <DependentUpon>BottomRightTest.xaml</DependentUpon>
@@ -358,6 +362,10 @@
     <Page Include="MainPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Tests\AccordionTest.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Tests\Alignments\BottomRightTest.xaml">
       <SubType>Designer</SubType>

--- a/src/Tests/TestApplication/TestApplication/Tests/AccordionTest.xaml
+++ b/src/Tests/TestApplication/TestApplication/Tests/AccordionTest.xaml
@@ -1,0 +1,22 @@
+﻿<sdk:Page x:Class="TestApplication.Tests.AccordionTest" 
+           xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+           xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" 
+           xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+           xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+           mc:Ignorable="d"
+           xmlns:sdk="http://schemas.microsoft.com/winfx/2006/xaml/presentation/sdk"
+           xmlns:layoutToolkit="http://schemas.microsoft.com/winfx/2006/xaml/presentation/toolkit">
+    <StackPanel Orientation="Vertical">
+        <layoutToolkit:Accordion Name="Accordion" Width="500" SelectionMode="ZeroOrMore">
+            <layoutToolkit:AccordionItem Header="First item">
+                <TextBlock Text="First content"/>
+            </layoutToolkit:AccordionItem>
+            <layoutToolkit:AccordionItem Header="Second item">
+                <TextBlock Text="Second content"/>
+            </layoutToolkit:AccordionItem>
+            <layoutToolkit:AccordionItem Header="Third item">
+                <TextBlock Text="Third content"/>
+            </layoutToolkit:AccordionItem>
+        </layoutToolkit:Accordion>
+    </StackPanel>
+</sdk:Page>

--- a/src/Tests/TestApplication/TestApplication/Tests/AccordionTest.xaml.cs
+++ b/src/Tests/TestApplication/TestApplication/Tests/AccordionTest.xaml.cs
@@ -1,0 +1,18 @@
+﻿using System.Windows.Controls;
+using System.Windows.Navigation;
+
+namespace TestApplication.Tests
+{
+    public partial class AccordionTest : Page
+    {
+        public AccordionTest()
+        {
+            InitializeComponent();
+        }
+
+        // Executes when the user navigates to this page.
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+        }
+    }
+}


### PR DESCRIPTION
DesiredSize is not available.

To test this, go to the TestApplication -> Accordion and expand items.