### PR TITLE
Fix validation for a case when path contains more than one node

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Data/BindingExpression.cs
+++ b/src/Runtime/Runtime/System.Windows.Data/BindingExpression.cs
@@ -613,7 +613,7 @@ namespace Windows.UI.Xaml.Data
 
         private void OnSourceErrorsChanged(object sender, DataErrorsChangedEventArgs e)
         {
-            if (e.PropertyName == _propertyPathWalker.FirstNode.PropertyName)
+            if (e.PropertyName == _propertyPathWalker.FinalNode.PropertyName)
             {
                 UpdateNotifyDataErrors(_dataErrorSource, e.PropertyName, DependencyProperty.UnsetValue);
             }


### PR DESCRIPTION
For example `<TextBox Text="{Binding Test.FirstName, Mode=TwoWay, NotifyOnValidationError=True}"/>`