### PR TITLE
Fix Textbox sizing under custom layout

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
@@ -591,6 +591,8 @@ element_OutsideEventHandler.addEventListener('paste', function(e) {{
                 text = text.Replace('\n', '\0').Replace('\r', '\0');
             }
 
+            // This is the case when the text is changed by backspace or paste.
+            InvalidateMeasure();
             return text;
         }
 
@@ -610,6 +612,9 @@ element_OutsideEventHandler.addEventListener('paste', function(e) {{
                 return;
 
             INTERNAL_HtmlDomManager.SetContentString(this, Host.Text);
+
+            // This is the case when the text is changed by typing.
+            InvalidateMeasure();
         }
 
         private void TextBoxView_GotFocus(object e)


### PR DESCRIPTION
TextBox width was not changing when type or delete text.

```
    <Border HorizontalAlignment="Left">
        <TextBox Height="20" Text="1234" CustomLayout="True"/>
    </Border>
```