### PR TITLE
fix: ability to change UIElement.Effect

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Media.Effects/BlurEffect.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Effects/BlurEffect.cs
@@ -76,5 +76,14 @@ namespace System.Windows.Media.Effects
                 domStyle.filter = $"blur({cssRadius.ToInvariantString()}px)";
             }
         }
+
+        internal override void Discard(UIElement renderTarget)
+        {
+            if (renderTarget != null && INTERNAL_VisualTreeManager.IsElementInVisualTree(renderTarget))
+            {
+                var domStyle = INTERNAL_HtmlDomManager.GetFrameworkElementOuterStyleForModification(renderTarget);
+                domStyle.filter = "";
+            }
+        }
     }
 }

--- a/src/Runtime/Runtime/System.Windows.Media.Effects/DropShadowEffect.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Effects/DropShadowEffect.cs
@@ -188,5 +188,24 @@ namespace System.Windows.Media.Effects
                 }
             }
         }
+
+        internal override void Discard(UIElement renderTarget)
+        {
+            if (renderTarget != null && INTERNAL_VisualTreeManager.IsElementInVisualTree(renderTarget))
+            {
+                var domStyle = INTERNAL_HtmlDomManager.GetFrameworkElementOuterStyleForModification(renderTarget);
+
+                if (renderTarget is TextBlock)
+                {
+                    domStyle.textShadow = "";
+                }
+                else
+                {
+                    domStyle.boxShadow = "";
+                    domStyle.borderCollapse = "";
+                    domStyle.borderSpacing = "";
+                }
+            }
+        }
     }
 }

--- a/src/Runtime/Runtime/System.Windows.Media.Effects/Effect.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Effects/Effect.cs
@@ -56,5 +56,7 @@ namespace System.Windows.Media.Effects
         internal void RaiseChanged() => Changed?.Invoke(this, EventArgs.Empty);
 
         internal virtual void Render(UIElement renderTarget) { }
+
+        internal virtual void Discard(UIElement renderTarget) { }
     }
 }

--- a/src/Runtime/Runtime/System.Windows/UIElement.cs
+++ b/src/Runtime/Runtime/System.Windows/UIElement.cs
@@ -519,10 +519,7 @@ namespace Windows.UI.Xaml
                 nameof(Effect),
                 typeof(Effect),
                 typeof(UIElement),
-                new PropertyMetadata(null, OnEffectChanged)
-                {
-                    MethodToUpdateDom = (d, e) => ((Effect)e)?.Render((UIElement)d)
-                });
+                new PropertyMetadata(null, OnEffectChanged));
 
         // todo: we may add the support for multiple effects on the same 
         // UIElement since it is possible in html (but not in wpf). If we 
@@ -553,6 +550,11 @@ namespace Windows.UI.Xaml
                 element._effectChangedListener = null;
             }
 
+            if (e.OldValue is Effect oldEffect && e.NewValue?.GetType() != oldEffect.GetType())
+            {
+                oldEffect.Discard(element);
+            }
+
             if (e.NewValue is Effect newEffect)
             {
                 element._effectChangedListener = new(element, newEffect)
@@ -561,6 +563,7 @@ namespace Windows.UI.Xaml
                     OnDetachAction = static (listener, source) => source.Changed -= listener.OnEvent,
                 };
                 newEffect.Changed += element._effectChangedListener.OnEvent;
+                newEffect.Render(element);
             }
         }
 


### PR DESCRIPTION
Effects were applying one upon other, in Silverlight we can apply only one effect, and can clear it by setting to null