### PR TITLE
feat: show ComboBox drop down when toggle button is not available

### DIFF
--- a/src/Runtime/Runtime/Core/Rendering/INTERNAL_PopupsManager.cs
+++ b/src/Runtime/Runtime/Core/Rendering/INTERNAL_PopupsManager.cs
@@ -97,7 +97,12 @@ namespace DotNetForHtml5.Core // Important: do not rename this class without upd
 
             foreach (Popup popup in listOfPopupThatMustBeClosed)
             {
-                popup.CloseFromAnOutsideClick();
+                var args = new OutsideClickEventArgs();
+                popup.OnOutsideClick(args);
+                if (!args.Handled)
+                {
+                    popup.CloseFromAnOutsideClick();
+                }
             }
 
         }

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
@@ -699,12 +699,15 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
         internal void CloseFromAnOutsideClick()
         {
-            if (ClosedDueToOutsideClick != null)
-                ClosedDueToOutsideClick(this, new EventArgs());
+            ClosedDueToOutsideClick?.Invoke(this, EventArgs.Empty);
 
             if (IsOpen)
                 this.IsOpen = false;
         }
+
+        internal event EventHandler<OutsideClickEventArgs> OutsideClick;
+
+        internal void OnOutsideClick(OutsideClickEventArgs args) => OutsideClick?.Invoke(this, args);
 
         private bool _stayOpen = true;
         public bool StayOpen
@@ -798,5 +801,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
         {
             INTERNAL_PopupsManager.EnsurePopupStaysWithinScreenBounds(this, forcedWidth, forcedHeight);
         }
+    }
+
+    internal class OutsideClickEventArgs : EventArgs
+    {
+        public bool Handled { get; set; }
     }
 }

--- a/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
@@ -18,9 +18,11 @@ using System;
 using System.Threading.Tasks;
 
 #if MIGRATION
+using System.Windows.Input;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 #else
+using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 #endif
@@ -55,6 +57,7 @@ namespace Windows.UI.Xaml.Controls
         private ToggleButton _dropDownToggle;
         private ContentPresenter _contentPresenter;
         private FrameworkElement _emptyContent;
+        private bool _suppressCloseOnOutsideClick;
 
         [Obsolete("ComboBox does not support Native ComboBox. Use 'CSHTML5.Native.Html.Controls.NativeComboBox' instead.")]
         public bool UseNativeComboBox
@@ -151,7 +154,11 @@ namespace Windows.UI.Xaml.Controls
             base.OnApplyTemplate();
 
             if (_popup != null)
+            {
+                _popup.PlacementTarget = null;
+                _popup.OutsideClick -= OnOutsideClick;
                 _popup.ClosedDueToOutsideClick -= Popup_ClosedDueToOutsideClick; // Note: we do this here rather than at "OnDetached" because it may happen that the popup is closed after the ComboBox has been removed from the visual tree (in which case, when putting it back into the visual tree, we want the drop down to be in its initial closed state).
+            }
 
             _popup = GetTemplateChild("Popup") as Popup;
           
@@ -180,7 +187,7 @@ namespace Windows.UI.Xaml.Controls
             }
 
             //todo: once we will have made the following properties (PlacementTarget and Placement) Dependencyproperties, unset it here and set it in the default style.
-            _popup.PlacementTarget = _dropDownToggle;
+            _popup.PlacementTarget = this;
             _popup.Placement = PlacementMode.Bottom;
             _popup.INTERNAL_PopupMoved += _popup_INTERNAL_PopupMoved;
 
@@ -194,10 +201,42 @@ namespace Windows.UI.Xaml.Controls
             if (_popup != null)
             {
                 _popup.StayOpen = false;
+                _popup.OutsideClick += OnOutsideClick;
                 _popup.ClosedDueToOutsideClick += Popup_ClosedDueToOutsideClick;
             }
             
             UpdatePresenter();
+        }
+
+        /// <summary>
+        /// Provides handling for the <see cref="UIElement.MouseLeftButtonDown"/> event
+        /// that occurs when the left mouse button is pressed while the mouse pointer is
+        /// over the combo box.
+        /// </summary>
+        /// <param name="e">
+        /// The event data.
+        /// </param>
+#if MIGRATION
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+#else
+        protected override void OnPointerPressed(PointerRoutedEventArgs e)
+#endif
+        {
+#if MIGRATION
+            base.OnMouseLeftButtonDown(e);
+#else
+            base.OnPointerPressed(e);
+#endif
+
+            if (e.Handled)
+            {
+                return;
+            }
+
+            e.Handled = true;
+
+            _suppressCloseOnOutsideClick = true;
+            IsDropDownOpen = true;
         }
 
         /// <inheritdoc />
@@ -334,7 +373,7 @@ namespace Windows.UI.Xaml.Controls
                     // Show the popup:
                     if (comboBox._popup != null)
                     {
-                        // add removed 
+                        // add removed
 
                         comboBox._popup.IsOpen = true;
 
@@ -411,6 +450,15 @@ namespace Windows.UI.Xaml.Controls
         /// </summary>
         public static readonly DependencyProperty MaxDropDownHeightProperty =
             DependencyProperty.Register("MaxDropDownHeight", typeof(double), typeof(ComboBox), new PropertyMetadata(200d));
+
+        private void OnOutsideClick(object sender, OutsideClickEventArgs e)
+        {
+            if (_suppressCloseOnOutsideClick)
+            {
+                e.Handled = true;
+                _suppressCloseOnOutsideClick = false;
+            }
+        }
 
         void Popup_ClosedDueToOutsideClick(object sender, EventArgs e)
         {

--- a/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
@@ -19,8 +19,10 @@ using System.Threading.Tasks;
 
 #if MIGRATION
 using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 #else
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Input;
 #endif
 
 #if MIGRATION
@@ -261,6 +263,23 @@ namespace Windows.UI.Xaml.Controls
         {
             if (DropDownOpened != null)
                 DropDownOpened(this, e);
+        }
+
+#if MIGRATION
+        protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
+#else
+        protected override void OnPointerReleased(PointerRoutedEventArgs e)
+#endif
+        {
+            IsDropDownOpen = !IsDropDownOpen;
+
+            e.Handled = true;
+
+#if MIGRATION
+            base.OnMouseLeftButtonUp(e);
+#else
+            base.OnPointerReleased(e);
+#endif
         }
 
         /// <summary>

--- a/src/Tests/TestApplication/TestApplication/Registry/TestRegistry.cs
+++ b/src/Tests/TestApplication/TestApplication/Registry/TestRegistry.cs
@@ -18,11 +18,8 @@ namespace TestApplication
             Tests.Add(new Test("ItemsControl", "ItemsControl"));
             Tests.Add(new Test("ComboBox", "ComboBox"));
             Tests.Add(new Test("AutoCompleteBox", "AutoCompleteBox"));
-<<<<<<< HEAD
             Tests.Add(new Test("TimePicker", "TimePicker"));
-=======
             Tests.Add(new Test("Accordion", "Accordion"));
->>>>>>> develop
             Tests.Add(new Test("Negative Margin", "Negative Margin"));
             Tests.Add(new Test("LinQ", "LinQ"));
             Tests.Add(new Test("Opacity", "IsHitTestVisible Opacity"));

--- a/src/Tests/TestApplication/TestApplication/Registry/TestRegistry.cs
+++ b/src/Tests/TestApplication/TestApplication/Registry/TestRegistry.cs
@@ -18,8 +18,11 @@ namespace TestApplication
             Tests.Add(new Test("ItemsControl", "ItemsControl"));
             Tests.Add(new Test("ComboBox", "ComboBox"));
             Tests.Add(new Test("AutoCompleteBox", "AutoCompleteBox"));
+<<<<<<< HEAD
             Tests.Add(new Test("TimePicker", "TimePicker"));
+=======
             Tests.Add(new Test("Accordion", "Accordion"));
+>>>>>>> develop
             Tests.Add(new Test("Negative Margin", "Negative Margin"));
             Tests.Add(new Test("LinQ", "LinQ"));
             Tests.Add(new Test("Opacity", "IsHitTestVisible Opacity"));

--- a/src/Tests/TestApplication/TestApplication/Tests/ComboBoxTest.xaml
+++ b/src/Tests/TestApplication/TestApplication/Tests/ComboBoxTest.xaml
@@ -28,6 +28,56 @@
             <TextBlock Text="SelectedItem:"/>
             <TextBlock Margin="5,0,0,0" Text="{Binding ElementName=ComboBox1, Path=SelectedItem}"/>
         </StackPanel>
+
+        <TextBlock Text="ComboBox styled to not have a ToggleButton (still shows DropDown in Silverlight):"/>
+        <ComboBox x:Name="ComboBoxWithoutToggleButton" Width="150">
+            <ComboBox.Style>
+                <Style TargetType="ComboBox" x:Name="ComboBoxStyle">
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="ComboBox">
+                                <Grid>
+                                    <Border x:Name="ContentPresenterBorder" CornerRadius="2">
+                                        <Grid Margin="0,0,7,0">
+                                            <Border x:Name="Border" CornerRadius="2" Opacity="1"
+                                            Background="{TemplateBinding Background}">
+                                                <Grid Margin="0">
+                                                    <ToggleButton x:Name="DropDownToggle"
+                                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                                            HorizontalAlignment="Stretch" HorizontalContentAlignment="Right"
+                                                            Margin="0"
+                                                            VerticalAlignment="Stretch" Background="#001F3B53" Visibility="Collapsed"/>
+                                                    <ContentPresenter x:Name="ContentPresenter"
+                                                                HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                                Margin="{TemplateBinding Padding}">
+                                                        <TextBlock Text=" " />
+                                                    </ContentPresenter>
+                                                </Grid>
+                                            </Border>
+                                        </Grid>
+                                    </Border>
+                                    <Popup x:Name="Popup">
+                                        <Border x:Name="PopupBorder" HorizontalAlignment="Stretch" 
+                                        Padding="0,2,0,3" Background="Transparent">
+                                            <ScrollViewer x:Name="ScrollViewer"
+                                                    MaxHeight="324"
+                                                    HorizontalScrollBarVisibility="Disabled">
+                                                <ItemsPresenter Margin="0,0,7,0" />
+                                            </ScrollViewer>
+                                        </Border>
+                                    </Popup>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ComboBox.Style>
+            <ComboBoxItem>First item</ComboBoxItem>
+            <ComboBoxItem>Second item</ComboBoxItem>
+            <ComboBoxItem>Third item</ComboBoxItem>
+        </ComboBox>
     </StackPanel>
     
 </sdk:Page>


### PR DESCRIPTION
Custom style can make DropDownToggleButton not have Content,
but Silverlight still shows the DropDown on ComboBox MouseLeftDown.

To test, go to TestApplication -> ComboBox page and click on the ComboBox labeled to not have a toggle button and still see the dropdown (as the same in Silverlight).