### PR TITLE
Implement getting Resources from xml parser

### DIFF
--- a/src/Runtime/OpenSilver.Xaml/System.Xaml/XamlObjectWriter.cs
+++ b/src/Runtime/OpenSilver.Xaml/System.Xaml/XamlObjectWriter.cs
@@ -382,6 +382,7 @@ namespace System.Xaml
                 object_states.Peek().IsValueProvidedByParent = true;
             state.Value = instance;
             state.IsInstantiated = true;
+            HandleBeginInit(instance);
             object_states.Push(state);
         }
 

--- a/src/Runtime/OpenSilver.Xaml/System.Xaml/XamlObjectWriter.cs
+++ b/src/Runtime/OpenSilver.Xaml/System.Xaml/XamlObjectWriter.cs
@@ -382,7 +382,6 @@ namespace System.Xaml
                 object_states.Peek().IsValueProvidedByParent = true;
             state.Value = instance;
             state.IsInstantiated = true;
-            HandleBeginInit(instance);
             object_states.Push(state);
         }
 

--- a/src/Runtime/Runtime/System.Windows.Markup/StaticResourceExtension.cs
+++ b/src/Runtime/Runtime/System.Windows.Markup/StaticResourceExtension.cs
@@ -116,19 +116,26 @@ namespace System.Windows.Markup
             return false;
         }
 
-        private bool TryFindResourceFromParser(IAmbientProvider ambientProvider,
-            IXamlSchemaContextProvider schemaContextProvider,
-            out object resource)
+        private bool TryFindResourceFromParser(IAmbientProvider ambientProvider, IXamlSchemaContextProvider schemaContextProvider, out object resource)
         {
             Debug.Assert(ambientProvider != null);
             Debug.Assert(schemaContextProvider != null);
 
-            var schemaContext = schemaContextProvider.SchemaContext;
-            var feXType = schemaContext.GetXamlType(typeof(FrameworkElement));
-            var feResourcesProperty = feXType.GetMember("Resources");
+            XamlSchemaContext schemaContext = schemaContextProvider.SchemaContext;
 
-            var types = new XamlType[1] { schemaContext.GetXamlType(typeof(ResourceDictionary)) };
-            var ambientValues = ambientProvider.GetAllAmbientValues(null, true, types, feResourcesProperty);
+            XamlType feXType = schemaContext.GetXamlType(typeof(FrameworkElement));
+            XamlType appXType = schemaContext.GetXamlType(typeof(Application));
+
+            XamlMember feResourcesProperty = feXType.GetMember("Resources");
+            XamlMember appResourcesProperty = appXType.GetMember("Resources");
+
+            XamlType[] types = new XamlType[1] { schemaContext.GetXamlType(typeof(ResourceDictionary)) };
+
+            var ambientValues = ambientProvider.GetAllAmbientValues(null,
+                                                                    false,
+                                                                    types,
+                                                                    feResourcesProperty,
+                                                                    appResourcesProperty);
 
             foreach (var ambientValue in ambientValues)
             {
@@ -140,6 +147,7 @@ namespace System.Windows.Markup
                     }
                 }
             }
+
             resource = null;
             return false;
         }

--- a/src/Runtime/Runtime/System.Windows.Markup/StaticResourceExtension.cs
+++ b/src/Runtime/Runtime/System.Windows.Markup/StaticResourceExtension.cs
@@ -120,13 +120,26 @@ namespace System.Windows.Markup
             IXamlSchemaContextProvider schemaContextProvider,
             out object resource)
         {
-            // TODO
+            Debug.Assert(ambientProvider != null);
+            Debug.Assert(schemaContextProvider != null);
 
-            Debug.Assert(ambientProvider != null);            
-            
-            // return false so that it can attempt to find the resource in the 
-            // application's resources.
+            var schemaContext = schemaContextProvider.SchemaContext;
+            var feXType = schemaContext.GetXamlType(typeof(FrameworkElement));
+            var feResourcesProperty = feXType.GetMember("Resources");
 
+            var types = new XamlType[1] { schemaContext.GetXamlType(typeof(ResourceDictionary)) };
+            var ambientValues = ambientProvider.GetAllAmbientValues(null, true, types, feResourcesProperty);
+
+            foreach (var ambientValue in ambientValues)
+            {
+                if (ambientValue.Value is ResourceDictionary rd)
+                {
+                    if (rd.TryGetResource(ResourceKey, out resource))
+                    {
+                        return true;
+                    }
+                }
+            }
             resource = null;
             return false;
         }

--- a/src/Runtime/Runtime/System.Windows/Application.cs
+++ b/src/Runtime/Runtime/System.Windows/Application.cs
@@ -29,6 +29,7 @@ using OpenSilver.Internal.Xaml;
 using System.Text.Json;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Xaml.Markup;
 
 #if MIGRATION
 using System.ApplicationModel.Activation;
@@ -280,6 +281,7 @@ namespace Windows.UI.Xaml
         /// Gets a collection of application-scoped resources, such as styles, templates,
         /// and brushes.
         /// </summary>
+        [Ambient]
         public ResourceDictionary Resources
         {
             get

--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
@@ -21,6 +21,7 @@ using System.Windows.Markup;
 using CSHTML5.Internal;
 using OpenSilver.Internal;
 using System.ComponentModel;
+using System.Xaml.Markup;
 
 #if MIGRATION
 using System.Windows.Controls;
@@ -409,6 +410,7 @@ namespace Windows.UI.Xaml
         /// resource items as child object elements of a frameworkElement.Resources property
         /// element, through XAML implicit collection syntax.
         /// </summary>
+        [Ambient]
         public ResourceDictionary Resources
         {
             get


### PR DESCRIPTION
To support XamlReader to get Resources declared in xaml string.
For example

```
        <Canvas xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
            <Canvas.Resources>
                <LinearGradientBrush x:Key="MyBrush">
                    <GradientStop Offset="0" Color="#ffcccccc"/>
                    <GradientStop Offset="1" Color="#ffffffcc"/>
                </LinearGradientBrush>
            </Canvas.Resources>
            <Rectangle Width="100"
                       Height="20"
                       Fill="{StaticResource MyBrush}"/>
        </Canvas>
```

This works if comment out throwing the exception in `ResourceDictionary.EndInit()`. The xml parser for `.Resources` calls `WriteEndObject()`, but not `WriteStartObject()`. Need to be fixed