### PR TITLE
Fix generating parameters in Reference.g.cs with ref keyword

### DIFF
--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/FixingServiceReferences.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/FixingServiceReferences.cs
@@ -513,6 +513,11 @@ namespace DotNetForHtml5.Compiler
                             trimmedParamName = trimmedParamName.Remove(0, 4).Trim();
                         }
 
+                        if (trimmedParamName.StartsWith("ref "))
+                        {
+                            trimmedParamName = trimmedParamName.Remove(0, 4);
+                        }
+
                         if (trimmedParamName == "null") continue;
 
                         string parameterDefinition = parameterNamesToTheirDefinitions.ContainsKey(trimmedParamName) ?

--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/Version.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/Version.cs
@@ -8,6 +8,6 @@ namespace DotNetForHtml5.Compiler
 {
     internal static class Version
     {
-        public const int CompilerBuildNumber = 7;
+        public const int CompilerBuildNumber = 8;
     }
 }

--- a/src/Targets/OpenSilver.Common.targets
+++ b/src/Targets/OpenSilver.Common.targets
@@ -106,7 +106,7 @@
   Set the default values for some properties (for example, if the output paths have not been specified, we set the default ones):
   ============================================================-->
   <PropertyGroup Condition="'$(CompilerBuildNumber)'==''">
-	  <CompilerBuildNumber>7</CompilerBuildNumber>
+	  <CompilerBuildNumber>8</CompilerBuildNumber>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsSecondPass)'==''">
     <IsSecondPass>False</IsSecondPass>


### PR DESCRIPTION
Fixes the issue:
Call a request that contains a parameter with `ref` keyword in `Reference.cs`.
There is an exception in `Prepare()` method of `CSHTML5_ClientBase_1.cs`, that `requestParameters` does not contain a key.