### PR TITLE
Fix touch events

### DIFF
--- a/src/Runtime/Runtime/System.Windows.input/PointerRoutedEventArgs.cs
+++ b/src/Runtime/Runtime/System.Windows.input/PointerRoutedEventArgs.cs
@@ -176,7 +176,9 @@ namespace Windows.UI.Xaml.Input
             {
                 // Hack to improve the Simulator performance by making only one interop call rather than two:
                 string sEvent = INTERNAL_InteropImplementation.GetVariableStringForJS(jsEventArg);
-                string concatenated = OpenSilver.Interop.ExecuteJavaScriptString($"{sEvent}.pageX + '|' + {sEvent}.pageY");
+                string type = OpenSilver.Interop.ExecuteJavaScriptString($"{sEvent}.type");
+                string concatenated = type.StartsWith("touch") ? OpenSilver.Interop.ExecuteJavaScriptString($"{sEvent}.changedTouches[0].pageX + '|' + {sEvent}.changedTouches[0].pageY")
+                                                               : OpenSilver.Interop.ExecuteJavaScriptString($"{sEvent}.pageX + '|' + {sEvent}.pageY");
                 int sepIndex = concatenated.IndexOf('|');
                 string pointerAbsoluteXAsString = concatenated.Substring(0, sepIndex);
                 string pointerAbsoluteYAsString = concatenated.Substring(sepIndex + 1);

--- a/src/Runtime/Runtime/System.Windows/UIElement.EventManager.cs
+++ b/src/Runtime/Runtime/System.Windows/UIElement.EventManager.cs
@@ -162,9 +162,8 @@ namespace Windows.UI.Xaml
                     ProcessMouseButtonEvent(
                         jsEventArg,
                         PointerReleasedEvent);
-
-                    ProcessOnTapped(jsEventArg);
 #endif
+                    ProcessOnTapped(jsEventArg);
                     break;
 
                 case 2:

--- a/src/Runtime/Runtime/System.Windows/UIElement.EventManager.cs
+++ b/src/Runtime/Runtime/System.Windows/UIElement.EventManager.cs
@@ -193,37 +193,29 @@ namespace Windows.UI.Xaml
             string eventType = OpenSilver.Interop.ExecuteJavaScriptString($"{eventVariable}.type", false);
 
 #if MIGRATION
-                MouseButtonEventArgs e = new MouseButtonEventArgs()
+            MouseButtonEventArgs e = new MouseButtonEventArgs()
 #else
-                PointerRoutedEventArgs e = new PointerRoutedEventArgs()
+            PointerRoutedEventArgs e = new PointerRoutedEventArgs()
 #endif
-                {
-                    RoutedEvent = routedEvent,
-                    OriginalSource = this,
-                    INTERNAL_OriginalJSEventArg = jsEventArg,
-                };
+            {
+                RoutedEvent = routedEvent,
+                OriginalSource = this,
+                INTERNAL_OriginalJSEventArg = jsEventArg,
+            };
 
-                if (refreshClickCount)
-                {
-                    e.RefreshClickCount(this);
-                }
+            if (refreshClickCount)
+            {
+                e.RefreshClickCount(this);
+            }
 
             // touchend event occurs only once as opposed to mouseup, so current UIElement is not the same as captured by touchstart event
-                if (eventType == "touchend" || e.CheckIfEventShouldBeTreated(this, jsEventArg))
-                {
-                    // Fill the position of the pointer and the key modifiers:
-                    e.FillEventArgs(this, jsEventArg);
+            if (eventType == "touchend" || e.CheckIfEventShouldBeTreated(this, jsEventArg))
+            {
+                // Fill the position of the pointer and the key modifiers:
+                e.FillEventArgs(this, jsEventArg);
 
-                    // Raise the event (if it was not already marked as "handled" by a child element in the visual tree):
-                    RaiseEvent(e);
-                }
-
-            // ignore the mouse events since they were already handled as touch events
-        // so the same user inputs are not handled twice. (Note: when using touch events, the browsers
-            // fire the touch events at the moment of the action, then throw the mouse events once touchend is fired)
-            if (eventType == "touchend")
-        {
-                OpenSilver.Interop.ExecuteJavaScriptVoid($"{eventVariable}.preventDefault()");
+                // Raise the event (if it was not already marked as "handled" by a child element in the visual tree):
+                RaiseEvent(e);
             }
         }
 

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -446,6 +446,14 @@ document._attachEventListeners = function (element, handler, isFocusable) {
         }
     }
 
+    function bubblingHandledEventHandler(e) {
+        if (!e.isHandled) {
+            e.isHandled = true;
+            handler(e);
+            e.preventDefault();
+        }
+    }
+
     const store = view._eventsStore = {};
     store.isFocusable = isFocusable;
     store.enableTouch = isTouchDevice();
@@ -458,7 +466,7 @@ document._attachEventListeners = function (element, handler, isFocusable) {
     view.addEventListener('mouseleave', store['mouseleave'] = handler);
     if (store.enableTouch) {
         view.addEventListener('touchstart', store['touchstart'] = bubblingEventHandler, { passive: true });
-        view.addEventListener('touchend', store['touchend'] = bubblingEventHandler);
+        view.addEventListener('touchend', store['touchend'] = bubblingHandledEventHandler);
         view.addEventListener('touchmove', store['touchmove'] = bubblingEventHandler, { passive: true });
     }
     if (isFocusable) {


### PR DESCRIPTION
* get pageX/pageY from touch event
* ignore mouse events by preventDefault() instead of DispatcherTimer

It fixes exceptions that was appearing in browser console on touch devices.
Also fixed the need to click twice on CheckBox or Button to execute an action on iOS devices.

Published app to test: https://steady-starship-0a0236.netlify.app/