### PR TITLE
Support type conversions in XamlReader

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Media.Animation/KeyTime.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/KeyTime.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 
 #if MIGRATION
 namespace System.Windows.Media.Animation
@@ -22,6 +23,7 @@ namespace Windows.UI.Xaml.Media.Animation
     /// <summary>
     /// Specifies when a particular key frame should take place during an animation.
     /// </summary>
+    [TypeConverter(typeof(KeyTimeConverter))]
     public partial struct KeyTime
     {
         internal KeyTime(TimeSpan timeSpan)

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/RepeatBehavior.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/RepeatBehavior.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Text;
 
 #if MIGRATION
@@ -26,6 +27,7 @@ namespace Windows.UI.Xaml.Media.Animation
     /// <summary>
     /// Describes how a <see cref="Timeline"/> repeats its simple duration.
     /// </summary>
+    [TypeConverter(typeof(RepeatBehaviorConverter))]
     public struct RepeatBehavior : IFormattable
     {
         private double _iterationCount;

--- a/src/Runtime/Runtime/System.Windows.Media/Brush.cs
+++ b/src/Runtime/Runtime/System.Windows.Media/Brush.cs
@@ -13,6 +13,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using CSHTML5.Internal;
 
@@ -26,6 +27,7 @@ namespace Windows.UI.Xaml.Media
     /// Defines objects used to paint graphical objects. Classes that derive from
     /// Brush describe how the area is painted.
     /// </summary>
+    [TypeConverter(typeof(BrushConverter))]
     public partial class Brush : DependencyObject,
         IHasAccessToPropertiesWhereItIsUsed2,
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Runtime/Runtime/System.Windows.Media/Color.cs
+++ b/src/Runtime/Runtime/System.Windows.Media/Color.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.Text;
 using OpenSilver.Internal;
@@ -29,6 +30,7 @@ namespace Windows.UI
     /// <summary>
     /// Describes a color in terms of alpha, red, green, and blue channels.
     /// </summary>
+    [TypeConverter(typeof(ColorConverter))]
     public struct Color : IFormattable
     {
         internal static Color INTERNAL_ConvertFromInt32(int argb)

--- a/src/Runtime/Runtime/System.Windows.Media/DoubleCollection.cs
+++ b/src/Runtime/Runtime/System.Windows.Media/DoubleCollection.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using OpenSilver.Internal;
 
@@ -24,6 +25,7 @@ namespace Windows.UI.Xaml.Media
     /// <summary>
     /// Represents an ordered collection of Double values.
     /// </summary>
+    [TypeConverter(typeof(DoubleCollectionConverter))]
     public sealed class DoubleCollection : PresentationFrameworkCollection<double>
     {
         public DoubleCollection() : base(false) 

--- a/src/Runtime/Runtime/System.Windows.Media/FontFamily.cs
+++ b/src/Runtime/Runtime/System.Windows.Media/FontFamily.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 
 #if MIGRATION
 namespace System.Windows.Media
@@ -22,6 +23,7 @@ namespace Windows.UI.Xaml.Media
     /// <summary>
     /// Represents a family of related fonts.
     /// </summary>
+    [TypeConverter(typeof(FontFamilyConverter))]
     public partial class FontFamily
     {
         // Parameters:

--- a/src/Runtime/Runtime/System.Windows.Media/Geometry.cs
+++ b/src/Runtime/Runtime/System.Windows.Media/Geometry.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 
 #if MIGRATION
 using System.Windows.Shapes;
@@ -31,6 +32,7 @@ namespace Windows.UI.Xaml.Media
     /// objects can be used for clipping regions and as geometry definitions for
     /// rendering two-dimensional graphical data as a Path.
     /// </summary>
+    [TypeConverter(typeof(GeometryConverter))]
     public abstract partial class Geometry : DependencyObject
     {
         /// <summary>

--- a/src/Runtime/Runtime/System.Windows.Media/Matrix.cs
+++ b/src/Runtime/Runtime/System.Windows.Media/Matrix.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using OpenSilver.Internal;
@@ -30,6 +31,7 @@ namespace Windows.UI.Xaml.Media
     /// Represents a 3x3 affine transformation matrix used for transformations in two-dimensional
     /// space.
     /// </summary>
+    [TypeConverter(typeof(MatrixConverter))]
     public struct Matrix : IFormattable
     {
         // the transform is identity by default

--- a/src/Runtime/Runtime/System.Windows.Media/PointCollection.cs
+++ b/src/Runtime/Runtime/System.Windows.Media/PointCollection.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using OpenSilver.Internal;
+using System.ComponentModel;
 
 #if MIGRATION
 using System.Windows.Shapes;
@@ -29,6 +30,7 @@ namespace System.Windows.Media
 namespace Windows.UI.Xaml.Media
 #endif
 {
+    [TypeConverter(typeof(PointCollectionConverter))]
     public sealed partial class PointCollection : PresentationFrameworkCollection<Point>
     {
         private Shape _parentShape;

--- a/src/Runtime/Runtime/System.Windows.Media/Transform.cs
+++ b/src/Runtime/Runtime/System.Windows.Media/Transform.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 
 #if !MIGRATION
 using Windows.Foundation;
@@ -26,6 +27,7 @@ namespace Windows.UI.Xaml.Media
     /// <summary>
     /// Defines functionality that enables transformations in a two-dimensional plane.
     /// </summary>
+    [TypeConverter(typeof(TransformConverter))]
     public abstract partial class Transform : GeneralTransform
     {
         internal Transform() { }

--- a/src/Runtime/Runtime/System.Windows.Media/WORKINPROGRESS/CacheMode.cs
+++ b/src/Runtime/Runtime/System.Windows.Media/WORKINPROGRESS/CacheMode.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 
 #if MIGRATION
 namespace System.Windows.Media
@@ -20,6 +21,7 @@ namespace Windows.UI.Xaml.Media
 #endif
 {
     [OpenSilver.NotImplemented]
+    [TypeConverter(typeof(CacheModeConverter))]
     public abstract partial class CacheMode : DependencyObject
     {
         /// <summary>

--- a/src/Runtime/Runtime/System.Windows.input/Cursor.cs
+++ b/src/Runtime/Runtime/System.Windows.input/Cursor.cs
@@ -11,11 +11,14 @@
 *  
 \*====================================================================================*/
 
+using System.ComponentModel;
+
 namespace System.Windows.Input
 {
     /// <summary>
     /// Represents the image used for the mouse pointer.
     /// </summary>
+    [TypeConverter(typeof(CursorConverter))]
     public sealed partial class Cursor : IDisposable
     {
         private static string[] HtmlCursors { get; }

--- a/src/Runtime/Runtime/System.Windows/CornerRadius.cs
+++ b/src/Runtime/Runtime/System.Windows/CornerRadius.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 
 #if MIGRATION
@@ -24,6 +25,7 @@ namespace Windows.UI.Xaml
     /// Describes the characteristics of a rounded corner, such as can be applied to
     /// a <see cref="Controls.Border"/>.
     /// </summary>
+    [TypeConverter(typeof(CornerRadiusConverter))]
     public partial struct CornerRadius
     {
         /// <summary>

--- a/src/Runtime/Runtime/System.Windows/Duration.cs
+++ b/src/Runtime/Runtime/System.Windows/Duration.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 
 #if MIGRATION
 namespace System.Windows
@@ -22,6 +23,7 @@ namespace Windows.UI.Xaml
     /// <summary>
     /// Represents the duration of time that a <see cref="Media.Animation.Timeline"/> is active.
     /// </summary>
+    [TypeConverter(typeof(DurationConverter))]
     public struct Duration
     {
         private TimeSpan _timeSpan;

--- a/src/Runtime/Runtime/System.Windows/FontStretch.cs
+++ b/src/Runtime/Runtime/System.Windows/FontStretch.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 
 #if MIGRATION
@@ -24,6 +25,7 @@ namespace Windows.UI.Xaml
     /// Describes the degree to which a font has been stretched, compared to the normal
     /// aspect ratio of that font.
     /// </summary>
+    [TypeConverter(typeof(FontStretchConverter))]
     public struct FontStretch : IFormattable
     {
         private readonly int _stretch;

--- a/src/Runtime/Runtime/System.Windows/FontStyle.cs
+++ b/src/Runtime/Runtime/System.Windows/FontStyle.cs
@@ -13,6 +13,7 @@
 
 #if MIGRATION
 
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace System.Windows
@@ -20,6 +21,7 @@ namespace System.Windows
     /// <summary>
     /// Represents the style of a font face (for instance, as normal or italic).
     /// </summary>
+    [TypeConverter(typeof(FontStyleConverter))]
     public struct FontStyle : IFormattable
     {
         private readonly int _style;

--- a/src/Runtime/Runtime/System.Windows/FontWeight.cs
+++ b/src/Runtime/Runtime/System.Windows/FontWeight.cs
@@ -25,6 +25,7 @@ namespace Windows.UI.Text
     /// Refers to the density of a typeface, in terms of the lightness or heaviness of
     /// the strokes.
     /// </summary>
+    [TypeConverter(typeof(FontWeightConverter))]
     public struct FontWeight : IFormattable
     {
         private readonly int _weight;

--- a/src/Runtime/Runtime/System.Windows/GridLength.cs
+++ b/src/Runtime/Runtime/System.Windows/GridLength.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 
 #if MIGRATION
@@ -24,6 +25,7 @@ namespace Windows.UI.Xaml
     /// Represents the length of elements that explicitly support <see cref="GridUnitType.Star"/>
     /// unit types.
     /// </summary>
+    [TypeConverter(typeof(GridLengthConverter))]
     public struct GridLength
     {
         private double _unitValue;      //  unit value storage

--- a/src/Runtime/Runtime/System.Windows/Point.cs
+++ b/src/Runtime/Runtime/System.Windows/Point.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using OpenSilver.Internal;
 
@@ -25,6 +26,7 @@ namespace Windows.Foundation
     /// Represents an x- and y-coordinate pair in two-dimensional space. Can also represent
     /// a logical point for certain property usages.
     /// </summary>
+    [TypeConverter(typeof(PointConverter))]
     public struct Point : IFormattable
     {
         internal double _x;

--- a/src/Runtime/Runtime/System.Windows/PropertyPath.cs
+++ b/src/Runtime/Runtime/System.Windows/PropertyPath.cs
@@ -14,6 +14,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using CSHTML5.Internal;
 using OpenSilver.Internal.Data;
@@ -28,6 +29,7 @@ namespace Windows.UI.Xaml
     /// Implements a data structure for describing a property as a path below another
     /// property, or below an owning type. Property paths are used in data binding to objects.
     /// </summary>
+    [TypeConverter(typeof(PropertyPathConverter))]
     public sealed partial class PropertyPath : DependencyObject
     {
         private SourceValueInfo[] _arySVI;

--- a/src/Runtime/Runtime/System.Windows/Rect.cs
+++ b/src/Runtime/Runtime/System.Windows/Rect.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using OpenSilver.Internal;
 
@@ -24,6 +25,7 @@ namespace Windows.Foundation
     /// <summary>
     /// Describes the width, height, and point origin of a rectangle.
     /// </summary>
+    [TypeConverter(typeof(RectConverter))]
     public struct Rect
     {
         internal double _x;

--- a/src/Runtime/Runtime/System.Windows/Size.cs
+++ b/src/Runtime/Runtime/System.Windows/Size.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using OpenSilver.Internal;
 
@@ -24,6 +25,7 @@ namespace Windows.Foundation
     /// <summary>
     /// Describes the width and height of an object.
     /// </summary>
+    [TypeConverter(typeof(SizeConverter))]
     public struct Size
     {
         internal double _width;

--- a/src/Runtime/Runtime/System.Windows/TextDecorationCollection.cs
+++ b/src/Runtime/Runtime/System.Windows/TextDecorationCollection.cs
@@ -13,8 +13,11 @@
 
 #if MIGRATION
 
+using System.ComponentModel;
+
 namespace System.Windows
 {
+    [TypeConverter(typeof(TextDecorationCollectionConverter))]
     public sealed class TextDecorationCollection
     {
         internal TextDecorationCollection() { }

--- a/src/Runtime/Runtime/System.Windows/Thickness.cs
+++ b/src/Runtime/Runtime/System.Windows/Thickness.cs
@@ -12,6 +12,7 @@
 \*====================================================================================*/
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 
 #if MIGRATION
@@ -25,6 +26,7 @@ namespace Windows.UI.Xaml
     /// describe the <see cref="Left"/>, <see cref="Top"/>, <see cref="Right"/>, and 
     /// <see cref="Bottom"/> sides of the rectangle, respectively.
     /// </summary>
+    [TypeConverter(typeof(ThicknessConverter))]
     public struct Thickness
     {
         /// <summary>


### PR DESCRIPTION
`XamlReader.Load()` needs `TypeConverter` attributes to convert some types from xaml string, otherwise throws an exception.

[More of TypeConverter and XAML](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/typeconverters-and-xaml)