### PR TITLE
Prevent progressive loading from throwing IndexOutOfRangeException

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Panel.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Panel.cs
@@ -613,6 +613,10 @@ namespace Windows.UI.Xaml.Controls
 
                 for (int i = from; i < to; ++i)
                 {
+                    if (i >= newChildren.Count)
+                    {
+                        return; // in some cases Children collection can be changed during attach process
+                    }
                     INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(newChildren[i], this, i);
                 }
 


### PR DESCRIPTION
In our project exception happens when child window with information message appears for a few seconds