### PR TITLE
Make internals visible to OpenSilver.ControlsKit.FastControls

### DIFF
--- a/src/Runtime/Runtime/Properties/AssemblyInfo.cs
+++ b/src/Runtime/Runtime/Properties/AssemblyInfo.cs
@@ -55,6 +55,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("CSharpXamlForHtml5.Simulator")]
 #endif
 [assembly: InternalsVisibleTo("Runtime.OpenSilver.Tests")]
+[assembly: InternalsVisibleTo("OpenSilver.ControlsKit.FastControls")]
 
 [assembly: System.Windows.Markup.XmlnsDefinition("http://schemas.microsoft.com/winfx/2006/xaml", "System.Windows.Markup")] // This is used for example in the {x:Static ...} markup extension.
 


### PR DESCRIPTION
Is it ok to give access to internals for the OpenSilver.ControlsKit.FastControls lib?