### PR TITLE
Fix opening ComboBox if progressive loading is enabled

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Selector.Navigation.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Selector.Navigation.cs
@@ -259,7 +259,7 @@ public partial class Selector
         }
         itemsHostRect = new Rect(new Point(), new Point(viewport.ActualWidth, viewport.ActualHeight));
 
-        if (ItemContainerGenerator.ContainerFromIndex(index) is not ListBoxItem listBoxItem)
+        if (ItemContainerGenerator.ContainerFromIndex(index) is not ListBoxItem listBoxItem || !listBoxItem.IsConnectedToLiveTree)
         {
             listBoxItemRect = Rect.Empty;
             return false;


### PR DESCRIPTION
Steps to reproduce:
1. Set `Host.Settings.ProgressiveRenderingChunkSize = 10;`
2. Add ComboBox `<ComboBox ItemsSource="{Binding Items}" CustomLayout="True" MaxDropDownHeight="500"/>`
3. Add items `for (int i = 0; i < 100; i++) { Items.Add(i.ToString()); }`
4. Run, click on the ComboBox, select an item, and try to open again

```
DEBUG: OnCallBack: OnCallBackFromJavascript: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.ArgumentException: Value does not fall within the expected range.
   at System.Windows.UIElement.TransformToVisual(UIElement visual)
   at System.Windows.Controls.Primitives.Selector.IsOnCurrentPage(Int32 index, Rect& itemsHostRect, Rect& listBoxItemRect)
   at System.Windows.Controls.Primitives.Selector.ScrollIntoViewImpl(Int32 index)
   at System.Windows.Controls.ComboBox.ScrollTo(Int32 index)
   at System.Windows.Controls.ComboBox.OnIsDropDownOpenChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
   at CSHTML5.Internal.INTERNAL_PropertyStore.OnPropertyChanged(INTERNAL_PropertyStorage storage, Object oldValue, Object newValue)
   at CSHTML5.Internal.INTERNAL_PropertyStore.UpdateEffectiveValue(INTERNAL_PropertyStorage storage, Object newValue, BaseValueSourceInternal newValueSource, Boolean coerceWithCurrentValue, Boolean coerceValue, Boolean clearValue, Boolean propagateChanges)
   at CSHTML5.Internal.INTERNAL_PropertyStore.SetValueCommon(INTERNAL_PropertyStorage storage, Object newValue, Boolean coerceWithCurrentValue)
   at System.Windows.DependencyObject.SetValue(DependencyProperty dp, Object value)
   at System.Windows.Controls.ComboBox.set_IsDropDownOpen(Boolean value)
   at System.Windows.Controls.ComboBox.OnDropDownToggleClick(Object sender, RoutedEventArgs e)
   at System.Windows.Controls.Primitives.ButtonBase.OnClick()
   at System.Windows.Controls.Primitives.ToggleButton.OnClick()
   at System.Windows.Controls.Primitives.ButtonBase.OnMouseLeftButtonUp(MouseButtonEventArgs eventArgs)
```