### PR TITLE
Added support for html objects

### DIFF
--- a/src/Runtime/Scripts/OpenSilver.js
+++ b/src/Runtime/Scripts/OpenSilver.js
@@ -99,23 +99,14 @@ window.onCallBack = (function () {
 })();
 
 window.callJS = function (javaScriptToExecute) {
-    //console.log(javaScriptToExecute);
-
     var result = eval(javaScriptToExecute);
-    //console.log(result);
     var resultType = typeof result;
     if (resultType == 'string' || resultType == 'number' || resultType == 'boolean') {
-        //if (typeof result !== 'undefined' && typeof result !== 'function') {
-        //console.log("supported");
-        return result;
+       return result;
     }
-    else if (result == null && resultType == "object") {
+    else if (result == null) {
         return null;
-    } else {
-        //console.log("not supported");
-        if (resultType === 'undefined')
-            return "[UNDEFINED]";
-        else
+    } else {     
             return result + " [NOT USABLE DIRECTLY IN C#] (" + resultType + ")";
     }
 };
@@ -127,12 +118,9 @@ window.callJSUnmarshalled = function (javaScriptToExecute) {
     if (resultType == 'string' || resultType == 'number' || resultType == 'boolean') {
         return BINDING.js_to_mono_obj(result);
     }
-    else if (result == null && resultType == "object") {
+    else if (result == null) {
         return null;
     } else {
-        if (resultType === 'undefined')
-            return BINDING.js_to_mono_obj("[UNDEFINED]");
-        else
             return BINDING.js_to_mono_obj(result + " [NOT USABLE DIRECTLY IN C#] (" + resultType + ")");
     }
 }; 

--- a/src/Runtime/Scripts/OpenSilver.js
+++ b/src/Runtime/Scripts/OpenSilver.js
@@ -109,7 +109,9 @@ window.callJS = function (javaScriptToExecute) {
         //console.log("supported");
         return result;
     }
-    else {
+    else if (result == null && resultType == "object") {
+        return null;
+    } else {
         //console.log("not supported");
         if (resultType === 'undefined')
             return "[UNDEFINED]";
@@ -125,7 +127,9 @@ window.callJSUnmarshalled = function (javaScriptToExecute) {
     if (resultType == 'string' || resultType == 'number' || resultType == 'boolean') {
         return BINDING.js_to_mono_obj(result);
     }
-    else {
+    else if (result == null && resultType == "object") {
+        return null;
+    } else {
         if (resultType === 'undefined')
             return BINDING.js_to_mono_obj("[UNDEFINED]");
         else


### PR DESCRIPTION
Controls like DevExpress html editor return objects which we use as-is in our code. and it is returning this to user "null [NOT USABLE DIRECTLY IN C#] (object)"