### PR TITLE
implement autofocus for Dialogs

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/Control.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Control.cs
@@ -549,7 +549,7 @@ namespace Windows.UI.Xaml.Controls
                 nameof(TabIndex), 
                 typeof(int), 
                 typeof(Control), 
-                new PropertyMetadata(int.MaxValue)
+                new PropertyMetadata(int.MaxValue, new PropertyChangedCallback(OnTabIndexChanged))
                 {
                     MethodToUpdateDom = static (d, newValue) =>
                     {
@@ -557,6 +557,14 @@ namespace Windows.UI.Xaml.Controls
                         control.UpdateTabIndex(control.IsTabStop, (int)newValue);
                     },
                 });
+
+        private static void OnTabIndexChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var control = (Control)d;
+            control.TabIndex = (int)e.NewValue;
+            var z = e.NewValue;
+            //throw new NotImplementedException();
+        }
 
         private const int TABINDEX_BROWSER_MAX_VALUE = 32767;
 
@@ -719,7 +727,7 @@ namespace Windows.UI.Xaml.Controls
         /// true if focus was set to the control, or focus was already on the control.
         /// false if the control is not focusable.
         /// </returns>
-        public bool Focus()
+        public virtual bool Focus()
         {
             if (!Keyboard.IsSubTreeFocusable(this))
             {

--- a/src/Runtime/Runtime/System.Windows.Controls/Control.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Control.cs
@@ -549,7 +549,7 @@ namespace Windows.UI.Xaml.Controls
                 nameof(TabIndex), 
                 typeof(int), 
                 typeof(Control), 
-                new PropertyMetadata(int.MaxValue, new PropertyChangedCallback(OnTabIndexChanged))
+                new PropertyMetadata(int.MaxValue)
                 {
                     MethodToUpdateDom = static (d, newValue) =>
                     {
@@ -557,14 +557,6 @@ namespace Windows.UI.Xaml.Controls
                         control.UpdateTabIndex(control.IsTabStop, (int)newValue);
                     },
                 });
-
-        private static void OnTabIndexChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var control = (Control)d;
-            control.TabIndex = (int)e.NewValue;
-            var z = e.NewValue;
-            //throw new NotImplementedException();
-        }
 
         private const int TABINDEX_BROWSER_MAX_VALUE = 32767;
 

--- a/src/Tests/TestApplication/TestApplication/TestingChildWindow/LoginWindow.xaml
+++ b/src/Tests/TestApplication/TestApplication/TestingChildWindow/LoginWindow.xaml
@@ -13,9 +13,9 @@
         </Grid.RowDefinitions>
         <StackPanel>
             <TextBlock Text="Name" />
-            <TextBox x:Name="nameBox"/>
+            <TextBox x:Name="nameBox" TabIndex="1"/>
             <TextBlock Text="Password" />
-            <PasswordBox x:Name="passwordBox"/>
+            <PasswordBox x:Name="passwordBox" TabIndex="0"/>
         </StackPanel>
 
         <Button x:Name="CancelButton" Content="Cancel" Click="CancelButton_Click" Width="75" Height="23" HorizontalAlignment="Right" Margin="0,12,0,0" Grid.Row="1" />


### PR DESCRIPTION
In Silverlight, when we open new dialog window, first focusable element (textbox,passwordbox etc) is focused (according to TabIndex). In OpenSilver it is not. This pr autofocuses control by TabIndex. Test application contains TestingChildWindow, if you open that dialog passwordbox should be autofocused