### PR TITLE
small speed improvements -- if only first child needed

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/ContentControl.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ContentControl.cs
@@ -231,12 +231,11 @@ namespace Windows.UI.Xaml.Controls
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            IEnumerable<DependencyObject> childElements = VisualTreeHelper.GetVisualChildren(this);
-            if (childElements.Count() > 0)
+            // ... enumerate one element only
+            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
             {
-                UIElement elementChild = ((UIElement)childElements.ElementAt(0));
-                elementChild.Measure(availableSize);
-                return elementChild.DesiredSize;
+                firstChild.Measure(availableSize);
+                return firstChild.DesiredSize;
             }
 
             Size actualSize = new Size(Double.IsNaN(Width) ? ActualWidth : Width, Double.IsNaN(Height) ? ActualHeight : Height);
@@ -245,12 +244,10 @@ namespace Windows.UI.Xaml.Controls
 
         protected override Size ArrangeOverride(Size finalSize)
         {
-
-            IEnumerable<DependencyObject> childElements = VisualTreeHelper.GetVisualChildren(this);
-            if (childElements.Count() > 0)
+            // ... enumerate one element only
+            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
             {
-                UIElement elementChild = ((UIElement)childElements.ElementAt(0));
-                elementChild.Arrange(new Rect(finalSize));
+                firstChild.Arrange(new Rect(finalSize));
             }
             return finalSize;
         }

--- a/src/Runtime/Runtime/System.Windows.Controls/ContentControl.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ContentControl.cs
@@ -231,25 +231,20 @@ namespace Windows.UI.Xaml.Controls
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            // ... enumerate one element only
-            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
+            int count = VisualChildrenCount;
+
+            if (count > 0)
             {
-                firstChild.Measure(availableSize);
-                return firstChild.DesiredSize;
+                UIElement child = GetVisualChild(0);
+                if (child != null)
+                {
+                    child.Measure(availableSize);
+                    return child.DesiredSize;
+                }
             }
 
             Size actualSize = new Size(Double.IsNaN(Width) ? ActualWidth : Width, Double.IsNaN(Height) ? ActualHeight : Height);
             return actualSize;
-        }
-
-        protected override Size ArrangeOverride(Size finalSize)
-        {
-            // ... enumerate one element only
-            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
-            {
-                firstChild.Arrange(new Rect(finalSize));
-            }
-            return finalSize;
         }
     }
 }

--- a/src/Runtime/Runtime/System.Windows.Controls/ContentPresenter.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ContentPresenter.cs
@@ -559,11 +559,16 @@ namespace Windows.UI.Xaml.Controls
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            // ... enumerate one element only
-            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
+            int count = VisualChildrenCount;
+
+            if (count > 0)
             {
-                firstChild.Measure(availableSize);
-                return firstChild.DesiredSize;
+                UIElement child = GetVisualChild(0);
+                if (child != null)
+                {
+                    child.Measure(availableSize);
+                    return child.DesiredSize;
+                }
             }
 
             if (Content == null)
@@ -571,16 +576,6 @@ namespace Windows.UI.Xaml.Controls
 
             Size actualSize = new Size(double.IsNaN(Width) ? ActualWidth : Width, double.IsNaN(Height) ? ActualHeight : Height);
             return actualSize;
-        }
-
-        protected override Size ArrangeOverride(Size finalSize) {
-            // ... enumerate one element only
-            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
-            {
-                firstChild.Arrange(new Rect(finalSize));
-            }
-
-            return finalSize;
         }
     }
 }

--- a/src/Runtime/Runtime/System.Windows.Controls/ContentPresenter.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ContentPresenter.cs
@@ -559,12 +559,11 @@ namespace Windows.UI.Xaml.Controls
 
         protected override Size MeasureOverride(Size availableSize)
         {
-            IEnumerable<DependencyObject> childElements = VisualTreeHelper.GetVisualChildren(this);
-            if (childElements.Count() > 0)
+            // ... enumerate one element only
+            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
             {
-                UIElement elementChild = ((UIElement)childElements.ElementAt(0));
-                elementChild.Measure(availableSize);
-                return elementChild.DesiredSize;
+                firstChild.Measure(availableSize);
+                return firstChild.DesiredSize;
             }
 
             if (Content == null)
@@ -574,13 +573,11 @@ namespace Windows.UI.Xaml.Controls
             return actualSize;
         }
 
-        protected override Size ArrangeOverride(Size finalSize)
-        {
-            IEnumerable<DependencyObject> childElements = VisualTreeHelper.GetVisualChildren(this);
-            if (childElements.Count() > 0)
+        protected override Size ArrangeOverride(Size finalSize) {
+            // ... enumerate one element only
+            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
             {
-                UIElement elementChild = ((UIElement)childElements.ElementAt(0));
-                elementChild.Arrange(new Rect(finalSize));
+                firstChild.Arrange(new Rect(finalSize));
             }
 
             return finalSize;

--- a/src/Runtime/Runtime/System.Windows.Controls/Control.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Control.cs
@@ -1166,16 +1166,11 @@ void Control_PointerReleased(object sender, Input.PointerRoutedEventArgs e)
         }
         protected override Size MeasureOverride(Size availableSize)
         {
-            IEnumerable<DependencyObject> childElements = VisualTreeHelper.GetVisualChildren(this);
-            if (childElements.Count() == 0)
-            {
-                return new Size();
-            }
-
             Size extent = new Size(0.0, 0.0);
-
-            foreach (DependencyObject child in childElements)
-            {
+            var anyChild = false;
+            // ... enumerate only once
+            foreach (DependencyObject child in VisualTreeHelper.GetVisualChildren(this)) {
+                anyChild = true;
                 if (child as FrameworkElement == null)
                     continue;
 
@@ -1184,7 +1179,7 @@ void Control_PointerReleased(object sender, Input.PointerRoutedEventArgs e)
                 extent.Width += childElement.DesiredSize.Width;
                 extent.Height += childElement.DesiredSize.Height;
             }
-            return extent;
+            return anyChild ? extent : new Size();
         }
 
     }

--- a/src/Runtime/Runtime/System.Windows.Controls/Control.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Control.cs
@@ -1166,20 +1166,19 @@ void Control_PointerReleased(object sender, Input.PointerRoutedEventArgs e)
         }
         protected override Size MeasureOverride(Size availableSize)
         {
-            Size extent = new Size(0.0, 0.0);
-            var anyChild = false;
-            // ... enumerate only once
-            foreach (DependencyObject child in VisualTreeHelper.GetVisualChildren(this)) {
-                anyChild = true;
-                if (child as FrameworkElement == null)
-                    continue;
+            int count = VisualChildrenCount;
 
-                FrameworkElement childElement = child as FrameworkElement; 
-                childElement.Measure(availableSize);
-                extent.Width += childElement.DesiredSize.Width;
-                extent.Height += childElement.DesiredSize.Height;
+            if (count > 0)
+            {
+                UIElement child = GetVisualChild(0);
+                if (child != null)
+                {
+                    child.Measure(availableSize);
+                    return child.DesiredSize;
+                }
             }
-            return anyChild ? extent : new Size();
+
+            return new Size(0.0, 0.0);
         }
 
     }

--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
@@ -1275,12 +1275,10 @@ namespace Windows.UI.Xaml
         //     The actual size that is used after the element is arranged in layout.
         protected virtual Size ArrangeOverride(Size finalSize)
         {
-            IEnumerable<DependencyObject> childElements = VisualTreeHelper.GetVisualChildren(this);
-
-            if (childElements.Count() > 0)
+            // ... enumerate one element only
+            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
             {
-                UIElement elementChild = ((UIElement)childElements.ElementAt(0));
-                elementChild.Arrange(new Rect(finalSize));
+                firstChild.Arrange(new Rect(finalSize));
                 return finalSize;
             }
 

--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
@@ -1275,13 +1275,16 @@ namespace Windows.UI.Xaml
         //     The actual size that is used after the element is arranged in layout.
         protected virtual Size ArrangeOverride(Size finalSize)
         {
-            // ... enumerate one element only
-            if (VisualTreeHelper.GetVisualChildren(this).FirstOrDefault() is UIElement firstChild)
-            {
-                firstChild.Arrange(new Rect(finalSize));
-                return finalSize;
-            }
+            int count = VisualChildrenCount;
 
+            if (count > 0)
+            {
+                UIElement child = GetVisualChild(0);
+                if (child != null)
+                {
+                    child.Arrange(new Rect(finalSize));
+                }
+            }
             return finalSize;
         }
 


### PR DESCRIPTION
Calling .Count() would enumerate all type's interfaces (reflection) to see if it can find .Count, and then call it (via reflection, again)