### PR TITLE
Prevent null exception on Focus()

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Control.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Control.cs
@@ -775,7 +775,7 @@ namespace Windows.UI.Xaml.Controls
         /// </returns>
         public bool Focus()
         {
-            if (Keyboard.IsFocusable(this) && IsConnectedToLiveTree)
+            if (Keyboard.IsFocusable(this))
             {
                 INTERNAL_HtmlDomManager.SetFocus(this);
                 

--- a/src/Runtime/Runtime/System.Windows.Controls/Control.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Control.cs
@@ -775,7 +775,7 @@ namespace Windows.UI.Xaml.Controls
         /// </returns>
         public bool Focus()
         {
-            if (Keyboard.IsFocusable(this))
+            if (Keyboard.IsFocusable(this) && IsConnectedToLiveTree)
             {
                 INTERNAL_HtmlDomManager.SetFocus(this);
                 

--- a/src/Runtime/Runtime/System.Windows.input/Keyboard.cs
+++ b/src/Runtime/Runtime/System.Windows.input/Keyboard.cs
@@ -35,6 +35,6 @@ namespace System.Windows.Input
             => (ModifierKeys)Convert.ToInt32(OpenSilver.Interop.ExecuteJavaScript("document.modifiersPressed"));
 
         internal static bool IsFocusable(Control control)
-            => control.IsVisible && control.IsEnabled && control.IsTabStop;
+            => control.IsConnectedToLiveTree && control.IsVisible && control.IsEnabled && control.IsTabStop;
     }
 }


### PR DESCRIPTION
In our project there is a case when FocusManager.SetFocusedElement() throws exception because of null INTERNAL_ParentWindow