### PR TITLE
Add a separate step to validate building of Test Application

### DIFF
--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -55,6 +55,8 @@ jobs:
         run: dotnet test src/Tests/Runtime.OpenSilver.Tests/bin/SL/net472/Runtime.OpenSilver.Tests.dll
       - name: Run Analyzers Tests Configuration
         run: dotnet test src/Analyzers/NotImplemented.Tests/bin/Debug/net472/OpenSilver.Analyzers.Tests.dll
+      - name: Verify Building of TestApplication
+        run: msbuild src/Tests/TestApplication/TestApplication.OpenSilver.sln -p:Configuration=Release -clp:ErrorsOnly -restore
       - name: Drop all bin and obj folders
         run: 'find . -iname "bin" -o -iname "obj" | xargs rm -rf'
         shell: bash


### PR DESCRIPTION
Previously it was a part of OpenSilver.sln, but we do not build the TestApplication with OpenSilver.sln now.
