### PR TITLE
Fix grid exception when column or row size is 0*

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Grid_InternalHelpers.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Grid_InternalHelpers.cs
@@ -346,9 +346,10 @@ namespace Windows.UI.Xaml.Controls
                 //we get the smallest star value in the columns:
                 foreach (ColumnDefinition col in columnDefinitionsOrNull)
                 {
-                    if (col.Width.IsStar && col.Width.Value < smallestColumnStarValue)
+                    var value = col.Width.Value;
+                    if (col.Width.IsStar && value < smallestColumnStarValue && value > 0)
                     {
-                        smallestColumnStarValue = col.Width.Value;
+                        smallestColumnStarValue = value;
                     }
                 }
 
@@ -371,9 +372,10 @@ namespace Windows.UI.Xaml.Controls
             {
                 foreach (RowDefinition row in rowDefinitionsOrNull)
                 {
-                    if (row.Height.IsStar && row.Height.Value < smallestRowStarValue)
+                    var value = row.Height.Value;
+                    if (row.Height.IsStar && value < smallestRowStarValue && value > 0)
                     {
-                        smallestRowStarValue = row.Height.Value;
+                        smallestRowStarValue = value;
                     }
                 }
 


### PR DESCRIPTION
Fix an exception that occurs sometimes on RadGridView scrolling. `Column.Width` or `Row.Height` might be `0*`.

```Method excution failed: System.ArgumentException: 'NaN' parameter cannot be NaN. (Parameter 'value')
   at System.Windows.GridLength..ctor(Double value, GridUnitType type)
   at System.Windows.Controls.Grid_InternalHelpers.NormalizeWidthAndHeightPercentages_CSSVersion(Grid grid, ColumnDefinitionCollection columnDefinitionsOrNull, RowDefinitionCollection rowDefinitionsOrNull, List`1& normalizedColumnDefinitions, List`1& normalizedRowDefinitions)
   at System.Windows.Controls.Grid_InternalHelpers.NormalizeWidthAndHeightPercentages(Grid grid, ColumnDefinitionCollection columnDefinitionsOrNull, RowDefinitionCollection rowDefinitionsOrNull, List`1& normalizedColumnDefinitions, List`1& normalizedRowDefinitions)
   at System.Windows.Controls.Grid.CreateDomElement_CSSVersion(Object parentRef, Object& domElementWhereToPlaceChildren)
   at System.Windows.Controls.Grid.CreateDomElement(Object parentRef, Object& domElementWhereToPlaceChildren)
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChild_Private_MainSteps(UIElement child, UIElement parent, Int32 index, Boolean doesParentRequireToCreateAWrapperForEachChild, Object innerDivOfWrapperForChild, Object domElementWhereToPlaceChildStuff, Object wrapperForChild)
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChild_Private(UIElement child, UIElement parent, Int32 index)
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(UIElement child, UIElement parent, Int32 index)
   at System.Windows.Controls.Border.INTERNAL_OnAttachedToVisualTree()
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChild_Private_MainSteps(UIElement child, UIElement parent, Int32 index, Boolean doesParentRequireToCreateAWrapperForEachChild, Object innerDivOfWrapperForChild, Object domElementWhereToPlaceChildStuff, Object wrapperForChild)
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChild_Private(UIElement child, UIElement parent, Int32 index)
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(UIElement child, UIElement parent, Int32 index)
   at System.Windows.Controls.Panel.OnChildrenReset()
   at System.Windows.Controls.Grid.OnChildrenReset()
   at System.Windows.Controls.Panel.INTERNAL_OnAttachedToVisualTree()
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChild_Private_MainSteps(UIElement child, UIElement parent, Int32 index, Boolean doesParentRequireToCreateAWrapperForEachChild, Object innerDivOfWrapperForChild, Object domElementWhereToPlaceChildStuff, Object wrapperForChild)
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChild_Private(UIElement child, UIElement parent, Int32 index)
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(UIElement child, UIElement parent, Int32 index)
   at System.Windows.FrameworkElement.MeasureCore()
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.MeasureQueue.Add(UIElement uie)
   at System.Windows.UIElement.InvalidateMeasureInternal()
   at System.Windows.FrameworkElement.INTERNAL_OnAttachedToVisualTree()
   at System.Windows.Controls.ContentControl.INTERNAL_OnAttachedToVisualTree()
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChild_Private_MainSteps(UIElement child, UIElement parent, Int32 index, Boolean doesParentRequireToCreateAWrapperForEachChild, Object innerDivOfWrapperForChild, Object domElementWhereToPlaceChildStuff, Object wrapperForChild)
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChild_Private(UIElement child, UIElement parent, Int32 index)
   at CSHTML5.Internal.INTERNAL_VisualTreeManager.AttachVisualChildIfNotAlreadyAttached(UIElement child, UIElement parent, Int32 index)
   at System.Windows.Controls.Panel.OnChildrenAdded(UIElement newChild, Int32 index)
   at System.Windows.Controls.Panel.OnChildrenCollectionChanged(Object sender, NotifyCollectionChangedEventArgs e)
   at System.Windows.PresentationFrameworkCollection`1[[System.Windows.UIElement, OpenSilver, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null]].__OnCollectionChanged(NotifyCollectionChangedEventArgs e)
   at System.Windows.PresentationFrameworkCollection`1[[System.Windows.UIElement, OpenSilver, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null]].OnCollectionChanged(NotifyCollectionChangedAction action, Object item, Int32 index)
   at System.Windows.PresentationFrameworkCollection`1[[System.Windows.UIElement, OpenSilver, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null]].Insert(Int32 index, UIElement value)
   at Telerik.Windows.Controls.GridView.GridViewVirtualizingPanel.NestedLayoutStrategy.InsertContainer(Int32 childIndex, UIElement container, Boolean isRecycled)
   at Telerik.Windows.Controls.GridView.GridViewVirtualizingPanel.NestedLayoutStrategy.InsertRecycledContainer(Int32 childIndex, UIElement container)
   at Telerik.Windows.Controls.GridView.GridViewVirtualizingPanel.NestedLayoutStrategy.AddContainerFromGenerator(Int32 childIndex, UIElement child, Boolean newlyRealized)
   at Telerik.Windows.Controls.GridView.GridViewVirtualizingPanel.NestedLayoutStrategy.GenerateNextChild(IItemContainerGenerator generator, Int32 childIndex)
   at Telerik.Windows.Controls.GridView.GridViewVirtualizingPanel.NestedLayoutStrategy.MeasureOverride(Size constraint)
   at Telerik.Windows.Controls.GridView.GridViewVirtualizingPanel.MeasureOverride(Size availableSize)
   at System.Windows.FrameworkElement.MeasureCore(Size availableSize)
   at System.Windows.UIElement.Measure(Size availableSize)
   at System.Windows.LayoutManager.UpdateLayout()
   at System.Windows.Threading.DispatcherOperation.<>c__DisplayClass20_0.<.ctor>b__0()
   at System.Windows.Threading.DispatcherOperation.Invoke()
   at System.Windows.Threading.Dispatcher.<ProcessQueueAsync>b__13_0()
   at System.Windows.Threading.Dispatcher.<>c__DisplayClass3_0.<<BeginInvokeInternal>b__0>d.MoveNext()```