### PR TITLE
Fix: Fixed issue Popup showing briefly at 0,0

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Popup.cs
@@ -302,6 +302,10 @@ namespace Windows.UI.Xaml.Controls.Primitives
                 {
                     // Show the popup:
                     popup.ShowPopupRootIfNotAlreadyVisible();
+                    if (popup.CustomLayout)
+                    {
+                        popup._popupRoot.Visibility = Visibility.Visible;
+                    }
                     popup.OnOpened();
                 }
                 else
@@ -346,6 +350,11 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
                         //We put the popup at the calculated position:
                         popup.RefreshPopupPosition(placementTargetPosition, elementCurrentSize); //note: We might have a position bug here if parentposition is set, ie if popup is in the visual tree
+
+                        if (popup.CustomLayout)
+                        {
+                            popup._popupRoot.Visibility = Visibility.Visible;
+                        }
                     }
                     else
                     {
@@ -601,6 +610,9 @@ namespace Windows.UI.Xaml.Controls.Primitives
                 // Set CustomLayout of the popup root:
                 if (CustomLayout)
                 {
+                    // Setting Visibility to Collapse as a fix to the issue where Popup shows briefly at 0,0
+                    // Will set to Visible where ShowPopupRootIfNotAlreadyVisible is called
+                    _popupRoot.Visibility = Visibility.Collapsed; 
                     _popupRoot.CustomLayout = true;
                     if (Child is FrameworkElement childFe)
                     {

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Selector.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Selector.cs
@@ -780,7 +780,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
         {
             int selectedIndex = SelectedIndex;
             if ((selectedIndex > Items.Count - 1)
-                || (selectedIndex == -1 && _selectedItems.Count > 0)
+                || (selectedIndex <= -1 && _selectedItems.Count > 0)
                 || (selectedIndex > -1
                     && (_selectedItems.Count == 0 || selectedIndex != _selectedItems[0].Index)))
             {

--- a/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
@@ -116,7 +116,8 @@ namespace Windows.UI.Xaml.Controls
             }
             else
             {
-                ComboBoxItem cbi = (ItemContainerGenerator.ContainerFromIndex(index) ?? Items[index]) as ComboBoxItem;
+                var defaultItem = index >= 0 && index < Items.Count ? Items[index] : null;
+                ComboBoxItem cbi = (ItemContainerGenerator.ContainerFromIndex(index) ?? defaultItem) as ComboBoxItem;
                 if (cbi != null)
                 {
                     content = selectionBoxItem = cbi.Content;
@@ -124,7 +125,7 @@ namespace Windows.UI.Xaml.Controls
                 }
                 else
                 {
-                    object item = Items[index];
+                    object item = defaultItem;
                     content = selectionBoxItem = item;
                     if (item is UIElement)
                     {

--- a/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
@@ -108,7 +108,7 @@ namespace Windows.UI.Xaml.Controls
             DataTemplate selectionBoxItemTemplate;
 
             int index = SelectedIndex;
-            if (index == -1 || (IsDropDownOpen && SelectedItem is FrameworkElement))
+            if (index <= -1 || (IsDropDownOpen && SelectedItem is FrameworkElement))
             {
                 content = _emptyContent;
                 selectionBoxItem = null;
@@ -116,8 +116,7 @@ namespace Windows.UI.Xaml.Controls
             }
             else
             {
-                var defaultItem = index >= 0 && index < Items.Count ? Items[index] : null;
-                ComboBoxItem cbi = (ItemContainerGenerator.ContainerFromIndex(index) ?? defaultItem) as ComboBoxItem;
+                ComboBoxItem cbi = (ItemContainerGenerator.ContainerFromIndex(index) ?? Items[index]) as ComboBoxItem;
                 if (cbi != null)
                 {
                     content = selectionBoxItem = cbi.Content;
@@ -125,7 +124,7 @@ namespace Windows.UI.Xaml.Controls
                 }
                 else
                 {
-                    object item = defaultItem;
+                    object item = Items[index];
                     content = selectionBoxItem = item;
                     if (item is UIElement)
                     {


### PR DESCRIPTION
If CustomLayout set to true to a Popup target, the popup shows briefly at 0,0. This [video ](https://drive.google.com/file/d/1IyMHREKJezFq5M4qjUzkotcFtXYbfcMF/view?usp=share_link) shows the issue and [this one](https://drive.google.com/file/d/1PRUo0i1jvRx2Os8k3mHL7WJFGzNhUW_-/view?usp=share_link) the fix. The fix is keeping the popup root hidden until its's position is measured.