### PR TITLE
Prevent redundant updates of binding value

### DIFF
--- a/src/Runtime/Runtime/OpenSilver/Internal/Data/PropertyPathNode.cs
+++ b/src/Runtime/Runtime/OpenSilver/Internal/Data/PropertyPathNode.cs
@@ -54,7 +54,7 @@ namespace OpenSilver.Internal.Data
 
         private void SetSource(object source, bool sourceIsCurrentItem)
         {
-            var needToUpdateValue = source != _source;
+            var needToUpdateValue = source != _source || Value == DependencyProperty.UnsetValue;
             UpdateSource(source, sourceIsCurrentItem);
 
             if (needToUpdateValue)

--- a/src/Runtime/Runtime/OpenSilver/Internal/Data/PropertyPathNode.cs
+++ b/src/Runtime/Runtime/OpenSilver/Internal/Data/PropertyPathNode.cs
@@ -54,9 +54,13 @@ namespace OpenSilver.Internal.Data
 
         private void SetSource(object source, bool sourceIsCurrentItem)
         {
+            var needToUpdateValue = source != _source;
             UpdateSource(source, sourceIsCurrentItem);
 
-            UpdateValue();
+            if (needToUpdateValue)
+            {
+                UpdateValue();
+            }
 
             if (Next != null)
             {

--- a/src/Runtime/Runtime/System.Windows/Settings.cs
+++ b/src/Runtime/Runtime/System.Windows/Settings.cs
@@ -87,7 +87,7 @@ namespace System
         /// <summary>
         /// When True, do not apply the CSS properties of the UI elements that are not visible.
         /// Those property are applied later, when the control becomes visible.
-        /// Enabling this option results in improved performance.
+        /// Enabling this option results in improved performance. It is enabled by default.
         /// </summary>
         public bool EnableOptimizationWhereCollapsedControlsAreNotRendered
         {


### PR DESCRIPTION
Fix bug, that property getter is called two times from binding, but has to be called only once. This causes unexpected behaviour of client code, if it contains additional logic in getters

Minimal reproducible example: https://github.com/avdynut/SL_OS_Test/tree/get-property-value