### PR TITLE
Prevent text selection on dragdroptarget

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/DragDropTarget_2.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/DragDropTarget_2.cs
@@ -550,15 +550,8 @@ namespace Windows.UI.Xaml.Controls
         {
             base.INTERNAL_OnAttachedToVisualTree();
 
-#if OPENSILVER
-            if (false)
-#elif BRIDGE
-            if (!CSHTML5.Interop.IsRunningInTheSimulator)
-#endif
-            {
-                // Prevent the selection of text while dragging from the DragDropTarget
-                CSHTML5.Interop.ExecuteJavaScriptAsync("$0.onselectstart = function() { return false; }", this.INTERNAL_OuterDomElement);
-            }
+            // Prevent the selection of text while dragging from the DragDropTarget
+            OpenSilver.Interop.ExecuteJavaScriptAsync("$0.style.userSelect = 'none'", this.INTERNAL_OuterDomElement);
         }
 
 


### PR DESCRIPTION
If a `ListBoxItem` contains a `TextBox` inside it, it is not focusable because of `onselectstart` (if used with #241). So use `user-select` property instead to prevent text selection on labels but allow textbox focusing