### PR TITLE
Memory consumption improvements (expected: 10-15+%)

### DIFF
--- a/src/Runtime/Runtime/Core/Events/DOMEventManager.cs
+++ b/src/Runtime/Runtime/Core/Events/DOMEventManager.cs
@@ -78,10 +78,10 @@ namespace CSHTML5.Internal
             object domElement = _domElementProvider();
             if (domElement != null)
             {
+                string sAction = INTERNAL_InteropImplementation.GetVariableStringForJS(_handler);
                 foreach (string eventName in _domEventsNamesToListenTo)
                 {
                     string sElement = INTERNAL_InteropImplementation.GetVariableStringForJS(domElement);
-                    string sAction = INTERNAL_InteropImplementation.GetVariableStringForJS(_handler);
                     OpenSilver.Interop.ExecuteJavaScriptFastAsync(
                         $@"document.addEventListenerSafe({sElement}, ""{eventName}"", {sAction})"
                     );

--- a/src/Runtime/Runtime/Core/Events/INTERNAL_EventsHelper.cs
+++ b/src/Runtime/Runtime/Core/Events/INTERNAL_EventsHelper.cs
@@ -94,6 +94,8 @@ namespace CSHTML5.Internal
             else
                 Interop.ExecuteJavaScriptFastAsync($@"document.removeEventListenerSafe({INTERNAL_InteropImplementation.GetVariableStringForJS(domElementRef)}, ""{eventName}"", {sAction})");
 
+            JavascriptCallback.Remove(proxy.Handler);
+
             /*
             DOMEventType eventType;
 

--- a/src/Runtime/Runtime/OpenSilver/Internal/Xaml/RuntimeHelpers.cs
+++ b/src/Runtime/Runtime/OpenSilver/Internal/Xaml/RuntimeHelpers.cs
@@ -15,6 +15,7 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Xaml;
+using CSHTML5.Internal;
 using OpenSilver.Internal.Xaml.Context;
 
 #if MIGRATION
@@ -247,5 +248,11 @@ namespace OpenSilver.Internal.Xaml
             Debug.Assert(uie != null);
             uie.KeepHiddenInFirstRender = value;
         }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void RemoveJavascriptCallback(Delegate d) {
+            JavascriptCallback.Remove(d);
+        }
+
     }
 }

--- a/src/Runtime/Runtime/System.Windows/Content.cs
+++ b/src/Runtime/Runtime/System.Windows/Content.cs
@@ -36,10 +36,10 @@ namespace Windows.UI.Xaml // Note: we didn't use the "Interop" namespace to avoi
             if (hookupEvents)
             {
                 // Hooks the FullScreenChanged event
-                OpenSilver.Interop.ExecuteJavaScriptVoid($"document.addEventListener('fullscreenchange', {INTERNAL_InteropImplementation.GetVariableStringForJS(new Action(FullScreenChangedCallback))})");
+                OpenSilver.Interop.ExecuteJavaScriptVoid($"document.addEventListener('fullscreenchange', {INTERNAL_InteropImplementation.GetVariableStringForJS(FullScreenChangedCallback)})");
 
                 // Hooks the Resized event
-                OpenSilver.Interop.ExecuteJavaScriptVoid($"new ResizeSensor(document.getXamlRoot(), {INTERNAL_InteropImplementation.GetVariableStringForJS(new Action(WindowResizeCallback))})");
+                OpenSilver.Interop.ExecuteJavaScriptVoid($"new ResizeSensor(document.getXamlRoot(), {INTERNAL_InteropImplementation.GetVariableStringForJS(WindowResizeCallback)})");
 
                 // WORKINPROGRESS
                 // Add Zoomed event

--- a/src/Runtime/Runtime/System.Windows/Settings.cs
+++ b/src/Runtime/Runtime/System.Windows/Settings.cs
@@ -174,6 +174,13 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsRunningOutOfBrowser { get; set; }
 
+        // if turned on, in case of Javascript error, we'll drop a detailed message with the JS that caused the issue
+        //
+        // so why isn't this always ON ?
+        // Because this leaks strings. You should turn this on only when you get JS errors, to get the full details
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool EnableJavascriptErrorCallback { get; set; } = false;
+
         /// <summary>
         /// Gets or sets a value that indicates whether the Silverlight plug-in will resize
         /// its content based on the current browser zoom setting.


### PR DESCRIPTION
Memory consumption improvements (expected: 10-15+%)

1. JavascriptCallback A. Now, I hold a dictionary with the Delegate being the key.  The advantage here is that for a certain Delegate, only one callback is generated (and subsequently returned) - less leaks B. Added .Remove(Delegate), so you can manually remove the Delegate from the callback collection once you don't need it anymore C. You can use RuntimeHelpers.RemoveJavascriptCallback to remove such a callback yourself, from client code D. Overload for InteropImplementation.GetVariableStringForJS for delegates

2. Error Callback (INTERNAL_InteropImplementation) A. Setting to turn ErrorCallback ON/OFF (OFF by default) B. The idea here is that when using ErrorCallback, this will leak strings. So, just use it if/when you get a JS Exception (you'll see that in the console)

3. SynchronizedStore A. Use a dictionary instead of a list.
B The rationale is -- in the old code, the List would only grow, Clean() would just set the _items[index] to default.