### PR TITLE
Correct updating column width for Grid under custom layout

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/ColumnDefinition.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ColumnDefinition.cs
@@ -267,6 +267,11 @@ namespace Windows.UI.Xaml.Controls
             }
 
             columnDefinition.Parent?.InvalidateMeasure();
+
+            if (columnDefinition.Parent?.IsUnderCustomLayout == true)
+            {
+                columnDefinition.Parent.InvalidateArrange();
+            }            
         }
 
         #region ActualWidth / ActualHeight


### PR DESCRIPTION
As DataGrid uses CustomLayout by default, there is a case when custom cell is not updated correctly.
Here is simplified example:

```
    <Grid>
        <Grid.RowDefinitions>
            <RowDefinition Height="Auto"/>
            <RowDefinition Height="*"/>
        </Grid.RowDefinitions>

        <Button Click="Button_Click" Content="Update"/>

        <Grid x:Name="testGrid" Grid.Row="1">
            <Grid.ColumnDefinitions>
                <ColumnDefinition Width="*"/>
                <ColumnDefinition Width="*"/>
            </Grid.ColumnDefinitions>
            <Border Grid.Column="0" Background="Gray"/>
            <Border Grid.Column="0" Background="Green"/>
        </Grid>
    </Grid>
```

```
        public MainPage()
        {
            InitializeComponent();

#if OPENSILVER
            CustomLayout = true;
#endif
        }

        private void Button_Click(object sender, System.Windows.RoutedEventArgs e)
        {
            var percent = new Random().Next(0, 100);
            testGrid.ColumnDefinitions[0].Width = new GridLength(percent, GridUnitType.Star);
            testGrid.ColumnDefinitions[1].Width = new GridLength(100 - percent, GridUnitType.Star);
        }
```