### PR TITLE
Handle the case with empty function name for the typescript generator

### DIFF
--- a/src/Compiler/Compiler.TypeScriptDefToCSharp/Model/Function.cs
+++ b/src/Compiler/Compiler.TypeScriptDefToCSharp/Model/Function.cs
@@ -127,7 +127,7 @@ namespace TypeScriptDefToCSharp.Model
                 jsObj.Append(classPath);
             // Else call with $0 ($0 will be this.UnderlyingJSInstance here)
             else
-                jsObj.Append("$0.");
+                jsObj.Append(string.IsNullOrWhiteSpace(this.Name) ? "$0" : "$0.");
             jsObj.Append(this.Name)
                  .Append("(");
 


### PR DESCRIPTION
For example, if we have the following typescript typings:
```
interface UrlStatic {
    (): string;
}
```
In this case, the correct typescript output would be:
`Interop.ExecuteJavaScript("$0()", this.UnderlyingJSInstance) `
instead of
`Interop.ExecuteJavaScript("$0.()", this.UnderlyingJSInstance) `
