### PR TITLE
Support StaticResource for XamlReader

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Markup/StaticResourceExtension.cs
+++ b/src/Runtime/Runtime/System.Windows.Markup/StaticResourceExtension.cs
@@ -70,10 +70,8 @@ namespace System.Windows.Markup
         {
             if (serviceProvider.GetService(typeof(IAmbientResourcesProvider)) is not IAmbientResourcesProvider ambientProvider)
             {
-                throw new InvalidOperationException(
-                    string.Format("Markup extension '{0}' requires '{1}' be implemented in the IServiceProvider for ProvideValue.",
-                        GetType().Name,
-                        nameof(IAmbientResourcesProvider)));
+                resource = null;
+                return false;
             }
 
             IEnumerable<object> ambientValues = ambientProvider.GetAllAmbientValues();


### PR DESCRIPTION
If provide xaml string that contains `StaticResource` to `XamlReader.Load()`, it throws an exception.

```
        <Grid xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'>
            <TextBlock Style="{StaticResource FieldNameTextBlock}" Text="Station"/>
        </Grid>
```

So, if return `false` from `TryFindTheResource()` the resource will be found in `FindResourceInAppOrSystem()`.