### PR TITLE
Enhancement: Progressive loading of data-grid continues after reattaching to visual tree.

### DIFF
--- a/src/Runtime/Controls.Data/DataGrid/DataGrid.xaml.cs
+++ b/src/Runtime/Controls.Data/DataGrid/DataGrid.xaml.cs
@@ -1191,6 +1191,8 @@ namespace Windows.UI.Xaml.Controls
         private static void OnItemsSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             DataGrid dataGrid = (DataGrid)d;
+            dataGrid._pausedSlotCreationParam = null;
+
             if (!dataGrid.AreHandlersSuspended())
             {
                 Debug.Assert(dataGrid.DataConnection != null);

--- a/src/Runtime/Controls.Data/DataGrid/DataGrid.xaml.cs
+++ b/src/Runtime/Controls.Data/DataGrid/DataGrid.xaml.cs
@@ -1191,8 +1191,6 @@ namespace Windows.UI.Xaml.Controls
         private static void OnItemsSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             DataGrid dataGrid = (DataGrid)d;
-            dataGrid._pausedSlotCreationParam = null;
-
             if (!dataGrid.AreHandlersSuspended())
             {
                 Debug.Assert(dataGrid.DataConnection != null);

--- a/src/Runtime/Controls.Data/DataGrid/DataGrid.xaml.cs
+++ b/src/Runtime/Controls.Data/DataGrid/DataGrid.xaml.cs
@@ -2922,6 +2922,7 @@ namespace Windows.UI.Xaml.Controls
             if (_rowsPresenter != null)
             {
                 _rowsPresenter.OwningGrid = this;
+                _rowsPresenter.ProgressiveRenderingChunkSize = EffectiveProgressiveLoadingChunkSize;
                 InvalidateRowHeightEstimate();
                 UpdateRowDetailsHeightEstimate();
             }

--- a/src/Runtime/Controls.Data/DataGrid/DataGrid.xaml.cs
+++ b/src/Runtime/Controls.Data/DataGrid/DataGrid.xaml.cs
@@ -1191,6 +1191,8 @@ namespace Windows.UI.Xaml.Controls
         private static void OnItemsSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             DataGrid dataGrid = (DataGrid)d;
+            dataGrid._pausedSlotCreationParam = null;
+
             if (!dataGrid.AreHandlersSuspended())
             {
                 Debug.Assert(dataGrid.DataConnection != null);
@@ -2922,7 +2924,6 @@ namespace Windows.UI.Xaml.Controls
             if (_rowsPresenter != null)
             {
                 _rowsPresenter.OwningGrid = this;
-                _rowsPresenter.ProgressiveRenderingChunkSize = EffectiveProgressiveLoadingChunkSize;
                 InvalidateRowHeightEstimate();
                 UpdateRowDetailsHeightEstimate();
             }

--- a/src/Runtime/Controls.Data/DataGrid/DataGridRows.cs
+++ b/src/Runtime/Controls.Data/DataGrid/DataGridRows.cs
@@ -874,6 +874,8 @@ namespace Windows.UI.Xaml.Controls
         /// </summary>
         public int? ProgressiveLoadingRowChunkSize { get; set; }
 
+        private int EffectiveProgressiveLoadingChunkSize => ProgressiveLoadingRowChunkSize ?? GlobalProgressiveLoadingChunkSize ?? 0;
+
         /// <summary>
         /// Fires when progressive loading starts and ends
         /// </summary>
@@ -903,7 +905,7 @@ namespace Windows.UI.Xaml.Controls
                 }
             }
 
-            int chunkSize = ProgressiveLoadingRowChunkSize ?? GlobalProgressiveLoadingChunkSize ?? 0;
+            int chunkSize = EffectiveProgressiveLoadingChunkSize;
             int chunkSlots = chunkSize > 0 ? Math.Min(chunkSize, totalSlots) : totalSlots;
 
             int addedfRows = 0;
@@ -918,13 +920,6 @@ namespace Windows.UI.Xaml.Controls
             while (chunkSlots < totalSlots)
             {
                 await Task.Delay(1);
-
-                // this can happen if the DataGrid is detached during the delay.
-                if (!INTERNAL_VisualTreeManager.IsElementInVisualTree(this))
-                {
-                    OnProgressiveLoadingInProgressChanged(false);
-                    return;
-                }
 
                 // this can happen while refreshing rows while progressive loading rows
                 if (_pendingRefreshRowsArgs != null && _pendingRefreshRowsArgs.Length == 2)

--- a/src/Runtime/Controls.Data/DataGrid/DataGridRows.cs
+++ b/src/Runtime/Controls.Data/DataGrid/DataGridRows.cs
@@ -874,8 +874,6 @@ namespace Windows.UI.Xaml.Controls
         /// </summary>
         public int? ProgressiveLoadingRowChunkSize { get; set; }
 
-        private int EffectiveProgressiveLoadingChunkSize => ProgressiveLoadingRowChunkSize ?? GlobalProgressiveLoadingChunkSize ?? 0;
-
         /// <summary>
         /// Fires when progressive loading starts and ends
         /// </summary>
@@ -888,38 +886,85 @@ namespace Windows.UI.Xaml.Controls
         }
 
         private bool _isProgressiveLoadingInProgress;
-        private bool[] _pendingRefreshRowsArgs;
+        private bool[] _pendingRefreshRowsArgs;        
 
-        private async void AddSlots(int totalSlots)
+        internal class SlotCreationParams
+        {
+            internal int totalSlots;
+            internal IEnumerator<int> groupSlots;
+            internal int nextGroupSlot;
+            internal int chunkSize;
+            internal int chunkSlots;
+            internal int addedfRows;
+            internal int slot;
+        }
+
+        private SlotCreationParams _pausedSlotCreationParam = null;
+
+        private void AddSlots(int totalSlots)
         {
             this.SlotCount = 0;
             this.VisibleSlotCount = 0;
-            IEnumerator<int> groupSlots = null;
-            int nextGroupSlot = -1;
+
+            var scp = new SlotCreationParams();
+            scp.totalSlots = totalSlots;
+            scp.nextGroupSlot = -1;
+
             if (this.RowGroupHeadersTable.RangeCount > 0)
             {
-                groupSlots = this.RowGroupHeadersTable.GetIndexes().GetEnumerator();
-                if (groupSlots != null && groupSlots.MoveNext())
+                scp.groupSlots = this.RowGroupHeadersTable.GetIndexes().GetEnumerator();
+                if (scp.groupSlots != null && scp.groupSlots.MoveNext())
                 {
-                    nextGroupSlot = groupSlots.Current;
+                    scp.nextGroupSlot = scp.groupSlots.Current;
                 }
             }
 
-            int chunkSize = EffectiveProgressiveLoadingChunkSize;
-            int chunkSlots = chunkSize > 0 ? Math.Min(chunkSize, totalSlots) : totalSlots;
+            scp.chunkSize = ProgressiveLoadingRowChunkSize ?? GlobalProgressiveLoadingChunkSize ?? 0;
+            if (scp.groupSlots != null) // progressive loading for groups is not supported yet
+            {
+                scp.chunkSize = 0;
+            }
 
-            int addedfRows = 0;
-            int slot = 0;
-            AddSlotsInChunk(ref addedfRows, ref slot, ref nextGroupSlot, chunkSlots, groupSlots);
+            scp.chunkSlots = scp.chunkSize > 0 ? Math.Min(scp.chunkSize, totalSlots) : totalSlots;
+            scp.addedfRows = 0;
+            scp.slot = 0;
 
-            if (chunkSlots < totalSlots)
+            AddSlotsInChunk(ref scp.addedfRows, ref scp.slot, ref scp.nextGroupSlot, scp.chunkSlots, scp.groupSlots);
+
+            if (scp.chunkSlots < scp.totalSlots)
             {
                 OnProgressiveLoadingInProgressChanged(true);
             }
 
-            while (chunkSlots < totalSlots)
+            ContinueAddingSlots(scp);
+        }
+
+        private void OnDataGridLoaded(object sender, RoutedEventArgs e)
+        {
+            Loaded -= OnDataGridLoaded;
+
+            if (_pausedSlotCreationParam != null)
+            {
+                var i = _pausedSlotCreationParam;
+                _pausedSlotCreationParam = null;
+                ContinueAddingSlots(i);
+            }
+        }
+
+        private async void ContinueAddingSlots(SlotCreationParams scp)
+        {
+            while (scp.chunkSlots < scp.totalSlots)
             {
                 await Task.Delay(1);
+
+                // this can happen if the DataGrid is detached during the delay.
+                if (!INTERNAL_VisualTreeManager.IsElementInVisualTree(this))
+                {
+                    _pausedSlotCreationParam = scp;
+                    Loaded += OnDataGridLoaded;
+                    OnProgressiveLoadingInProgressChanged(false);
+                    return;
+                }
 
                 // this can happen while refreshing rows while progressive loading rows
                 if (_pendingRefreshRowsArgs != null && _pendingRefreshRowsArgs.Length == 2)
@@ -932,8 +977,8 @@ namespace Windows.UI.Xaml.Controls
                     return;
                 }
 
-                chunkSlots = Math.Min(SlotIsDisplayed(slot) ? chunkSlots + chunkSize : totalSlots, totalSlots);
-                AddSlotsInChunk(ref addedfRows, ref slot, ref nextGroupSlot, chunkSlots, groupSlots);
+                scp.chunkSlots = Math.Min(SlotIsDisplayed(scp.slot) ? scp.chunkSlots + scp.chunkSize : scp.totalSlots, scp.totalSlots);
+                AddSlotsInChunk(ref scp.addedfRows, ref scp.slot, ref scp.nextGroupSlot, scp.chunkSlots, scp.groupSlots);
             }
 
             if (_isProgressiveLoadingInProgress)
@@ -941,10 +986,10 @@ namespace Windows.UI.Xaml.Controls
                 OnProgressiveLoadingInProgressChanged(false);
             }
 
-            if (slot < totalSlots)
+            if (scp.slot < scp.totalSlots)
             {
-                this.SlotCount += totalSlots - slot;
-                this.VisibleSlotCount += totalSlots - slot;
+                this.SlotCount += scp.totalSlots - scp.slot;
+                this.VisibleSlotCount += scp.totalSlots - scp.slot;
                 OnAddedElement_Phase2(0, this._vScrollBar == null || this._vScrollBar.Visibility == Visibility.Visible /*updateVerticalScrollBarOnly*/);
                 OnElementsChanged(true /*grew*/);
             }


### PR DESCRIPTION
The issues is described in this [video](https://drive.google.com/file/d/1WG9SHgNL-SfCv9CvJmnv26c5Uc7o6uec/view?usp=share_link), the progessive loading of rows is stuck if the datagrid was removed and reattached into the visual tree. [This video](https://drive.google.com/file/d/13tyVAqcUlzngf1eFafyU-Z1usECaFVba/view?usp=share_link) has the fix testing.

Here is the sample [XAML File](https://drive.google.com/file/d/18kuJVsUdSQjg8Y602p2iVPOjFLwKs-1Z/view?usp=share_link) and  [CS file](https://drive.google.com/file/d/1KhR_NPrBpRzPtjxA3PxJ-kNARHvFdvh5/view?usp=share_link) to test the issue.

The changes are just about keeping all the variables remembered when detached from visual-tree and resuming the executing with the same variables again once re-attached.