### PR TITLE
fix: fix keyup event not being triggered

### DIFF
--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -583,7 +583,7 @@ document.createInputManager = function (callback) {
                 view.addEventListener('keyup', function (e) {
                     if (!e.isHandled) {
                         e.isHandled = true;
-                        callback(this.id, EVENTS.KEYPRESS, e);
+                        callback(this.id, EVENTS.KEYUP, e);
                     }
                 });
 


### PR DESCRIPTION
JS event callback had the wrong enum id for when it was keyup