### PR TITLE
Remember control from position watcher to remove it on closing

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
@@ -345,6 +345,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
                     {
                         popup.OnClosed();
                         Window.Current.INTERNAL_PositionsWatcher.RemoveControlToWatch(popup._controlToWatch);
+                        popup._controlToWatch = null;
                         popup.HidePopupRootIfVisible();
                     }
                 }
@@ -357,6 +358,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
             if (PlacementTarget != null && !INTERNAL_VisualTreeManager.IsElementInVisualTree(PlacementTarget))
             {
                 Window.Current.INTERNAL_PositionsWatcher.RemoveControlToWatch(_controlToWatch);
+                _controlToWatch = null;
                 HidePopupRootIfVisible();
             }
             else if (PlacementTarget != null)

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
@@ -319,7 +319,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
                     {
                         popup.OnOpened();
 
-                        Window.Current.INTERNAL_PositionsWatcher.AddControlToWatch(targetElement, popup.RefreshPopupPosition);
+                        popup._controlToWatch = Window.Current.INTERNAL_PositionsWatcher.AddControlToWatch(targetElement, popup.RefreshPopupPosition);
                         popup.ShowPopupRootIfNotAlreadyVisible();
 
                         //We calculate the position at which the popup will be:


### PR DESCRIPTION
There is a memory leak now.
Steps to reproduce:
1. Create a popup.
2. Open it. The popup is added to the watcher
3. Close the popup. It is not removed from the watcher and the watcher continues to check position in background for closed or removed popup forever.