### PR TITLE
Disable TextBox spellcheck

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
@@ -431,13 +431,24 @@ namespace Windows.UI.Xaml.Controls
             tb.UpdateVisualStates();
         }
 
+        /// <summary>
+        /// Gets or sets a value that specifies whether the <see cref="TextBox"/> input 
+        /// interacts with a spell check engine.
+        /// </summary>
+        /// <returns>
+        /// true if the <see cref="TextBox"/> input interacts with a spell check engine; 
+        /// otherwise, false. The default is false.
+        /// </returns>
         public bool IsSpellCheckEnabled
         {
             get { return (bool)GetValue(IsSpellCheckEnabledProperty); }
             set { SetValue(IsSpellCheckEnabledProperty, value); }
         }
 
-        private static readonly DependencyProperty IsSpellCheckEnabledProperty =
+        /// <summary>
+        /// Identifies the <see cref="IsSpellCheckEnabled"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty IsSpellCheckEnabledProperty =
             DependencyProperty.Register(
                 nameof(IsSpellCheckEnabled),
                 typeof(bool),

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
@@ -430,6 +430,28 @@ namespace Windows.UI.Xaml.Controls
 
             tb.UpdateVisualStates();
         }
+
+        public bool IsSpellCheckEnabled
+        {
+            get { return (bool)GetValue(IsSpellCheckEnabledProperty); }
+            set { SetValue(IsSpellCheckEnabledProperty, value); }
+        }
+
+        private static readonly DependencyProperty IsSpellCheckEnabledProperty =
+            DependencyProperty.Register(
+                nameof(IsSpellCheckEnabled),
+                typeof(bool),
+                typeof(TextBox),
+                new PropertyMetadata(false, OnIsSpellCheckEnabledChanged));
+
+        private static void OnIsSpellCheckEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var tb = (TextBox)d;
+            if (tb._textViewHost != null)
+            {
+                tb._textViewHost.View.OnIsSpellCheckEnabledChanged((bool)e.NewValue);
+            }
+        }
         
         public string SelectedText
         {

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
@@ -437,6 +437,9 @@ sel.setBaseAndExtent(nodesAndOffsets['startParent'], nodesAndOffsets['startOffse
             contentEditableDivStyle.background = "solid transparent";
             contentEditableDivStyle.cursor = "text";
 
+            // Disable spell check
+            INTERNAL_HtmlDomManager.SetDomElementAttribute(contentEditableDiv, "spellcheck", false);
+
             // Apply TextAlignment
             UpdateTextAlignment(contentEditableDivStyle, Host.TextAlignment);
 

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
@@ -332,6 +332,14 @@ element.setAttribute(""data-isreadonly"",""{isReadOnly.ToString().ToLower()}"");
             }
         }
 
+        internal void OnIsSpellCheckEnabledChanged(bool isSpellCheckEnabled)
+        {
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(this) && _contentEditableDiv != null)
+            {
+                INTERNAL_HtmlDomManager.SetDomElementAttribute(_contentEditableDiv, "spellcheck", isSpellCheckEnabled);
+            }
+        }
+
         internal void NEW_GET_SELECTION(out int selectionStartIndex, out int selectionLength)
         {
             //todo: fix the that happens (at least in chrome) that makes the index returned be 0 when the caret is on the last line when it's empty
@@ -438,7 +446,7 @@ sel.setBaseAndExtent(nodesAndOffsets['startParent'], nodesAndOffsets['startOffse
             contentEditableDivStyle.cursor = "text";
 
             // Disable spell check
-            INTERNAL_HtmlDomManager.SetDomElementAttribute(contentEditableDiv, "spellcheck", false);
+            INTERNAL_HtmlDomManager.SetDomElementAttribute(contentEditableDiv, "spellcheck", this.Host.IsSpellCheckEnabled);
 
             // Apply TextAlignment
             UpdateTextAlignment(contentEditableDivStyle, Host.TextAlignment);


### PR DESCRIPTION
TextBox in Silverlight doesn't support spell check.