### PR TITLE
Do not close popup if the click happened in itself

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/PopupRoot.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/PopupRoot.cs
@@ -152,11 +152,11 @@ namespace Windows.UI.Xaml.Controls.Primitives
                 {
                     // We must prevent all the parents of a popup to be closed when:
                     // - this popup is set to StayOpen
-                    // - or the click happend in this popup
+                    // - or the click happened in this popup
 
                     Popup popup = popupRoot.INTERNAL_LinkedPopup;
 
-                    if (popup.StayOpen)
+                    if (popup.StayOpen || ((UIElement)e.OriginalSource)?.INTERNAL_VisualParent == popupRoot)
                     {
                         do
                         {


### PR DESCRIPTION
Fixes an issue with `DatePicker`:

Click the calendar button
Attempt to click next/previous button for month or year
Year/month remains the same and the calendar popup closes

It was working well before this change: https://github.com/OpenSilver/OpenSilver/commit/dcaa7ef6b7698b669518489cb670bd7568ef8197