### PR TITLE
Provide correct source for _valueErrorsChangedListener

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Data/BindingExpression.cs
+++ b/src/Runtime/Runtime/System.Windows.Data/BindingExpression.cs
@@ -408,7 +408,7 @@ namespace Windows.UI.Xaml.Data
 
                 if (_dataErrorValue != null)
                 {
-                    _valueErrorsChangedListener = new(this, _dataErrorSource)
+                    _valueErrorsChangedListener = new(this, _dataErrorValue)
                     {
                         OnEventAction = static (instance, source, args) => instance.OnValueErrorsChanged(source, args),
                         OnDetachAction = static (listener, source) => source.ErrorsChanged -= listener.OnEvent,


### PR DESCRIPTION
In some cases DataContext was null, because WeakEventListener was throwing ArgumentNullException