### PR TITLE
Memory leak in the dispatcher

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Threading/CoreDispatcher.cs
+++ b/src/Runtime/Runtime/System.Windows.Threading/CoreDispatcher.cs
@@ -135,8 +135,9 @@ namespace Windows.UI.Core
                     return;
                 }
 
-                Task.Run(() =>
+                Task.Run(async () =>
                 {
+                    await Task.Delay(1);
                     try
                     {
                         method();

--- a/src/Runtime/Runtime/System.Windows.Threading/CoreDispatcher.cs
+++ b/src/Runtime/Runtime/System.Windows.Threading/CoreDispatcher.cs
@@ -23,6 +23,7 @@ using CSHTML5.Internal;
 using DotNetForHtml5.Core;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 #if !MIGRATION
 using Windows.Foundation;
 #endif
@@ -134,18 +135,18 @@ namespace Windows.UI.Core
                     return;
                 }
 
-                CSHTML5.Interop.ExecuteJavaScriptAsync("setTimeout($0, 1)",
-                    (Action)(() =>
+                Task.Run(() =>
+                {
+                    try
                     {
-                        try
-                        {
-                            method();
-                        }
-                        catch (Exception e)
-                        {
-                            Console.Error.WriteLine("DEBUG: CoreDispatcher: BeginIvokeInternal: Method excution failed: " + e);
-                        }
-                    }));
+                        method();
+                    }
+                    catch (Exception e)
+                    {
+                        Console.Error.WriteLine("DEBUG: CoreDispatcher: BeginIvokeInternal: Method excution failed: " +
+                                                e);
+                    }
+                });
             }
             else
             {

--- a/src/Tests/Runtime.OpenSilver.Tests/Maintenance/MemoryLeak/ItemWithTrackableCallback.cs
+++ b/src/Tests/Runtime.OpenSilver.Tests/Maintenance/MemoryLeak/ItemWithTrackableCallback.cs
@@ -1,0 +1,40 @@
+﻿
+/*===================================================================================
+*
+*   Copyright (c) Userware/OpenSilver.net
+*
+*   This file is part of the OpenSilver Runtime (https://opensilver.net), which is
+*   licensed under the MIT license: https://opensource.org/licenses/MIT
+*
+*   As stated in the MIT license, "the above copyright notice and this permission
+*   notice shall be included in all copies or substantial portions of the Software."
+*
+\*====================================================================================*/
+
+
+using System.Threading;
+
+namespace Runtime.OpenSilver.Tests.Maintenance.MemoryLeak
+{
+    class ItemWithTrackableCallback
+    {
+        private readonly GarbageCollectorTracker _gcTracker;
+        private readonly ManualResetEvent _manualResetEvent;
+
+        public ItemWithTrackableCallback(GarbageCollectorTracker gcTracker, ManualResetEvent manualResetEvent)
+        {
+            _gcTracker = gcTracker;
+            _manualResetEvent = manualResetEvent;
+        }
+
+        ~ItemWithTrackableCallback()
+        {
+            _gcTracker.Collected = true;
+        }
+
+        public void Callback()
+        {
+            _manualResetEvent.Set();
+        }
+    }
+}

--- a/src/Tests/Runtime.OpenSilver.Tests/Maintenance/MemoryLeak/MemoryLeakTest.cs
+++ b/src/Tests/Runtime.OpenSilver.Tests/Maintenance/MemoryLeak/MemoryLeakTest.cs
@@ -13,14 +13,17 @@
 
 
 using System;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 #if MIGRATION
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Threading;
 #else
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Core;
 #endif
 
 namespace Runtime.OpenSilver.Tests.Maintenance.MemoryLeak
@@ -36,14 +39,40 @@ namespace Runtime.OpenSilver.Tests.Maintenance.MemoryLeak
             mainWindow.Content = new Grid();
         }
 
+        private void InvokeCoreDispatcher(GarbageCollectorTracker c)
+        {
+            var resetEvent = new ManualResetEvent(false);
+            var trackableCallback = new ItemWithTrackableCallback(c, resetEvent);
+#if MIGRATION
+            Dispatcher.INTERNAL_GetCurrentDispatcher().BeginInvoke(trackableCallback.Callback);
+#else
+            CoreDispatcher.INTERNAL_GetCurrentDispatcher().BeginInvoke(trackableCallback.Callback);
+#endif
+            resetEvent.WaitOne(5000);
+        }
+
+        private static void CollectGarbage()
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
         [TestMethod]
         public void Grid_Must_Be_Collected()
         {
             var c = new GarbageCollectorTracker();
             CreateRemoveGrid(c);
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
+            CollectGarbage();
+            Assert.IsTrue(c.Collected);
+        }
+
+        [TestMethod]
+        public void CoreDispatcher_Should_Release_Callback()
+        {
+            var c = new GarbageCollectorTracker();
+            InvokeCoreDispatcher(c);
+            CollectGarbage();
             Assert.IsTrue(c.Collected);
         }
     }


### PR DESCRIPTION
Replace CSHTML5.Interop.ExecuteJavaScriptAsync by Task.Run for the dispatcher.
It fixes memory leak and removes redundancy: it is not necessary to call JavaScript side for async execution.
