### PR TITLE
Dispose callback when animation stopped

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Media.Animation/AnimationHelpers.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/AnimationHelpers.cs
@@ -37,6 +37,7 @@ namespace Windows.UI.Xaml.Media.Animation
     internal static class AnimationHelpers
     {
         internal static void CallVelocity(
+            AnimationTimeline animation,
             object domElement,
             Duration Duration,
             EasingFunctionBase easingFunction,
@@ -69,9 +70,9 @@ queue:""{visualStateGroupName}""
 
             if (callbackForWhenfinished != null)
             {
-                var jsCallback = JavaScriptCallbackHelper.CreateSelfDisposedJavaScriptCallback(callbackForWhenfinished);
+                var jsCallback = JavaScriptCallbackHelper.CreateSelfDisposedJavaScriptCallback(callbackForWhenfinished);                
                 sb.Append($"options.complete = {CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(jsCallback)};");
-                sb.Append($"options.callbackId = {jsCallback.Id};");
+                animation.RegisterCallback(jsCallback);
             }
 
             if (easingFunction != null)
@@ -96,12 +97,7 @@ queue:""{visualStateGroupName}""
 
         internal static void StopVelocity(string domElement, string visualStateGroupName)
         {
-            var id = Convert.ToInt32(OpenSilver.Interop.ExecuteJavaScript(@"document.getActiveAnimationCallbackId($0);", visualStateGroupName));
             OpenSilver.Interop.ExecuteJavaScriptFastAsync($@"Velocity({domElement}, ""stop"", ""{visualStateGroupName}"");");
-            if (id != -1)
-            {
-                JavascriptCallback.Get(id)?.Dispose();
-            }
         }
 
         internal static void ApplyValue(DependencyObject target, PropertyPath propertyPath, object value)

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/AnimationHelpers.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/AnimationHelpers.cs
@@ -71,6 +71,7 @@ queue:""{visualStateGroupName}""
             {
                 var jsCallback = JavaScriptCallbackHelper.CreateSelfDisposedJavaScriptCallback(callbackForWhenfinished);
                 sb.Append($"options.complete = {CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(jsCallback)};");
+                sb.Append($"options.callbackId = {jsCallback.Id};");
             }
 
             if (easingFunction != null)
@@ -91,6 +92,16 @@ queue:""{visualStateGroupName}""
             sb.Append($"}})({sElement});");
 
             OpenSilver.Interop.ExecuteJavaScriptFastAsync(sb.ToString());
+        }
+
+        internal static void StopVelocity(string domElement, string visualStateGroupName)
+        {
+            var id = Convert.ToInt32(OpenSilver.Interop.ExecuteJavaScript(@"document.getActiveAnimationCallbackId($0);", visualStateGroupName));
+            OpenSilver.Interop.ExecuteJavaScriptFastAsync($@"Velocity({domElement}, ""stop"", ""{visualStateGroupName}"");");
+            if (id != -1)
+            {
+                JavascriptCallback.Get(id)?.Dispose();
+            }
         }
 
         internal static void ApplyValue(DependencyObject target, PropertyPath propertyPath, object value)

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/AnimationTimeline.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/AnimationTimeline.cs
@@ -29,6 +29,7 @@ namespace Windows.UI.Xaml.Media.Animation
 {
     public abstract partial class AnimationTimeline : Timeline
     {
+        private List<JavascriptCallback> _velocityCallbacks;
         internal string _targetName;
         internal PropertyPath _targetProperty;
         internal DependencyObject _propertyContainer;
@@ -117,10 +118,30 @@ namespace Windows.UI.Xaml.Media.Animation
                 {
                     UnApply();
                 }
+                ReleaseCallbacks();
             }
         }
 
         internal virtual void StopAnimation() { }
+
+        internal void RegisterCallback(JavascriptCallback callback)
+        {
+            _velocityCallbacks ??= new List<JavascriptCallback>();
+            _velocityCallbacks.Add(callback);
+        }
+
+        private void ReleaseCallbacks()
+        {
+            if (_velocityCallbacks != null)
+            {
+                foreach (JavascriptCallback callback in _velocityCallbacks)
+                {
+                    callback.Dispose();
+                }
+
+                _velocityCallbacks = null;
+            }
+        }
 
         private void UnApply()
         {

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/ColorAnimation.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/ColorAnimation.cs
@@ -349,7 +349,7 @@ namespace Windows.UI.Xaml.Media.Animation
                                 {
                                     cssEquivalentExists = true;
                                     string sDomElement = INTERNAL_InteropImplementation.GetVariableStringForJS(cssEquivalent.DomElement);
-                                    CSHTML5.Interop.ExecuteJavaScriptFastAsync($@"Velocity({sDomElement}, ""stop"", ""{specificGroupName}"");");
+                                    AnimationHelpers.StopVelocity(sDomElement, specificGroupName);
                                 }
                             }
                         }
@@ -364,7 +364,7 @@ namespace Windows.UI.Xaml.Media.Animation
                             {
                                 cssEquivalentExists = true;
                                 string sDomElement = INTERNAL_InteropImplementation.GetVariableStringForJS(equivalent.DomElement);
-                                CSHTML5.Interop.ExecuteJavaScriptFastAsync($@"Velocity({sDomElement}, ""stop"", ""{specificGroupName}"");");
+                                AnimationHelpers.StopVelocity(sDomElement, specificGroupName);
                             }
                         }
                     }

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/ColorAnimation.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/ColorAnimation.cs
@@ -208,7 +208,7 @@ namespace Windows.UI.Xaml.Media.Animation
             return () => OnAnimationCompleted(parameters, isLastLoop, value, target, propertyPath, callBackGuid);
         }
 
-        static bool TryStartAnimation(DependencyObject target, CSSEquivalent cssEquivalent, Color? from, object to, Duration Duration, EasingFunctionBase easingFunction, string visualStateGroupName, DependencyProperty dependencyProperty, Action callbackForWhenfinished = null)
+        private bool TryStartAnimation(DependencyObject target, CSSEquivalent cssEquivalent, Color? from, object to, Duration Duration, EasingFunctionBase easingFunction, string visualStateGroupName, DependencyProperty dependencyProperty, Action callbackForWhenfinished = null)
         {
             if (cssEquivalent.Name != null && cssEquivalent.Name.Count != 0)
             {
@@ -288,6 +288,7 @@ namespace Windows.UI.Xaml.Media.Animation
                         }
 
                         AnimationHelpers.CallVelocity(
+                            this,
                             cssEquivalent.DomElement,
                             Duration,
                             easingFunction,

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/ColorAnimationUsingKeyFrames.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/ColorAnimationUsingKeyFrames.cs
@@ -263,7 +263,7 @@ namespace Windows.UI.Xaml.Media.Animation
             }
         }
 
-        static bool StartAnimation(DependencyObject target, CSSEquivalent cssEquivalent, Color? from, object to, Duration duration, EasingFunctionBase easingFunction, string visualStateGroupName, DependencyProperty dependencyProperty, Action callbackForWhenfinished = null)
+        private bool StartAnimation(DependencyObject target, CSSEquivalent cssEquivalent, Color? from, object to, Duration duration, EasingFunctionBase easingFunction, string visualStateGroupName, DependencyProperty dependencyProperty, Action callbackForWhenfinished = null)
         {
             if (cssEquivalent.Name != null && cssEquivalent.Name.Count != 0)
             {
@@ -343,6 +343,7 @@ namespace Windows.UI.Xaml.Media.Animation
                         }
 
                         AnimationHelpers.CallVelocity(
+                            this,
                             cssEquivalent.DomElement,
                             duration,
                             easingFunction,

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/ColorAnimationUsingKeyFrames.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/ColorAnimationUsingKeyFrames.cs
@@ -436,7 +436,8 @@ namespace Windows.UI.Xaml.Media.Animation
                             if (cssEquivalent.DomElement != null)
                             {
                                 cssEquivalentExists = true;
-                                CSHTML5.Interop.ExecuteJavaScriptAsync(@"Velocity($0, ""stop"", $1);", cssEquivalent.DomElement, specificGroupName);
+                                string sDomElement = CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(cssEquivalent.DomElement);
+                                AnimationHelpers.StopVelocity(sDomElement, specificGroupName);
                             }
                         }
                     }
@@ -450,7 +451,8 @@ namespace Windows.UI.Xaml.Media.Animation
                         if (equivalent.DomElement != null && equivalent.CallbackMethod == null)
                         {
                             cssEquivalentExists = true;
-                            CSHTML5.Interop.ExecuteJavaScriptAsync(@"Velocity($0, ""stop"", $1);", equivalent.DomElement, specificGroupName);
+                            string sDomElement = CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(equivalent.DomElement);
+                            AnimationHelpers.StopVelocity(sDomElement, specificGroupName);
                         }
                     }
                 }

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/DoubleAnimation.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/DoubleAnimation.cs
@@ -273,7 +273,7 @@ namespace Windows.UI.Xaml.Media.Animation
                                 if (cssEquivalent.DomElement != null)
                                 {
                                     string sDomElement = CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(cssEquivalent.DomElement);
-                                    CSHTML5.Interop.ExecuteJavaScriptFastAsync($@"Velocity({sDomElement}, ""stop"", ""{specificGroupName}"");");
+                                    AnimationHelpers.StopVelocity(sDomElement, specificGroupName);
                                 }
                             }
                         }
@@ -286,7 +286,7 @@ namespace Windows.UI.Xaml.Media.Animation
                             if (equivalent.DomElement != null)
                             {
                                 string sDomElement = CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(equivalent.DomElement);
-                                CSHTML5.Interop.ExecuteJavaScriptFastAsync($@"Velocity({sDomElement}, ""stop"", ""{specificGroupName}"");");
+                                AnimationHelpers.StopVelocity(sDomElement, specificGroupName);
                             }
                         }
                     }

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/DoubleAnimation.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/DoubleAnimation.cs
@@ -186,7 +186,7 @@ namespace Windows.UI.Xaml.Media.Animation
             return () => OnAnimationCompleted(parameters, isLastLoop, value, target, propertyPath, callBackGuid);
         }
 
-        static void StartAnimation(DependencyObject target, CSSEquivalent cssEquivalent, double? from, object to, Duration Duration, EasingFunctionBase easingFunction, string visualStateGroupName, DependencyProperty dependencyProperty, Action callbackForWhenfinished = null)
+        private void StartAnimation(DependencyObject target, CSSEquivalent cssEquivalent, double? from, object to, Duration Duration, EasingFunctionBase easingFunction, string visualStateGroupName, DependencyProperty dependencyProperty, Action callbackForWhenfinished = null)
         {
             if (cssEquivalent.Name != null && cssEquivalent.Name.Count != 0)
             {
@@ -221,6 +221,7 @@ namespace Windows.UI.Xaml.Media.Animation
                         }
 
                         AnimationHelpers.CallVelocity(
+                            this,
                             cssEquivalent.DomElement,
                             Duration,
                             easingFunction,

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/DoubleAnimationUsingKeyFrames.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/DoubleAnimationUsingKeyFrames.cs
@@ -310,8 +310,7 @@ namespace Windows.UI.Xaml.Media.Animation
             return new Duration(LargestTimeSpanKeyTime);
         }
 
-
-        static void StartAnimation(DependencyObject target, CSSEquivalent cssEquivalent, double? from, object to, Duration Duration, EasingFunctionBase easingFunction, string visualStateGroupName, DependencyProperty dependencyProperty, Action callbackForWhenfinished = null)
+        private void StartAnimation(DependencyObject target, CSSEquivalent cssEquivalent, double? from, object to, Duration Duration, EasingFunctionBase easingFunction, string visualStateGroupName, DependencyProperty dependencyProperty, Action callbackForWhenfinished = null)
         {
             if (cssEquivalent.Name != null && cssEquivalent.Name.Count != 0)
             {
@@ -344,6 +343,7 @@ namespace Windows.UI.Xaml.Media.Animation
                         }
 
                         AnimationHelpers.CallVelocity(
+                            this,
                             cssEquivalent.DomElement,
                             Duration,
                             easingFunction,

--- a/src/Runtime/Runtime/System.Windows.Media.Animation/DoubleAnimationUsingKeyFrames.cs
+++ b/src/Runtime/Runtime/System.Windows.Media.Animation/DoubleAnimationUsingKeyFrames.cs
@@ -254,7 +254,7 @@ namespace Windows.UI.Xaml.Media.Animation
                             if (cssEquivalent.DomElement != null)
                             {
                                 string sDomElement = CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(cssEquivalent.DomElement);
-                                CSHTML5.Interop.ExecuteJavaScriptFastAsync($@"Velocity({sDomElement}, ""stop"", ""{specificGroupName}"");");
+                                AnimationHelpers.StopVelocity(sDomElement, specificGroupName);
                             }
                         }
                     }
@@ -267,7 +267,7 @@ namespace Windows.UI.Xaml.Media.Animation
                         if (equivalent.DomElement != null)
                         {
                             string sDomElement = CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(equivalent.DomElement);
-                            CSHTML5.Interop.ExecuteJavaScriptFastAsync($@"Velocity({sDomElement}, ""stop"", ""{specificGroupName}"");");
+                            AnimationHelpers.StopVelocity(sDomElement, specificGroupName);
                         }
                     }
                 }

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -484,21 +484,6 @@ document._attachEventListeners = function (element, handler, isFocusable) {
     }
 }
 
-document.getActiveAnimationCallbackId = function (groupName) {
-    var result = -1;
-    for (let i = 0; i < Velocity.State.calls.length; i++) {
-        var options = Velocity.State.calls[i];
-        if (options && Array.isArray(options)) {
-            var queue = options[2].queue;
-            if (queue === groupName) {
-                result = options[2].callbackId;
-                return result;
-            }
-        }
-    }
-    return result;
-}
-
 document.eventCallback = function (callbackId, args, sync) {
     const argsArray = args;
     const idWhereCallbackArgsAreStored = "callback_args_" + document.callbackCounterForSimulator++;

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -484,6 +484,21 @@ document._attachEventListeners = function (element, handler, isFocusable) {
     }
 }
 
+document.getActiveAnimationCallbackId = function (groupName) {
+    var result = -1;
+    for (let i = 0; i < Velocity.State.calls.length; i++) {
+        var options = Velocity.State.calls[i];
+        if (options && Array.isArray(options)) {
+            var queue = options[2].queue;
+            if (queue === groupName) {
+                result = options[2].callbackId;
+                return result;
+            }
+        }
+    }
+    return result;
+}
+
 document.eventCallback = function (callbackId, args, sync) {
     const argsArray = args;
     const idWhereCallbackArgsAreStored = "callback_args_" + document.callbackCounterForSimulator++;


### PR DESCRIPTION
If the animation is stopped while it is in progress, the complete callback will never be called so the callback will not be Disposed.
The fix checks if the animation is in progress before calling "stop" and then Disposes the callback.