### PR TITLE
Use Async call when enabling/disabling focus

### DIFF
--- a/src/Runtime/Runtime/System.Windows/UIElement_Events.cs
+++ b/src/Runtime/Runtime/System.Windows/UIElement_Events.cs
@@ -1003,7 +1003,7 @@ namespace Windows.UI.Xaml
             object target = GetFocusTarget();
             if (target != null)
             {
-                OpenSilver.Interop.ExecuteJavaScriptAsync($"document.enableFocus(\"{((INTERNAL_HtmlDomElementReference)target).UniqueIdentifier}\")");
+                OpenSilver.Interop.ExecuteJavaScriptFastAsync($"document.enableFocus(\"{((INTERNAL_HtmlDomElementReference)target).UniqueIdentifier}\")");
             }
         }
 
@@ -1012,7 +1012,7 @@ namespace Windows.UI.Xaml
             object target = GetFocusTarget();
             if (target != null)
             {
-                OpenSilver.Interop.ExecuteJavaScriptAsync($"document.disableFocus(\"{((INTERNAL_HtmlDomElementReference)target).UniqueIdentifier}\")");
+                OpenSilver.Interop.ExecuteJavaScriptFastAsync($"document.disableFocus(\"{((INTERNAL_HtmlDomElementReference)target).UniqueIdentifier}\")");
             }
         }
 

--- a/src/Runtime/Runtime/System.Windows/UIElement_Events.cs
+++ b/src/Runtime/Runtime/System.Windows/UIElement_Events.cs
@@ -1003,7 +1003,7 @@ namespace Windows.UI.Xaml
             object target = GetFocusTarget();
             if (target != null)
             {
-                OpenSilver.Interop.ExecuteJavaScript($"document.enableFocus(\"{((INTERNAL_HtmlDomElementReference)target).UniqueIdentifier}\")");
+                OpenSilver.Interop.ExecuteJavaScriptAsync($"document.enableFocus(\"{((INTERNAL_HtmlDomElementReference)target).UniqueIdentifier}\")");
             }
         }
 
@@ -1012,7 +1012,7 @@ namespace Windows.UI.Xaml
             object target = GetFocusTarget();
             if (target != null)
             {
-                OpenSilver.Interop.ExecuteJavaScript($"document.disableFocus(\"{((INTERNAL_HtmlDomElementReference)target).UniqueIdentifier}\")");
+                OpenSilver.Interop.ExecuteJavaScriptAsync($"document.disableFocus(\"{((INTERNAL_HtmlDomElementReference)target).UniqueIdentifier}\")");
             }
         }
 


### PR DESCRIPTION
`enableFocus/disableFocus` is being called many times so it would be better to have asynchronous calls.