### PR TITLE
Interop2 - another way to execute javascript that doesn't consume as much memory

### DIFF
--- a/src/Runtime/Runtime/Core/Main/INTERNAL_ExecuteJavaScript.cs
+++ b/src/Runtime/Runtime/Core/Main/INTERNAL_ExecuteJavaScript.cs
@@ -36,6 +36,22 @@ namespace CSHTML5.Internal
         public static object ExecuteJavaScriptWithResult(string javascript, bool flush = true)
             => ExecuteJavaScriptSync(javascript, referenceId: 0, wantsResult: true, flush: flush);
 
+
+        // allow calling custom JS functions
+        public static object ExecuteJavaScriptFuncSync<T>(string funcName, T arg0) {
+            return JavaScriptRuntime.ExecuteJavaScriptFunc(funcName, arg0);
+        }
+
+        // allow calling custom JS functions
+        public static object ExecuteJavaScriptFuncSync<T0,T1>(string funcName, T0 arg0, T1 arg1) {
+            return JavaScriptRuntime.ExecuteJavaScriptFunc(funcName, arg0, arg1);
+        }
+
+        // allow calling custom JS functions
+        public static object ExecuteJavaScriptFuncSync<T0,T1,T2>(string funcName, T0 arg0, T1 arg1, T2 arg2) {
+            return JavaScriptRuntime.ExecuteJavaScriptFunc(funcName, arg0, arg1, arg2);
+        }
+
         /// <summary>
         /// Executes JavaScript code immediately. This also forces all the pending async JS code to be executed (flush).
         /// </summary>

--- a/src/Runtime/Runtime/Core/Rendering/INTERNAL_HtmlDomManager.JsCall.cs
+++ b/src/Runtime/Runtime/Core/Rendering/INTERNAL_HtmlDomManager.JsCall.cs
@@ -1,0 +1,258 @@
+﻿using OpenSilver;
+
+namespace CSHTML5.Internal;
+
+public static partial class INTERNAL_HtmlDomManager
+{
+    private enum JsCall
+    {
+        [JsCall("ref;document.getXamlRoot()")]
+        GetXamlRoot,
+
+        [JsCall(@"void;
+let element = document.getElementById({htmlDomElRef.UniqueIdentifier});
+if (element) element.parentNode.removeChild(element);
+")]
+        RemoveFromDom,
+
+        [JsCall("{sDomElement}.childNodes.length")]
+        GetChildDomElementAt1,
+
+        [JsCall("let child = {sDomElement}.childNodes[{index,n}]; return child.id;")]
+        GetChildDomElementAt2,
+
+        [JsCall("ref;window")]
+        HtmlWindow,
+
+
+
+
+
+
+
+
+        [JsCall("void;{sElement}.focus({{ preventScroll: true }});")]
+        SetFocusNative,
+
+        [JsCall("void;document.setContentString({uniqueIdentifier},{content},{removeTextWrapping})")]
+        SetContent,
+
+        [JsCall(@"void;
+let element = document.getElementById({uniqueIdentifier});
+if (element)
+{{
+element.value = {newText};
+element.style.visibility='collapse';
+setTimeout(function() {{ let element2 = document.getElementById({uniqueIdentifier}); if (element2) {{ element2.style.visibility='visible'; }} }}, 0);
+}}
+")]
+        SetUIElementContent,
+
+        [JsCall("getTextAreaInnerText({sElement})")]
+        GetTextBoxText,
+
+        [JsCall(@"ref;
+(function() {{
+    let option = document.createElement('option');
+    option.text = {elementToAdd};
+    {sElement}.add(option, {index,n});
+    return option;
+}}())")]
+        AddOptionToNativeComboBoxAtIndex,
+
+        [JsCall(@"ref;
+(function() {{
+    let option = document.createElement('option');
+    option.text = {elementToAdd};
+    {sElement}.add(option);
+    return option;
+}}())")]
+        AddOptionToNativeComboBox,
+
+        [JsCall("void;{sElement}.removeChild({sToRemove})")]
+        RemoveChild,
+
+        [JsCall("void;{sElement}.remove({index,n})")]
+        RemoveIndex,
+
+        [JsCall("void;let element = document.getElementById({uniqueIdentifier});if (element) {{ element[{attributeName}] = {attributeValue} }};")]
+        SetDomElementProperty,
+        
+        [JsCall("void;document.setDomAttribute({uid},{attributeName},{value})")]
+        SetDomElementAttribute,
+
+        [JsCall("void;document.setDomAttribute({uid},{attributeName},{value,d})")]
+        SetDomElementAttributeDouble,
+
+        [JsCall("void;let element = document.getElementById({uniqueIdentifier});if (element) {{ element.removeAttribute({attributeName}) }};")]
+        RemoveDomElementAttribute,
+
+        [JsCall("ref;{sElement}[{attributeName}]")]
+        GetDomElementAttribute,
+
+        [JsCall("void;document.createPopupRootElement('{uniqueIdentifier}', {sRootElement}, '{sPointerEvents}');")]
+        CreatePopupRoot,
+
+        [JsCall("void;document.createTextBlockElement({uniqueIdentifier}, {sParentRef}, {wrap})")]
+        CreateTextBlock,
+
+        [JsCall("void;document.createCanvasElement({uniqueIdentifier}, {sParentRef})")]
+        CreateCanvas,
+
+        [JsCall("void;document.createImageElement({uniqueIdentifier}, {sParentRef})")]
+        CreateImage,
+        
+        [JsCall("void;document.createFrameworkElement({uniqueIdentifier}, {sParentRef}, {enablePointerEvents,b})")]
+        CreateFE,
+
+        
+        [JsCall("void;document.createRunElement({uniqueIdentifier}, {sParentRef})")]
+        CreateRun,
+
+        
+        [JsCall("void;document.createShapeOuterElement({uniqueIdentifier}, {sParentRef})")]
+        CreateShapeOuter,
+
+        
+        [JsCall("void;document.createShapeInnerElement({uniqueIdentifier}, {sParentRef})")]
+        CreateShapeInner,
+
+        
+        [JsCall("void;document.createElementSafe({domElementTag}, {uniqueIdentifier}, {sParentRef}, {index,n})")]
+        CreateDomElement,
+
+        [JsCall(@"void;
+let newElement = document.createElement({domElementTag});
+newElement.setAttribute('id', {uniqueIdentifier});
+let parentElement = document.getElementByIdSafe({parentUniqueIdentifier});
+parentElement.children[{insertionIndex,n}].insertAdjacentElement({relativePosition}, newElement);")]
+        CreateDomElementAndInsert,
+
+        [JsCall(@"void;
+let tempDiv = document.createElement(div);
+tempDiv.innerHTML = {domAsString};
+let newElement = tempDiv.firstChild;
+newElement.setAttribute('id', {uniqueIdentifier});
+let parentElement = document.getElementByIdSafe({parentUniqueIdentifier});
+parentElement.appendChild(newElement);")]
+        CreateDomFromString,
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        
+        [JsCall(@"void;
+let child = document.getElementByIdSafe({childUniqueIdentifier});
+let parentElement = document.getElementByIdSafe({parentUniqueIdentifier});
+parentElement.appendChild(child);
+")]
+        AppendChild,
+
+        
+        [JsCall(@"ref;
+(function(){{
+    let domElementAtCoordinates = document.elementFromPoint({x,n}, {y,n});
+    if (!domElementAtCoordinates || domElementAtCoordinates === document.documentElement)
+    {{
+        return null;
+    }}
+    else
+    {{
+        return domElementAtCoordinates;
+    }}
+}}())")]
+        FindElementSimulator,
+
+        
+        [JsCall("window.elementsFromPointOpensilver({intersectingPoint.X,d},{intersectingPoint.Y,d},{sDiv})")]
+        FindElement,
+        [JsCall("window.elementsFromPointOpensilver({intersectingPoint.X,d},{intersectingPoint.Y,d},null)")]
+        FindElementNull,
+
+        
+        [JsCall("$0 == null")]
+        GetUIElementFromDomElement0,
+
+        
+        [JsCall("{sElement}.id")]
+        GetUIElementFromDomElementGetId,
+        
+        [JsCall("ref;{sElement}.parentNode")]
+        GetParentNode,
+
+        [JsCall("void;document.setVisualBounds({style.Uid},{left,d},{top,d},{width,d},{height,d},{bSetPositionAbsolute,n},{bSetZeroMargin,n},{bSetZeroPadding,n})")]
+        SetVisualBounds,
+
+        
+        [JsCall("void;document.setPosition({style.Uid},{left,d},{top,d},{bSetPositionAbsolute,n},{bSetZeroMargin,n},{bSetZeroPadding,n})")]
+        SetPosition,
+
+        [JsCall("let element = document.getElementById({uniqueIdentifier});if (element) {{ $result = element[{methodName}](); }};")]
+        CallDomMethod,
+
+        [JsCall("let element = document.getElementById({uniqueIdentifier});if (element) {{ $result = element[{methodName}]({parameters}); }};")]
+        CallDomMethodArg,
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        [JsCall(@"void;
+let element = document.getElementById({uniqueIdentifier});
+if (!element)
+    return;
+
+$temp0 = JSON.parse({values});
+for (const v of $temp0)
+    element.style[v.propertyName] = v.value;
+")]
+        SetDomElementStyleProperty,
+
+        [JsCall("void;document.velocityHelpers.setDomStyle({sElement}, '{cssPropertyNames}', {sCssValue});")]
+        SetDomElementStylePropertyUsingVelocity,
+
+
+
+
+
+
+
+
+
+
+        
+
+
+    }
+}

--- a/src/Runtime/Runtime/OpenSilver/Internal/StringBuilderFactory.cs
+++ b/src/Runtime/Runtime/OpenSilver/Internal/StringBuilderFactory.cs
@@ -22,11 +22,23 @@ internal static class StringBuilderFactory
 
     static StringBuilderFactory()
     {
-        var provider = new DefaultObjectPoolProvider { MaximumRetained = 10 };
-        _pool = provider.CreateStringBuilderPool();
+        var provider = new DefaultObjectPoolProvider { };
+        _pool = provider.CreateStringBuilderPool( initialCapacity: 16 * 1024, maximumRetainedCapacity: 32);
     }
 
-    public static StringBuilder Get() => _pool.Get();
+    public static StringBuilder Get() {
+        var sb = _pool.Get();
+        sb.Clear();
+        return sb;
+    }
+
+    // helper - wrap a string into a stringbuilder
+    public static StringBuilder Get(string s) {
+        var sb = _pool.Get();
+        sb.Clear();
+        sb.Append(s);
+        return sb;
+    }
 
     public static void Return(StringBuilder sb) => _pool.Return(sb);
 }

--- a/src/Runtime/Runtime/OpenSilver/Internal/StringBuilderFactory.cs
+++ b/src/Runtime/Runtime/OpenSilver/Internal/StringBuilderFactory.cs
@@ -22,23 +22,11 @@ internal static class StringBuilderFactory
 
     static StringBuilderFactory()
     {
-        var provider = new DefaultObjectPoolProvider { };
-        _pool = provider.CreateStringBuilderPool( initialCapacity: 16 * 1024, maximumRetainedCapacity: 32);
+        var provider = new DefaultObjectPoolProvider { MaximumRetained = 10 };
+        _pool = provider.CreateStringBuilderPool();
     }
 
-    public static StringBuilder Get() {
-        var sb = _pool.Get();
-        sb.Clear();
-        return sb;
-    }
-
-    // helper - wrap a string into a stringbuilder
-    public static StringBuilder Get(string s) {
-        var sb = _pool.Get();
-        sb.Clear();
-        sb.Append(s);
-        return sb;
-    }
+    public static StringBuilder Get() => _pool.Get();
 
     public static void Return(StringBuilder sb) => _pool.Return(sb);
 }

--- a/src/Runtime/Runtime/PublicAPI/Interop/BulkExecuteJavascriptAsync.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/BulkExecuteJavascriptAsync.cs
@@ -25,23 +25,17 @@ namespace OpenSilver
     {
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
         private readonly StringBuilder _javascript;
-        private StringBuilder _jsBuffer;
 
         public BulkExecuteJavascriptAsync()
         {
             _javascript = StringBuilderFactory.Get();
         }
 
-        private StringBuilder JsBuffer(string s) {
-            if (_jsBuffer == null)
-                _jsBuffer = StringBuilderFactory.Get(s);
-            return _jsBuffer;
-        }
 
         public IDisposable AddJavascriptAsync(string javascript, params object[] variables)
         {
-            INTERNAL_InteropImplementation.ReplaceJSArgsStringBuilder(JsBuffer(javascript), variables);
-            return AddJavascriptAsync(_jsBuffer.ToString());
+            javascript = INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, variables);
+            return AddJavascriptAsync(javascript);
         }
 
         public IDisposable AddJavascriptAsync(string javascript)
@@ -57,8 +51,8 @@ namespace OpenSilver
 
         public void AddJavascript(string javascript, params object[] variables)
         {
-            INTERNAL_InteropImplementation.ReplaceJSArgsStringBuilder( JsBuffer(javascript), variables);
-            AddJavascript(_jsBuffer.ToString());
+            javascript = INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, variables);
+            AddJavascript(javascript);
         }
 
         public void AddJavascript(string javascript)
@@ -88,8 +82,6 @@ namespace OpenSilver
             }
 
             StringBuilderFactory.Return(_javascript);
-            if (_jsBuffer != null)
-                StringBuilderFactory.Return(_jsBuffer);
 
             // Console.WriteLine($"disposed of JS Obj Refs: {string.Join(",", _disposables.OfType<INTERNAL_JSObjectReference>().Select(js => js.ReferenceId))}");
             foreach (var d in _disposables)

--- a/src/Runtime/Runtime/PublicAPI/Interop/BulkExecuteJavascriptAsync.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/BulkExecuteJavascriptAsync.cs
@@ -25,16 +25,23 @@ namespace OpenSilver
     {
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
         private readonly StringBuilder _javascript;
+        private StringBuilder _jsBuffer;
 
         public BulkExecuteJavascriptAsync()
         {
             _javascript = StringBuilderFactory.Get();
         }
 
+        private StringBuilder JsBuffer(string s) {
+            if (_jsBuffer == null)
+                _jsBuffer = StringBuilderFactory.Get(s);
+            return _jsBuffer;
+        }
+
         public IDisposable AddJavascriptAsync(string javascript, params object[] variables)
         {
-            javascript = INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, variables);
-            return AddJavascriptAsync(javascript);
+            INTERNAL_InteropImplementation.ReplaceJSArgsStringBuilder(JsBuffer(javascript), variables);
+            return AddJavascriptAsync(_jsBuffer.ToString());
         }
 
         public IDisposable AddJavascriptAsync(string javascript)
@@ -50,8 +57,8 @@ namespace OpenSilver
 
         public void AddJavascript(string javascript, params object[] variables)
         {
-            javascript = INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, variables);
-            AddJavascript(javascript);
+            INTERNAL_InteropImplementation.ReplaceJSArgsStringBuilder( JsBuffer(javascript), variables);
+            AddJavascript(_jsBuffer.ToString());
         }
 
         public void AddJavascript(string javascript)
@@ -81,6 +88,8 @@ namespace OpenSilver
             }
 
             StringBuilderFactory.Return(_javascript);
+            if (_jsBuffer != null)
+                StringBuilderFactory.Return(_jsBuffer);
 
             // Console.WriteLine($"disposed of JS Obj Refs: {string.Join(",", _disposables.OfType<INTERNAL_JSObjectReference>().Select(js => js.ReferenceId))}");
             foreach (var d in _disposables)

--- a/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_InteropImplementation.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_InteropImplementation.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using OpenSilver.Internal;
 
@@ -104,7 +105,7 @@ namespace CSHTML5
             }
         }
 
-        internal static string ReplaceJSArgs(string javascript, params object[] variables)
+        internal static void ReplaceJSArgsStringBuilder(StringBuilder javascript, params object[] variables)
         {
             // Make sure the JS to C# interop is set up:
             EnsureInitialized();
@@ -117,11 +118,22 @@ namespace CSHTML5
             // followed by the number "0". To reproduce the issue, call "ExecuteJavaScript" passing
             // 10 arguments and using "$10".
             for (int i = variables.Length - 1; i >= 0; i--)
-            {
-                javascript = javascript.Replace($"${i}", GetVariableStringForJS(variables[i]));
-            }
+                javascript.Replace($"${i}", GetVariableStringForJS(variables[i]));
+        }
 
-            return javascript;
+        [Obsolete("use ReplaceJSArgsStringBuilder")]
+        internal static string ReplaceJSArgs(string javascript, params object[] variables) {
+            // Make sure the JS to C# interop is set up:
+            EnsureInitialized();
+
+            if (variables.Length == 0)
+                return javascript;
+
+            var sb = StringBuilderFactory.Get(javascript);
+            ReplaceJSArgsStringBuilder(sb, variables);
+            var result = sb.ToString();
+            StringBuilderFactory.Return(sb);
+            return result;
         }
 
         internal static object ExecuteJavaScript_Implementation(

--- a/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_InteropImplementation.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_InteropImplementation.cs
@@ -122,6 +122,9 @@ namespace CSHTML5
             return javascript;
         }
 
+        // used in Interop2
+        internal static int NewReferenceId() => _refIdGenerator.NewId();
+
         internal static object ExecuteJavaScript_Implementation(
             string javascript,
             bool runAsynchronously,

--- a/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_InteropImplementation.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_InteropImplementation.cs
@@ -105,8 +105,8 @@ namespace CSHTML5
             }
         }
 
-        internal static void ReplaceJSArgsStringBuilder(StringBuilder javascript, params object[] variables)
-        {
+
+        internal static string ReplaceJSArgs(string javascript, params object[] variables) {
             // Make sure the JS to C# interop is set up:
             EnsureInitialized();
 
@@ -118,22 +118,8 @@ namespace CSHTML5
             // followed by the number "0". To reproduce the issue, call "ExecuteJavaScript" passing
             // 10 arguments and using "$10".
             for (int i = variables.Length - 1; i >= 0; i--)
-                javascript.Replace($"${i}", GetVariableStringForJS(variables[i]));
-        }
-
-        [Obsolete("use ReplaceJSArgsStringBuilder")]
-        internal static string ReplaceJSArgs(string javascript, params object[] variables) {
-            // Make sure the JS to C# interop is set up:
-            EnsureInitialized();
-
-            if (variables.Length == 0)
-                return javascript;
-
-            var sb = StringBuilderFactory.Get(javascript);
-            ReplaceJSArgsStringBuilder(sb, variables);
-            var result = sb.ToString();
-            StringBuilderFactory.Return(sb);
-            return result;
+                javascript = javascript.Replace($"${i}", GetVariableStringForJS(variables[i]));
+            return javascript;
         }
 
         internal static object ExecuteJavaScript_Implementation(

--- a/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_JSObjectReference.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_JSObjectReference.cs
@@ -90,6 +90,9 @@ namespace CSHTML5.Types
 
         private void RemoveFromJS()
         {
+            //FIXME
+            return;
+
             if (ReferenceId != string.Empty)
             {
                 INTERNAL_ExecuteJavaScript.QueueExecuteJavaScript($"delete document.jsObjRef['{ReferenceId}']");

--- a/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_JSObjectReference.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/INTERNAL_JSObjectReference.cs
@@ -90,9 +90,6 @@ namespace CSHTML5.Types
 
         private void RemoveFromJS()
         {
-            //FIXME
-            return;
-
             if (ReferenceId != string.Empty)
             {
                 INTERNAL_ExecuteJavaScript.QueueExecuteJavaScript($"delete document.jsObjRef['{ReferenceId}']");

--- a/src/Runtime/Runtime/PublicAPI/Interop/Interop.Obsolete.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/Interop.Obsolete.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Runtime.OpenSilver.PublicAPI.Interop;
 
 #if MIGRATION
 using System.Windows;

--- a/src/Runtime/Runtime/PublicAPI/Interop/Interop.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/Interop.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using CSHTML5;
 using OpenSilver.Internal;
 using Runtime.OpenSilver.PublicAPI.Interop;
 
@@ -160,6 +161,14 @@ namespace OpenSilver
         public static T1 ExecuteJavaScriptGetResult<T1>(string javascript)
         {
             JavascriptCallsTracker.Instance.AddJavascriptCall(javascript);
+            var result = INTERNAL_ExecuteJavaScript.ExecuteJavaScriptSync(javascript, referenceId: 0, wantsResult: true, flush: true);
+            T1 t1 = ConvertJavascriptResult<T1>(result);
+            return t1;
+        }
+        public static T1 ExecuteJavaScriptGetResult<T1>(string javascript, params object[] variables)
+        {
+            JavascriptCallsTracker.Instance.AddJavascriptCall(javascript);
+            javascript = INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, variables);
             var result = INTERNAL_ExecuteJavaScript.ExecuteJavaScriptSync(javascript, referenceId: 0, wantsResult: true, flush: true);
             T1 t1 = ConvertJavascriptResult<T1>(result);
             return t1;

--- a/src/Runtime/Runtime/PublicAPI/Interop/Interop.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/Interop.cs
@@ -174,10 +174,21 @@ namespace OpenSilver
             INTERNAL_ExecuteJavaScript.ExecuteJavaScriptSync(javascript, referenceId: 0, wantsResult: false, flush: true);
         }
 
-        public static void ExecuteJavaScriptVoidAsync(string javascript, params object[] variables)
+        public static void CreateJavascriptFunction(string funcName, string javascript)
         {
-            javascript = CSHTML5.INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, variables);
+            INTERNAL_ExecuteJavaScript.ExecuteJavaScriptFuncSync("createFunction", funcName, javascript);
+        }
+
+        public static object CallJavascriptFunction(string funcName, int subId, string args) 
+        {
+            return INTERNAL_ExecuteJavaScript.ExecuteJavaScriptFuncSync("callFunction", funcName, subId, args);
+        }
+
+        public static void ExecuteJavaScriptVoidAsync(string javascript, params object[] variables) {
+            var sb = StringBuilderFactory.Get(javascript);
+            CSHTML5.INTERNAL_InteropImplementation.ReplaceJSArgsStringBuilder(sb, variables);
             INTERNAL_ExecuteJavaScript.QueueExecuteJavaScript(javascript);
+            StringBuilderFactory.Return(sb);
         }
 
         public static void ExecuteJavaScriptVoidAsync(string javascript)

--- a/src/Runtime/Runtime/PublicAPI/Interop/JSObjectReferenceHolder.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/JSObjectReferenceHolder.cs
@@ -86,7 +86,7 @@ namespace OpenSilver.Internal
         }
 
         private static string[] _ignoreFunctionNames = new[] {
-            ".INTERNAL_JsObjectReferenceHolder.Add",
+            ".JsObjectReferenceHolder.Add",
             ".INTERNAL_JSObjectReference..ctor",
             ".ExecuteJavaScript_Implementation",
             ".ExecuteJavaScript_GetJSObject",

--- a/src/Runtime/Runtime/PublicAPI/Interop/JavascriptCallsTracker.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/JavascriptCallsTracker.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenSilver.Internal;
+
+namespace Runtime.OpenSilver.PublicAPI.Interop
+{
+    internal static class ReadOnlyListExtensions {
+        public static int FindLastIndex<T>(this IReadOnlyList<T> self, Predicate<T> match) => FindLastIndex(self, self.Count - 1, self.Count, match);
+
+        public static int FindLastIndex<T>(this IReadOnlyList<T> self, int startIndex, int count, Predicate<T> match) {
+            if (self.Count == 0)
+                return -1;
+
+            if (startIndex >= self.Count)
+                return -1;
+
+            if (count < 0 || startIndex - count + 1 < 0)
+                return -1;
+
+            int endIndex = startIndex - count;
+            for (int i = startIndex; i > endIndex; i--)
+            {
+                if (match(self[i]))
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+    }
+
+    [SuppressMessage("ReSharper", "LocalizableElement")]
+    internal class JavascriptCallsTracker
+    {
+        private JavascriptCallsTracker(){ }
+        public static JavascriptCallsTracker Instance { get; } = new JavascriptCallsTracker();
+
+        private bool _isTracking = false;
+        
+        private int _bigCount = 50;
+
+        // how many calls to dump
+        private int _dumTopCount = 15;
+
+        private static int _maxJavascriptSize = 128;
+
+        private class CallInfo
+        {
+            public FunctionDetails FuncInfo;
+            public string Javascript;
+            public DateTime LastCall { get; private set; } = DateTime.Now;
+            public int CallCount { get; private set; } = 1;
+
+            public void AddCall()
+            {
+                ++CallCount;
+                LastCall = DateTime.Now;
+            }
+        }
+
+        private class CallArrayInfo
+        {
+            public Dictionary<string, CallInfo> All = new Dictionary<string, CallInfo>();
+            public int PrevCallCount = 0;
+            public int PrevCallStringSizeSum = 0;
+
+            public int CallCount = 0;
+            public int CallStringSizeSum = 0;
+
+            public void Clear()
+            {
+                All.Clear();
+                CallCount = 0;
+                CallStringSizeSum = 0;
+                PrevCallCount = 0;
+                PrevCallStringSizeSum = 0;
+            }
+
+            public void AddCall(FunctionDetails funcInfo, string js)
+            {
+                ++CallCount;
+                CallStringSizeSum += js.Length;
+                var funcName = funcInfo.FunctionName;
+                if (All.TryGetValue(funcName, out var call))
+                    call.AddCall();
+                else
+                {
+                    var jsInfo = js.Length < _maxJavascriptSize ? js : js.Substring(0, _maxJavascriptSize) + "...";
+                    All.Add(funcName, new CallInfo { FuncInfo = funcInfo, Javascript = jsInfo });
+                }
+            }
+        }
+
+        private CallArrayInfo _all = new CallArrayInfo();
+        private CallArrayInfo _shortTimeLast = new CallArrayInfo();
+        private CallArrayInfo _bigTimeLast = new CallArrayInfo();
+
+        public async void StackTracking(int ms)
+        {
+            _isTracking = true;
+
+            var secs = (double)ms / 1000d;
+            int bigTimeIndex = 0;
+            while (true)
+            {
+                await Task.Delay(ms);
+                DumpCallInfos(_shortTimeLast, $"NOW-{secs:F2}");
+                _shortTimeLast.Clear();
+                DumpCallInfos(_bigTimeLast, $"LAST-{(secs * _bigCount):F2}");
+                var needsResetPrevCallCount = (bigTimeIndex++ % _bigCount) == 0;
+                if (needsResetPrevCallCount)
+                    _bigTimeLast.Clear();
+                DumpCallInfos(_all, "ALL");
+            }
+        }
+
+        private void DumpCallInfos(CallArrayInfo ci, string callsType)
+        {
+            if (ci.PrevCallCount == ci.CallCount)
+                return; // no new calls
+
+            Console.WriteLine($"**** JS CALLS {callsType} - calls {ci.CallCount} ; size= {ci.CallStringSizeSum} ");
+            var top = ci.All.Values.OrderByDescending(c => c.CallCount).Take(_dumTopCount).ToList();
+            Console.WriteLine($"     {string.Join("\r\n     ", top.Select(c => $"calls={c.CallCount} {c.FuncInfo.FunctionName} : '{c.Javascript}'"))}");
+
+            ci.PrevCallCount = ci.CallCount;
+            ci.PrevCallStringSizeSum = ci.CallStringSizeSum;
+        }
+
+        public void AddJavascriptCall(string js)
+        {
+            if (!_isTracking)
+                return;
+
+            var stackTrace = StackTraceProvider.StackTrace().ToList();
+            // look for .Interop.ExecuteJavaScript...
+            // why the last? just in case there are calls to the obsolete API (Cshtml5...)
+            var prevCallIdx = stackTrace.FindLastIndex(st => st.FunctionName.Contains(".Interop.ExecuteJavaScript"));
+            if (prevCallIdx < 0 || prevCallIdx + 1 >= stackTrace.Count)
+            {
+                Console.WriteLine($"FATAL: invalid Javascript call {string.Join("\r\n", stackTrace.Select(st => st.FunctionName))}");
+                return;
+            }
+
+            var callInfo = stackTrace[prevCallIdx + 1];
+            _all.AddCall(callInfo, js);
+            _shortTimeLast.AddCall(callInfo, js);
+            _bigTimeLast.AddCall(callInfo, js);
+        }
+    }
+}

--- a/src/Runtime/Runtime/PublicAPI/Interop/JavascriptCallsTracker.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/JavascriptCallsTracker.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OpenSilver;
 using OpenSilver.Internal;
 
 namespace Runtime.OpenSilver.PublicAPI.Interop
@@ -105,6 +106,7 @@ namespace Runtime.OpenSilver.PublicAPI.Interop
 
             var secs = (double)ms / 1000d;
             int bigTimeIndex = 0;
+            int interop2CallCount = Interop2Caller.CallCount;
             while (true)
             {
                 await Task.Delay(ms);
@@ -115,6 +117,10 @@ namespace Runtime.OpenSilver.PublicAPI.Interop
                 if (needsResetPrevCallCount)
                     _bigTimeLast.Clear();
                 DumpCallInfos(_all, "ALL");
+                var interop2Diff = Interop2Caller.CallCount - interop2CallCount;
+                if (interop2Diff > 0)
+                    Console.WriteLine($"*** INTEROP2: +{interop2Diff} ({Interop2Caller.CallCount})");
+                interop2CallCount = Interop2Caller.CallCount;
             }
         }
 

--- a/src/Runtime/Runtime/PublicAPI/Interop/PendingJavascript.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/PendingJavascript.cs
@@ -26,6 +26,10 @@ namespace CSHTML5.Internal
 
         void Flush();
 
+        object ExecuteJavaScriptFunc<T>(string funcName, T arg0);
+        object ExecuteJavaScriptFunc<T0, T1>(string funcName, T0 arg0, T1 arg1);
+        object ExecuteJavaScriptFunc<T0, T1, T2>(string funcName, T0 arg0, T1 arg1, T2 arg2);
+
         object ExecuteJavaScript(string javascript, int referenceId, bool wantsResult);
     }
 
@@ -84,6 +88,19 @@ namespace CSHTML5.Internal
             _webAssemblyExecutionHandler.InvokeUnmarshalled<byte[], int, object>(CallJSMethodNameAsync, _buffer, curLength);
         }
 
+        public object ExecuteJavaScriptFunc<T>(string funcName, T arg0) {
+            var result = _webAssemblyExecutionHandler.InvokeUnmarshalled<T, object>(funcName, arg0);
+            return result;
+        }
+        public object ExecuteJavaScriptFunc<T0,T1>(string funcName, T0 arg0, T1 arg1) {
+            var result = _webAssemblyExecutionHandler.InvokeUnmarshalled<T0, T1, object>(funcName, arg0, arg1);
+            return result;
+        }
+        public object ExecuteJavaScriptFunc<T0,T1,T2>(string funcName, T0 arg0, T1 arg1, T2 arg2) {
+            var result = _webAssemblyExecutionHandler.InvokeUnmarshalled<T0, T1, T2, object>(funcName, arg0, arg1, arg2);
+            return result;
+        }
+
         public object ExecuteJavaScript(string javascript, int referenceId, bool wantsResult)
         {
             // IMPORTANT: wantsResult is passed on to JS, so that it will know if it needs to pass anything back to us
@@ -117,6 +134,19 @@ namespace CSHTML5.Internal
             string javascript = ReadAndClearAggregatedPendingJavaScriptCode();
             if (!string.IsNullOrWhiteSpace(javascript))
                 PerformActualInteropCallVoid(javascript);
+        }
+
+        public object ExecuteJavaScriptFunc<T>(string funcName, T arg0) {
+            // FIXME
+            return null;
+        }
+        public object ExecuteJavaScriptFunc<T0,T1>(string funcName, T0 arg0, T1 arg1) {
+            // FIXME
+            return null;
+        }
+        public object ExecuteJavaScriptFunc<T0,T1,T2>(string funcName, T0 arg0, T1 arg1, T2 arg2) {
+            // FIXME
+            return null;
         }
 
         public object ExecuteJavaScript(string javascript, int referenceId, bool wantsResult)

--- a/src/Runtime/Runtime/PublicAPI/Interop/PendingJavascript.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop/PendingJavascript.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
+using OpenSilver;
 
 namespace CSHTML5.Internal
 {
@@ -58,6 +59,15 @@ namespace CSHTML5.Internal
         public void AddJavaScript(string javascript)
         {
             if (javascript == null) return;
+
+            // the idea:
+            // when we have async calls, we need to have them executed sequentially
+            // however, this gets complicated when we're trying to do this with both Interop. and Interop2. calls,
+            // since Interop2. calls are executed one by one, while Interop. calls are appended to a byte-array and executed all at once
+            //
+            // so in order to maintain this sequential behavior, when we execute an Interop2 Async call, we flush the Interop. queue,
+            // and vice versa
+            Interop2.Flush();
 
             // the idea -- the current buffer is already huge - in the very rare scenario it would get full, just flush it and restart
             var maxByteCount = DefaultEncoding.GetMaxByteCount(javascript.Length) + Delimiter.Length;
@@ -123,6 +133,18 @@ namespace CSHTML5.Internal
 
         public void AddJavaScript(string javascript)
         {
+            if (javascript == null)
+                return;
+
+            // the idea:
+            // when we have async calls, we need to have them executed sequentially
+            // however, this gets complicated when we're trying to do this with both Interop. and Interop2. calls,
+            // since Interop2. calls are executed one by one, while Interop. calls are appended to a byte-array and executed all at once
+            //
+            // so in order to maintain this sequential behavior, when we execute an Interop2 Async call, we flush the Interop. queue,
+            // and vice versa
+            Interop2.Flush();
+
             lock (_pending)
             {
                 _pending.Add(javascript);

--- a/src/Runtime/Runtime/PublicAPI/Interop2/BulkInterop2.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop2/BulkInterop2.cs
@@ -1,0 +1,112 @@
+﻿using CSHTML5;
+using CSHTML5.Internal;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Windows.Threading;
+
+namespace OpenSilver
+{
+    public class BulkInterop2
+    {
+        private class SingleCall
+        {
+            public string Javascript;
+            public int Index;
+            public string FuncName;
+        }
+
+        private List<SingleCall> _cachedCalls ;
+
+        // if we get to this size, we automatically execute
+        // if < 0, we don't preallocate anything
+        private int _maxCapacity;
+
+        private int _index;
+        private bool _postponedExecute;
+
+        public static bool LogPerformance { get; set; } = false;
+
+        private bool PreallocateCapacity => _maxCapacity > 0;
+
+        public BulkInterop2( int maxCapacity = -1)
+        {
+            _maxCapacity = maxCapacity;
+            _cachedCalls = PreallocateCapacity ? new List<SingleCall>(_maxCapacity) : new List<SingleCall>();
+            if (PreallocateCapacity)
+                for (int i = 0; i < _maxCapacity; ++i)
+                    _cachedCalls.Add(new SingleCall());
+        }
+
+        public IDisposable AddJavascriptAsync<T>(T subId, params object[] args) where T : Enum
+        {
+            //FIXME not implemented
+            Debug.Assert(false);
+            //javascript = INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, variables);
+            //return AddJavascriptAsync(javascript);
+            return null;
+        }
+
+        private static object CallJavascriptFunctionImpl(string funcName, int subId, string args)
+        {
+            return INTERNAL_ExecuteJavaScript.ExecuteJavaScriptFuncSync("callFunction", funcName, subId, args);
+        }
+
+        public void AddJavascript<T>(T subId, params object[] args) where T : Enum
+        {
+            var funcName = Interop2.CreateFunctionAndReturnName<T>();
+            if (PreallocateCapacity)
+            {
+                _cachedCalls[_index].Javascript = Interop2Caller.ConvertArgsToString(args);
+                _cachedCalls[_index].Index = (int)(object)subId;
+                _cachedCalls[_index].FuncName = funcName;
+            } 
+            else
+                _cachedCalls.Add(new SingleCall
+                {
+                    Javascript = Interop2Caller.ConvertArgsToString(args),
+                    Index = (int)(object)subId,
+                    FuncName = funcName,
+                });
+
+            ++_index;
+            if (PreallocateCapacity && _index >= _maxCapacity)
+                Execute();
+        }
+
+        public void Execute()
+        {
+            var watch = Stopwatch.StartNew();
+            for (int i = 0; i < _index; ++i)
+            {
+                var call = _cachedCalls[i];
+                try
+                {
+                    CallJavascriptFunctionImpl(call.FuncName, call.Index, call.Javascript);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"FATAL BulkInterop2 execute: {call.FuncName}:{call.Index}  {call.Javascript}\r\n{e}");
+                }
+                if (PreallocateCapacity)
+                    call.Javascript = call.FuncName = null;
+            }
+            double ms = watch.ElapsedMilliseconds;
+            if (LogPerformance)
+                Console.WriteLine($"BULK2 INTEROP : calls: {_index} , took {ms} ({(ms / _index):F4}/call)");
+
+            _index = 0;
+            if (!PreallocateCapacity)
+                _cachedCalls.Clear();
+        }
+
+        public void PostponeExecute(Dispatcher dispatcher)
+        {
+            if (_postponedExecute)
+                return; // already postponed
+            _postponedExecute = true;
+            dispatcher.BeginInvoke(Execute);
+        }
+    }
+}

--- a/src/Runtime/Runtime/PublicAPI/Interop2/Interop2.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop2/Interop2.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace OpenSilver
+{
+    public class Interop2
+    {
+        private class JsFuncInfo
+        {
+            public string TypeName;
+            public IReadOnlyDictionary<int, (int ArgCount, bool ReturnsVoid)> Calls;
+        }
+
+        private static Dictionary<Type, JsFuncInfo> _types = new Dictionary<Type, JsFuncInfo>();
+
+        // for debugging/testing only!
+        public static bool DumpCreateFunction { get; set; } = false;
+
+        private static void CreateFunction<T>() where T : Enum
+        {
+            var type = typeof(T);
+            var enums = type.GetMembers().OfType<FieldInfo>().Where(e => e.FieldType.BaseType == typeof(Enum)).ToList();
+            Dictionary<int, string> subFunctions = new Dictionary<int, string>();
+            var idx = 0;
+            foreach (var e in enums)
+            {
+                var attr = e.GetCustomAttributes(typeof(JsCallAttribute), false);
+                if (attr.Length != 1)
+                    throw new Exception($"invalid JsCallAttribute for {e}");
+                var jsForEnum = (attr[0] as JsCallAttribute).JS;
+
+                var trueEnumValue = Enum.Parse(typeof(T), e.Name);
+                var intIndex = (int)trueEnumValue;
+
+                subFunctions.Add(intIndex, jsForEnum);
+            }
+
+            var enumName = typeof(T).ToString();
+            var result = Interop2Caller.CreateFunction(enumName, subFunctions);
+            if (!_types.ContainsKey(typeof(T)))
+                _types.Add(typeof(T), new JsFuncInfo { TypeName = enumName, Calls = result.ExtraInfo });
+
+            if (DumpCreateFunction)
+                Console.WriteLine($"**** JS CREATED FUNC {enumName}\r\n{result.JS}");
+        }
+
+        // FIXME later: validate the number of args you're sending to JS
+        public static object ExecuteJavaScript<T>(T subId, params object[] args) where T : Enum
+        {
+            if (!_types.ContainsKey(typeof(T)))
+                CreateFunction<T>();
+
+            var func = _types[typeof(T)];
+            var index = (int)(object)subId;
+            ValidateArgs(func, index, args.Length);
+            return Interop2Caller.CallJavascriptFunction(func.TypeName, index, args);
+        }
+
+        // used by BulkInterop2
+        internal static string CreateFunctionAndReturnName<T>() where T : Enum
+        {
+            if (!_types.ContainsKey(typeof(T)))
+                CreateFunction<T>();
+
+            var func = _types[typeof(T)];
+            return func.TypeName;
+        }
+
+        private static void ValidateArgs(JsFuncInfo func, int index, int argCount)
+        {
+            if (func.Calls[index].ArgCount != argCount)
+                throw new Exception($"Function {func.TypeName}:{index} has {func.Calls[index].ArgCount} arguments, but it's used with {argCount}");
+        }
+
+        // note: you won't be able to avoid specifying T type param here.
+        // so either specify it, or call some of the predefined functions
+        public static Result ExecuteJavaScriptGetResult<Result, T>(T subId, params object[] args) where T : Enum
+        {
+            if (!_types.ContainsKey(typeof(T)))
+                CreateFunction<T>();
+
+            var func = _types[typeof(T)];
+            var index = (int)(object)subId;
+            ValidateArgs(func, index, args.Length);
+            var result = Interop2Caller.CallJavascriptFunction(func.TypeName, index, args);
+            if (result != null)
+                return Interop.ConvertJavascriptResult<Result>(result);
+            else
+                return default;
+        }
+        private static Result TryExecuteJavaScriptGetResult<Result, T>(T subId, out bool nullOrUndefined, object[] args) where T : Enum
+        {
+            if (!_types.ContainsKey(typeof(T)))
+                CreateFunction<T>();
+
+            nullOrUndefined = false;
+            var func = _types[typeof(T)];
+            var index = (int)(object)subId;
+            ValidateArgs(func, index, args.Length);
+            var result = Interop2Caller.CallJavascriptFunction(func.TypeName, index, args);
+            if (result != null)
+                try
+                {
+                    return Interop.ConvertJavascriptResult<Result>(result);
+                }
+                catch 
+                {
+                    // error at conversion -- assume invalid
+                    nullOrUndefined = true;
+                    return default;
+                }
+            else
+            {
+                nullOrUndefined = true;
+                return default;
+            }
+        }
+
+        public static void ExecuteJavaScriptVoid<T>(T subId, params object[] args) where T : Enum
+        {
+            if (!_types.ContainsKey(typeof(T)))
+                CreateFunction<T>();
+
+            var func = _types[typeof(T)];
+            var index = (int)(object)subId;
+            if (!func.Calls[index].ReturnsVoid)
+                throw new Exception($"JS function {func.TypeName}:{subId} does not return void. Prefix it with 'void;' in the enum's JsCall attribute");
+
+            ExecuteJavaScript(subId, args);
+        }
+
+        public static bool ExecuteJavaScriptBoolean<T>(T subId, params object[] args) where T : Enum
+        {
+            return ExecuteJavaScriptGetResult<bool, T>(subId, args);
+        }
+        public static int ExecuteJavaScriptInt<T>(T subId, params object[] args) where T : Enum
+        {
+            return ExecuteJavaScriptGetResult<int, T>(subId, args);
+        }
+        public static long ExecuteJavaScriptLong<T>(T subId, params object[] args) where T : Enum
+        {
+            return ExecuteJavaScriptGetResult<long, T>(subId, args);
+        }
+        public static double ExecuteJavaScriptDouble<T>(T subId, params object[] args) where T : Enum
+        {
+            return ExecuteJavaScriptGetResult<double, T>(subId, args);
+        }
+        public static string ExecuteJavaScriptString<T>(T subId, params object[] args) where T : Enum
+        {
+            return ExecuteJavaScriptGetResult<string, T>(subId, args);
+        }
+
+
+
+
+        public static bool SafeExecuteJavaScriptBoolean<T>(T subId, params object[] args) where T : Enum
+        {
+            return TryExecuteJavaScriptGetResult<bool, T>(subId, out var ignore, args);
+        }
+        // returns MinValue on null-or-undefined
+        public static int SafeExecuteJavaScriptInt<T>(T subId, params object[] args) where T : Enum
+        {
+            var result = TryExecuteJavaScriptGetResult<int, T>(subId, out var nullOrUndefined, args);
+            return nullOrUndefined ? int.MinValue : result;
+        }
+        // returns MinValue on null-or-undefined
+        public static long SafeExecuteJavaScriptLong<T>(T subId, params object[] args) where T : Enum
+        {
+            var result =TryExecuteJavaScriptGetResult<long, T>(subId, out var nullOrUndefined, args);
+            return nullOrUndefined ? long.MinValue : result;
+        }
+        // returns NaN on null-or-undefined
+        public static double SafeExecuteJavaScriptDouble<T>(T subId, params object[] args) where T : Enum
+        {
+            var result = TryExecuteJavaScriptGetResult<double, T>(subId, out var nullOrUndefined, args);
+            return nullOrUndefined ? Double.NaN : result;
+        }
+        // returns "" on null-or-undefined
+        public static string SafeExecuteJavaScriptString<T>(T subId, params object[] args) where T : Enum
+        {
+            var result = TryExecuteJavaScriptGetResult<string, T>(subId, out var nullOrUndefined, args);
+            return nullOrUndefined ? "" : result;
+        }
+
+    }
+}

--- a/src/Runtime/Runtime/PublicAPI/Interop2/Interop2.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop2/Interop2.cs
@@ -3,6 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using CSHTML5;
+using CSHTML5.Internal;
+using CSHTML5.Types;
+using static OpenSilver.Interop2Caller;
 
 namespace OpenSilver
 {
@@ -11,13 +15,25 @@ namespace OpenSilver
         private class JsFuncInfo
         {
             public string TypeName;
-            public IReadOnlyDictionary<int, (int ArgCount, bool ReturnsVoid)> Calls;
+            public IReadOnlyDictionary<int, (int ArgCount, InteropReturnType ReturnType)> Calls;
+        }
+
+        private class AsyncCallInfo
+        {
+            public string FuncName;
+            public int Index;
+            public string Javascript;
+
         }
 
         private static Dictionary<Type, JsFuncInfo> _types = new Dictionary<Type, JsFuncInfo>();
+        private static List<AsyncCallInfo> _pendingAsyncCalls = new List<AsyncCallInfo>();
 
         // for debugging/testing only!
         public static bool DumpCreateFunction { get; set; } = false;
+        public static bool DumpCalls { get; set; } =  false;
+
+        public static Interop2OldImplementation Old { get; } = new Interop2OldImplementation();
 
         private static void CreateFunction<T>() where T : Enum
         {
@@ -39,24 +55,84 @@ namespace OpenSilver
             }
 
             var enumName = typeof(T).ToString();
-            var result = Interop2Caller.CreateFunction(enumName, subFunctions);
-            if (!_types.ContainsKey(typeof(T)))
-                _types.Add(typeof(T), new JsFuncInfo { TypeName = enumName, Calls = result.ExtraInfo });
+            try
+            {
+                var result = Interop2Caller.CreateFunction(enumName, subFunctions);
+                if (!_types.ContainsKey(typeof(T)))
+                    _types.Add(typeof(T), new JsFuncInfo { TypeName = enumName, Calls = result.ExtraInfo,  });
 
-            if (DumpCreateFunction)
-                Console.WriteLine($"**** JS CREATED FUNC {enumName}\r\n{result.JS}");
+                if (DumpCreateFunction)
+                    Console.WriteLine($"**** JS CREATED FUNC {enumName}\r\n{result.JS}");
+            }
+            catch (Exception e)
+            {
+                // in this case, something went wrong creating the function, very likely some syntax error
+                // lets find out the exact enum value that caused the error
+                ValidateFunctionEnums(enumName, subFunctions, e);
+            }
         }
 
-        // FIXME later: validate the number of args you're sending to JS
-        public static object ExecuteJavaScript<T>(T subId, params object[] args) where T : Enum
+        private static void ValidateFunctionEnums(string funcName,IReadOnlyDictionary<int,string> functions, Exception originalException)
+        {
+            var full = Interop2Caller.GetJavascriptFunctionStringForEnum(functions).JS;
+            var orderByIdx = functions.OrderBy(f => f.Key).ToList();
+            for (int i = 1; i <= functions.Count; ++i)
+            {
+                var subList = orderByIdx.Take(i).ToList();
+                var sub = subList. ToDictionary(kv => kv.Key, kv => kv.Value);
+                try
+                {
+                    Interop2Caller.CreateFunction($"{funcName}_{i}", sub);
+                    // if we get here, the function was successfully created
+                }
+                catch (Exception e)
+                {
+                    var index = subList.Last().Key;
+                    var func = subList.Last().Value;
+                    Console.WriteLine($"FATAL: can't create javascript function {funcName}:{index} -- js code:{func}\r\n\r\n" +
+                                      $"FULL FUNCTION:\r\n{full}\r\n\r\nException:{e}");
+                    return;
+                }
+            }
+
+            // worst case scenario - the function was created successfully, but we still got an exception?
+            Console.WriteLine($"FATAL: can't create javascript function {funcName}:\r\nFULL FUNCTION:\r\n{full}\r\n\r\nException: {originalException}");
+        }
+
+        private static object ExecuteJavaScript<T>(T subId, params object[] args) where T : Enum
+        {
+            if (!_types.ContainsKey(typeof(T)))
+                CreateFunction<T>();
+
+            var func = _types[typeof(T)];
+            ValidateArgs(func, subId, args.Length);
+
+            return Interop2Caller.CallJavascriptFunction(func.TypeName, subId, args);
+        }
+
+        private static object ExecuteJavaScriptImpl<T>(T subId, IReadOnlyList<object> args) where T : Enum
+        {
+            // validation already done - also, for JsObjRef, I'm manually adding an argument 
+            var func = _types[typeof(T)];
+            return Interop2Caller.CallJavascriptFunction(func.TypeName, subId, args);
+        }
+
+        public static void VoidAsync<T>(T subId, params object[] args) where T : Enum
         {
             if (!_types.ContainsKey(typeof(T)))
                 CreateFunction<T>();
 
             var func = _types[typeof(T)];
             var index = (int)(object)subId;
-            ValidateArgs(func, index, args.Length);
-            return Interop2Caller.CallJavascriptFunction(func.TypeName, index, args);
+            if (func.Calls[index].ReturnType != InteropReturnType.Void )
+                throw new Exception($"JS function {func.TypeName}:{subId} does not return void. Prefix it with 'void;' in the enum's JsCall attribute");
+
+            ValidateArgs(func, subId, args.Length);
+            // the idea: compute the whole string now, so args[] can be released ASAP
+            var all = Interop2Caller.ConvertArgsToString(args);
+            var funcName = func.TypeName;
+
+            AddAsyncCall(funcName, index, all);
         }
 
         // used by BulkInterop2
@@ -69,23 +145,24 @@ namespace OpenSilver
             return func.TypeName;
         }
 
-        private static void ValidateArgs(JsFuncInfo func, int index, int argCount)
+        private static void ValidateArgs<T>(JsFuncInfo func, T subId, int argCount)
         {
+            var index = (int)(object)subId;
             if (func.Calls[index].ArgCount != argCount)
-                throw new Exception($"Function {func.TypeName}:{index} has {func.Calls[index].ArgCount} arguments, but it's used with {argCount}");
+                throw new Exception($"Function {func.TypeName}:{subId} has {func.Calls[index].ArgCount} arguments, but it's used with {argCount}");
         }
 
         // note: you won't be able to avoid specifying T type param here.
         // so either specify it, or call some of the predefined functions
-        public static Result ExecuteJavaScriptGetResult<Result, T>(T subId, params object[] args) where T : Enum
+        public static Result GetResult<Result, T>(T subId, params object[] args) where T : Enum
         {
             if (!_types.ContainsKey(typeof(T)))
                 CreateFunction<T>();
 
             var func = _types[typeof(T)];
-            var index = (int)(object)subId;
-            ValidateArgs(func, index, args.Length);
-            var result = Interop2Caller.CallJavascriptFunction(func.TypeName, index, args);
+            ValidateArgs(func, subId, args.Length);
+            var result = Interop2Caller.CallJavascriptFunction(func.TypeName, subId, args);
+
             if (result != null)
                 return Interop.ConvertJavascriptResult<Result>(result);
             else
@@ -97,10 +174,11 @@ namespace OpenSilver
                 CreateFunction<T>();
 
             nullOrUndefined = false;
+
             var func = _types[typeof(T)];
-            var index = (int)(object)subId;
-            ValidateArgs(func, index, args.Length);
-            var result = Interop2Caller.CallJavascriptFunction(func.TypeName, index, args);
+            ValidateArgs(func, subId, args.Length);
+
+            var result = Interop2Caller.CallJavascriptFunction(func.TypeName, subId, args);
             if (result != null)
                 try
                 {
@@ -119,67 +197,142 @@ namespace OpenSilver
             }
         }
 
-        public static void ExecuteJavaScriptVoid<T>(T subId, params object[] args) where T : Enum
+        public static void Void<T>(T subId, params object[] args) where T : Enum
         {
             if (!_types.ContainsKey(typeof(T)))
                 CreateFunction<T>();
 
             var func = _types[typeof(T)];
             var index = (int)(object)subId;
-            if (!func.Calls[index].ReturnsVoid)
+            if (func.Calls[index].ReturnType != InteropReturnType.Void)
                 throw new Exception($"JS function {func.TypeName}:{subId} does not return void. Prefix it with 'void;' in the enum's JsCall attribute");
 
             ExecuteJavaScript(subId, args);
         }
 
-        public static bool ExecuteJavaScriptBoolean<T>(T subId, params object[] args) where T : Enum
+        public static IDisposable JsObjRef<T>(T subId, params object[] args) where T : Enum
         {
-            return ExecuteJavaScriptGetResult<bool, T>(subId, args);
+            if (!_types.ContainsKey(typeof(T)))
+                CreateFunction<T>();
+
+            var func = _types[typeof(T)];
+            var index = (int)(object)subId;
+            if (func.Calls[index].ReturnType != InteropReturnType.ReferenceId)
+                throw new Exception($"JS function {func.TypeName}:{subId} does not return jsObjRefId. Prefix it with 'ref;' in the enum's JsCall attribute");
+
+            ValidateArgs(func, subId, args.Length);
+            var copy = args.ToList();
+            var refId = INTERNAL_InteropImplementation.NewReferenceId().ToString();
+            copy.Add(refId);
+            var value = ExecuteJavaScriptImpl(subId, copy);
+            return new INTERNAL_JSObjectReference(value, refId, "interop2");
         }
-        public static int ExecuteJavaScriptInt<T>(T subId, params object[] args) where T : Enum
+
+        public static IDisposable JsObjRefAsync<T>(T subId, params object[] args) where T : Enum
         {
-            return ExecuteJavaScriptGetResult<int, T>(subId, args);
+            if (!_types.ContainsKey(typeof(T)))
+                CreateFunction<T>();
+
+            var func = _types[typeof(T)];
+            var index = (int)(object)subId;
+            if (func.Calls[index].ReturnType != InteropReturnType.ReferenceId)
+                throw new Exception($"JS function {func.TypeName}:{subId} does not return jsObjRefId. Prefix it with 'ref;' in the enum's JsCall attribute");
+
+            ValidateArgs(func, subId, args.Length);
+            var copy = args.ToList();
+            var refId = INTERNAL_InteropImplementation.NewReferenceId().ToString();
+            copy.Add(refId);
+
+            // the idea: compute the whole string now, so args[] can be released ASAP
+            var all = Interop2Caller.ConvertArgsToString(copy);
+            var funcName = func.TypeName;
+            AddAsyncCall(funcName, index, all);
+            return new INTERNAL_JSObjectReference(null, refId, "interop2");
         }
-        public static long ExecuteJavaScriptLong<T>(T subId, params object[] args) where T : Enum
+
+        internal static void AddAsyncCall(string funcName, int index, string javascript)
         {
-            return ExecuteJavaScriptGetResult<long, T>(subId, args);
+            // the idea:
+            // when we have async calls, we need to have them executed sequentially
+            // however, this gets complicated when we're trying to do this with both Interop. and Interop2. calls,
+            // since Interop2. calls are executed one by one, while Interop. calls are appended to a byte-array and executed all at once
+            //
+            // so in order to maintain this sequential behavior, when we execute an Interop2 Async call, we flush the Interop. queue,
+            // and vice versa
+            INTERNAL_ExecuteJavaScript.JavaScriptRuntime.Flush();
+
+            bool needsQueueAction = false;
+            lock (_pendingAsyncCalls)
+            {
+                needsQueueAction = _pendingAsyncCalls.Count == 0;
+                _pendingAsyncCalls.Add(new AsyncCallInfo
+                {
+                    FuncName = funcName, Index = index, Javascript = javascript,
+                });
+            }
+
+            if (needsQueueAction)
+                INTERNAL_DispatcherHelpers.QueueAction(Flush);
         }
-        public static double ExecuteJavaScriptDouble<T>(T subId, params object[] args) where T : Enum
+
+        internal static void Flush()
         {
-            return ExecuteJavaScriptGetResult<double, T>(subId, args);
+            lock (_pendingAsyncCalls)
+            {
+                foreach (var func in _pendingAsyncCalls)
+                    Interop2Caller.CallJavascriptFunctionWithAllArgs(func.FuncName, func.Index, func.Javascript);
+                _pendingAsyncCalls.Clear();
+            }
         }
-        public static string ExecuteJavaScriptString<T>(T subId, params object[] args) where T : Enum
+
+        public static bool Boolean<T>(T subId, params object[] args) where T : Enum
         {
-            return ExecuteJavaScriptGetResult<string, T>(subId, args);
+            return GetResult<bool, T>(subId, args);
+        }
+        public static int Int<T>(T subId, params object[] args) where T : Enum
+        {
+            return GetResult<int, T>(subId, args);
+        }
+        public static long Long<T>(T subId, params object[] args) where T : Enum
+        {
+            return GetResult<long, T>(subId, args);
+        }
+        public static double Double<T>(T subId, params object[] args) where T : Enum
+        {
+            return GetResult<double, T>(subId, args);
+        }
+        public static string String<T>(T subId, params object[] args) where T : Enum
+        {
+            return GetResult<string, T>(subId, args);
         }
 
 
 
 
-        public static bool SafeExecuteJavaScriptBoolean<T>(T subId, params object[] args) where T : Enum
+        public static bool SafeBoolean<T>(T subId, params object[] args) where T : Enum
         {
             return TryExecuteJavaScriptGetResult<bool, T>(subId, out var ignore, args);
         }
         // returns MinValue on null-or-undefined
-        public static int SafeExecuteJavaScriptInt<T>(T subId, params object[] args) where T : Enum
+        public static int SafeInt<T>(T subId, params object[] args) where T : Enum
         {
             var result = TryExecuteJavaScriptGetResult<int, T>(subId, out var nullOrUndefined, args);
             return nullOrUndefined ? int.MinValue : result;
         }
         // returns MinValue on null-or-undefined
-        public static long SafeExecuteJavaScriptLong<T>(T subId, params object[] args) where T : Enum
+        public static long SafeLong<T>(T subId, params object[] args) where T : Enum
         {
             var result =TryExecuteJavaScriptGetResult<long, T>(subId, out var nullOrUndefined, args);
             return nullOrUndefined ? long.MinValue : result;
         }
         // returns NaN on null-or-undefined
-        public static double SafeExecuteJavaScriptDouble<T>(T subId, params object[] args) where T : Enum
+        public static double SafeDouble<T>(T subId, params object[] args) where T : Enum
         {
             var result = TryExecuteJavaScriptGetResult<double, T>(subId, out var nullOrUndefined, args);
-            return nullOrUndefined ? Double.NaN : result;
+            return nullOrUndefined ? double.NaN : result;
         }
         // returns "" on null-or-undefined
-        public static string SafeExecuteJavaScriptString<T>(T subId, params object[] args) where T : Enum
+        public static string SafeString<T>(T subId, params object[] args) where T : Enum
         {
             var result = TryExecuteJavaScriptGetResult<string, T>(subId, out var nullOrUndefined, args);
             return nullOrUndefined ? "" : result;

--- a/src/Runtime/Runtime/PublicAPI/Interop2/Interop2Caller.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop2/Interop2Caller.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using CSHTML5;
+using CSHTML5.Internal;
+using OpenSilver.Internal;
+
+namespace OpenSilver
+{
+    internal class Interop2Caller
+    {
+        // jsObjRef,id,arrayindex
+
+        public (string VariableName, string VariableDefinition) JsReferenceObject(object o, int idx, int subIdx)
+        {
+            var js = INTERNAL_InteropImplementation.GetVariableStringForJS(o);
+            var name = $"obj{idx}_{subIdx}";
+            var vd = $"const {name} = {js};";
+            return (name, vd);
+        }
+
+        // IMPORTANT: $0..$20, if present, are handled first
+        //
+        // Examples:
+        //
+        // $"{sEvent}.shiftKey || false || $0 || $1"
+        // $"{sEvent}.shiftKey || false"
+        // $"{sEvent}.changedTouches[0].pageX + '|' + {sEvent}.changedTouches[0].pageY"
+        // $"({sElement}.getBoundingClientRect().left - document.body.getBoundingClientRect().left) + '|' + ({sElement}.getBoundingClientRect().top - document.body.getBoundingClientRect().top)"
+        // $"{sEvent}.doNotReroute = true"
+        // 
+        // $"{sRequest}.setRequestHeader({sKey}, {sHeader})"
+        // $"{sRequest}.open({sMethod}, {sAddress}, {sAsync})"
+        // $"{sRequest}.timeout = {sTimeout}"
+        // $"{sRequest}.onload = {sCallback}"
+        //
+        // $"(function(cvs) {{ const ctx = cvs.getContext('2d'); ctx.moveTo({_lastPos.X.ToInvariantString()}, {_lastPos.Y.ToInvariantString()}); ctx.lineTo({_mousePos.X.ToInvariantString()}, {_mousePos.Y.ToInvariantString()}); ctx.stroke(); }})({sCanvas})"
+        private static (string Js, int ArgCount, bool ReturnsVoid) CreateJavascriptCase(string str, int caseIdx)
+        {
+            // the args - each of the arg document.getJsRefObject(name) => name.startsWith("document.jsObjRef") -> get that otherwise, the name
+            var charIdx = 0;
+            var constAssignments = "";
+
+            // first, handle $X, like $0, $1, etc
+            var maxDollarIdx = -1;
+            for (int i = 20; i >= 0; --i) 
+            {
+                var escapedName = $"${i}";
+                if (str.IndexOf(escapedName) < 0)
+                    continue;
+                if (maxDollarIdx < 0)
+                    maxDollarIdx = i;
+                var replacedName = $"obj{caseIdx}_{i}";
+                constAssignments += $" const {replacedName} = document.argToJsObj(jsArgs[{i}]);";
+
+                str = str.Replace($"{escapedName}", replacedName);
+            }
+
+            var subConstIdx = maxDollarIdx + 1;
+
+            while (true)
+            {
+                var nextIdx = str.IndexOf('{', charIdx);
+                if (nextIdx < 0)
+                    break;
+                if (str[nextIdx + 1] == '{')
+                {
+                    // {{ -> escaped {
+                    charIdx = nextIdx + 2;
+                    continue;
+                }
+                if (str[nextIdx + 1] == ' ') 
+                {
+                    charIdx = nextIdx + 1;
+                    // "{ " - not an escaped name,
+                    // Example: "void;window.mapInitialize = function () { $0(); }"
+                    continue;
+                }
+
+                var endIdx = str.IndexOf('}', nextIdx);
+                var escapedName = str.Substring(nextIdx + 1, endIdx - nextIdx - 1);
+                var replacedName = $"obj{caseIdx}_{subConstIdx}";
+                constAssignments += $" const {replacedName} = document.argToJsObj(jsArgs[{subConstIdx}]);";
+                ++subConstIdx;
+
+                str = str.Replace($"{{{escapedName}}}", replacedName);
+            }
+
+            str = str.Replace("{{", "{").Replace("}}", "}").Trim();
+            if (!str.EndsWith(";"))
+                str += ";";
+
+            /* what does the function return ?
+             *
+             * by default, unless ANY of the below are met, it will return the result of the whole expression
+             *
+             * 1. if string starts with "void;" -> it returns void (undefined)
+             * 2. if string starts with return ... -> it returns the expression following return (until first ;)
+             * 3. if expression ends with return ..., I will take the expression from the last return, to the end.
+             *
+             * TOTHINK
+             * 4a. if expression starts with "ref;" or "refId;" -> the result will kept in a referenceId + the argument will name will hold the referenceid
+             * 4b. if in the code i have ref[...] -> turn into document.jsObRefId[...]
+             */
+
+            // append ; if not found
+            var returnStr = "";
+            bool returnsVoid = false;
+            if (str.StartsWith("void;"))
+            {
+                str = str.Substring(5);
+                returnStr = "return undefined;";
+                returnsVoid = true;
+            }
+            else if (str.StartsWith("return "))
+            {
+                var idx = str.IndexOf(';');
+                ++idx;
+                returnStr = str.Substring(0, idx);
+                str = str.Substring(idx);
+            }
+            else
+            {
+                var idx = str.LastIndexOf("return ");
+                if (idx >= 0)
+                {
+                    returnStr = str.Substring(idx);
+                    str = str.Substring(0, idx);
+                }
+                else
+                {
+                    returnStr = $"return {str}";
+                    str = "";
+                }
+            }
+
+            str = str.Trim();
+            if (str.Length > 0 && !str.EndsWith(";"))
+                str += ";";
+
+            var js = $" case {caseIdx}: {constAssignments} {str} {returnStr} break; ";
+            return (js, subConstIdx, returnsVoid);
+        }
+
+        private static void CreateJavascriptFunctionImpl(string funcName, string javascript)
+        {
+            INTERNAL_ExecuteJavaScript.ExecuteJavaScriptFuncSync("createFunction", funcName, javascript);
+        }
+
+        private static object CallJavascriptFunctionImpl(string funcName, int subId, string args)
+        {
+            return INTERNAL_ExecuteJavaScript.ExecuteJavaScriptFuncSync("callFunction", funcName, subId, args);
+        }
+
+
+        private static (string JS,IReadOnlyDictionary<int, (int ArgCount, bool ReturnsVoid)> ExtraInfo) CreateFunction(IReadOnlyDictionary<int, string> subFunctions)
+        {
+            var js = "\"use strict\";\r\n" +
+                     "const jsArgs = args.split('\\b');\r\n" +
+                     "switch(subId) { \r\n";
+            Dictionary<int, (int ArgCount, bool ReturnsVoid)> extraInfo = new Dictionary<int, (int, bool)>();
+            foreach (var func in subFunctions)
+            {
+                var result = CreateJavascriptCase(func.Value, func.Key);
+                js += $"{result.Js}\r\n";
+                extraInfo.Add(func.Key, (result.ArgCount, result.ReturnsVoid));
+            }
+
+            js += "}";
+            return (js, extraInfo);
+        }
+
+        public static (string JS,IReadOnlyDictionary<int, (int ArgCount, bool ReturnsVoid)> ExtraInfo) CreateFunction(string functionName, IReadOnlyDictionary<int, string> subFunctions)
+        {
+            var result = CreateFunction(subFunctions);
+            try
+            {
+                CreateJavascriptFunctionImpl(functionName, result.JS);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"FATAL: could not create function {functionName}:\r\n{e}");
+            }
+            return result;
+        }
+
+        private static object ConvertObjToJs(object a)
+        {
+            if (a == null)
+                return "null";
+
+            if (a is IJavaScriptConvertible jsc)
+                return jsc.ToJavaScriptString();
+            if (a is string)
+                return a;
+            if (a is bool b)
+                return (b ? "true" : "false");
+            if (a is IFormattable formattable)
+                return formattable.ToInvariantString();
+            if (a is Delegate d)
+            {
+                // always create it synchronously
+                var cb = JavaScriptCallback.Create(d, sync: true);
+                return INTERNAL_InteropImplementation.GetVariableStringForJS(cb);
+            }
+            // pass it unchanged, it will invoke .ToString()
+            return a;
+        }
+
+        public static object CallJavascriptFunction(string funcName, int subId, params object[] args)
+        {
+            var all = string.Join("\b", args.Select(ConvertObjToJs));
+            try
+            {
+                return CallJavascriptFunctionImpl(funcName, subId, all);
+            }
+            catch (Exception e)
+            {
+                // the idea -- write the args passed to the function, so we can investigate
+                Console.WriteLine($"FATAL error on CallJS: {funcName}, args={all}\r\n{e}");
+                return null;
+            }
+        }
+
+        public static string ConvertArgsToString(object[] args) => string.Join("\b", args.Select(ConvertObjToJs));
+
+    }
+}

--- a/src/Runtime/Runtime/PublicAPI/Interop2/Interop2Caller.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop2/Interop2Caller.cs
@@ -11,7 +11,9 @@ namespace OpenSilver
 {
     internal class Interop2Caller
     {
-        // jsObjRef,id,arrayindex
+        // for debugging/testing
+        private static int _callCount = 0;
+        public static int CallCount => _callCount;
 
         public (string VariableName, string VariableDefinition) JsReferenceObject(object o, int idx, int subIdx)
         {
@@ -21,6 +23,19 @@ namespace OpenSilver
             return (name, vd);
         }
 
+        private static string AsJavascriptNumber(string s) => $"parseInt({s})";
+        private static string AsJavascriptDouble(string s) => $"parseFloat({s})";
+        private static string AsJavascriptBool(string s) => $"({s} === 'true')";
+
+        public enum InteropReturnType
+        {
+            Object, Void, ReferenceId,
+        }
+
+        // to specify number or string: append |n or |d
+        // for $X -> use $X|n or $X|d -> ONLY ON FIRST USE
+        // for {name} -> {name|n} or {name|d} or {name,n} or {name,d}  -> ONLY ON FIRST USE
+        //
         // IMPORTANT: $0..$20, if present, are handled first
         //
         // Examples:
@@ -37,111 +52,241 @@ namespace OpenSilver
         // $"{sRequest}.onload = {sCallback}"
         //
         // $"(function(cvs) {{ const ctx = cvs.getContext('2d'); ctx.moveTo({_lastPos.X.ToInvariantString()}, {_lastPos.Y.ToInvariantString()}); ctx.lineTo({_mousePos.X.ToInvariantString()}, {_mousePos.Y.ToInvariantString()}); ctx.stroke(); }})({sCanvas})"
-        private static (string Js, int ArgCount, bool ReturnsVoid) CreateJavascriptCase(string str, int caseIdx)
+        private static (string Js, int ArgCount, InteropReturnType ReturnType) CreateJavascriptCase(string str, int caseIdx)
         {
-            // the args - each of the arg document.getJsRefObject(name) => name.startsWith("document.jsObjRef") -> get that otherwise, the name
-            var charIdx = 0;
-            var constAssignments = "";
-
-            // first, handle $X, like $0, $1, etc
-            var maxDollarIdx = -1;
-            for (int i = 20; i >= 0; --i) 
+            var originalStr = str;
+            try
             {
-                var escapedName = $"${i}";
-                if (str.IndexOf(escapedName) < 0)
-                    continue;
-                if (maxDollarIdx < 0)
-                    maxDollarIdx = i;
-                var replacedName = $"obj{caseIdx}_{i}";
-                constAssignments += $" const {replacedName} = document.argToJsObj(jsArgs[{i}]);";
+                // the args - each of the arg document.getJsRefObject(name) => name.startsWith("document.jsObjRef") -> get that otherwise, the name
+                var charIdx = 0;
+                var constAssignments = "";
 
-                str = str.Replace($"{escapedName}", replacedName);
-            }
-
-            var subConstIdx = maxDollarIdx + 1;
-
-            while (true)
-            {
-                var nextIdx = str.IndexOf('{', charIdx);
-                if (nextIdx < 0)
-                    break;
-                if (str[nextIdx + 1] == '{')
+                // first, handle $X, like $0, $1, etc
+                var maxDollarIdx = -1;
+                for (int i = 20; i >= 0; --i)
                 {
-                    // {{ -> escaped {
-                    charIdx = nextIdx + 2;
-                    continue;
+                    var escapedName = $"${i}";
+                    var escapeNameIdx = str.IndexOf(escapedName);
+                    if (str.IndexOf(escapedName) < 0)
+                        continue;
+
+                    var isNumber = escapeNameIdx == str.IndexOf(escapedName + "|n");
+                    var isDouble = escapeNameIdx == str.IndexOf(escapedName + "|d");
+                    var isBool = escapeNameIdx == str.IndexOf(escapedName + "|b");
+                    if (isNumber)
+                        str = str.Replace(escapedName + "|n", escapedName);
+                    if (isDouble)
+                        str = str.Replace(escapedName + "|d", escapedName);
+                    if (isBool)
+                        str = str.Replace(escapedName + "|b", escapedName);
+
+                    if (maxDollarIdx < 0)
+                        maxDollarIdx = i;
+                    var replacedName = $"obj{caseIdx}_{i}";
+                    var assignValue = $"document.argToJsObj(jsArgs[{i}])";
+                    if (isNumber)
+                        assignValue = AsJavascriptNumber(assignValue);
+                    else if (isDouble)
+                        assignValue = AsJavascriptDouble(assignValue);
+                    else if (isBool)
+                        assignValue = AsJavascriptBool(assignValue);
+                    constAssignments += $" const {replacedName} = {assignValue};";
+
+                    // console.log('$0') -> console.log(replacedName) - no need for quotes
+                    str = str.Replace($"'{escapedName}'", replacedName);
+                    str = str.Replace($"\"{escapedName}\"", replacedName);
+
+                    //obj.{property} -> obj[{property}] -> the {property} is passed as an argument
+                    str = str.Replace($".{escapedName}", $"[{replacedName}]");
+
+                    str = str.Replace($"{escapedName}", replacedName);
                 }
-                if (str[nextIdx + 1] == ' ') 
+
+                var subConstIdx = maxDollarIdx + 1;
+
+                while (true)
                 {
-                    charIdx = nextIdx + 1;
-                    // "{ " - not an escaped name,
-                    // Example: "void;window.mapInitialize = function () { $0(); }"
-                    continue;
+                    var nextIdx = str.IndexOf('{', charIdx);
+                    if (nextIdx < 0)
+                        break;
+                    if (str[nextIdx + 1] == '{')
+                    {
+                        // {{ -> escaped {
+                        charIdx = nextIdx + 2;
+                        continue;
+                    }
+
+                    if (Char.IsWhiteSpace(str[nextIdx + 1]))
+                    {
+                        charIdx = nextIdx + 1;
+                        // "{ " - not an escaped name,
+                        // Example: "void;window.mapInitialize = function () { $0(); }"
+                        continue;
+                    }
+
+                    var endIdx = str.IndexOf('}', nextIdx);
+                    var escapedName = str.Substring(nextIdx + 1, endIdx - nextIdx - 1);
+                    var replacedName = $"obj{caseIdx}_{subConstIdx}";
+
+                    var isNumber = false;
+                    var isDouble = false;
+                    var isBool = false;
+                    if (escapedName.EndsWith("|n") || escapedName.EndsWith(",n")) 
+                    {
+                        escapedName = escapedName.Substring(0, escapedName.Length - 2);
+                        str = str.Replace($"{{{escapedName}|n}}", $"{{{escapedName}}}");
+                        str = str.Replace($"{{{escapedName},n}}", $"{{{escapedName}}}");
+                        isNumber = true;
+                    } else if (escapedName.EndsWith("|d") || escapedName.EndsWith(",d")) {
+                        escapedName = escapedName.Substring(0, escapedName.Length - 2);
+                        str = str.Replace($"{{{escapedName}|d}}", $"{{{escapedName}}}");
+                        str = str.Replace($"{{{escapedName},d}}", $"{{{escapedName}}}");
+                        isDouble = true;
+                    } else if (escapedName.EndsWith("|b") || escapedName.EndsWith(",b")) {
+                        escapedName = escapedName.Substring(0, escapedName.Length - 2);
+                        str = str.Replace($"{{{escapedName}|b}}", $"{{{escapedName}}}");
+                        str = str.Replace($"{{{escapedName},b}}", $"{{{escapedName}}}");
+                        isBool = true;
+                    }
+
+                    var assignValue = $"document.argToJsObj(jsArgs[{subConstIdx}])";
+                    if (isNumber)
+                        assignValue = AsJavascriptNumber(assignValue);
+                    else if (isDouble)
+                        assignValue = AsJavascriptDouble(assignValue);
+                    else if (isBool)
+                        assignValue = AsJavascriptBool(assignValue);
+
+                    constAssignments += $" const {replacedName} = {assignValue};";
+                    ++subConstIdx;
+
+                    // console.log('{eventName}') -> console.log(replacedName) - no need for quotes
+                    str = str.Replace($"'{{{escapedName}}}'", replacedName);
+                    str = str.Replace($"\"{{{escapedName}}}\"", replacedName);
+
+                    //obj.{property} -> obj[{property}] -> the {property} is passed as an argument
+                    str = str.Replace($".{{{escapedName}}}", $"[{replacedName}]");
+
+                    str = str.Replace($"{{{escapedName}}}", replacedName);
                 }
 
-                var endIdx = str.IndexOf('}', nextIdx);
-                var escapedName = str.Substring(nextIdx + 1, endIdx - nextIdx - 1);
-                var replacedName = $"obj{caseIdx}_{subConstIdx}";
-                constAssignments += $" const {replacedName} = document.argToJsObj(jsArgs[{subConstIdx}]);";
-                ++subConstIdx;
+                str = str.Replace("{{", "{").Replace("}}", "}").Trim();
+                if (!str.EndsWith(";"))
+                    str += ";";
 
-                str = str.Replace($"{{{escapedName}}}", replacedName);
-            }
-
-            str = str.Replace("{{", "{").Replace("}}", "}").Trim();
-            if (!str.EndsWith(";"))
-                str += ";";
-
-            /* what does the function return ?
-             *
-             * by default, unless ANY of the below are met, it will return the result of the whole expression
-             *
-             * 1. if string starts with "void;" -> it returns void (undefined)
-             * 2. if string starts with return ... -> it returns the expression following return (until first ;)
-             * 3. if expression ends with return ..., I will take the expression from the last return, to the end.
-             *
-             * TOTHINK
-             * 4a. if expression starts with "ref;" or "refId;" -> the result will kept in a referenceId + the argument will name will hold the referenceid
-             * 4b. if in the code i have ref[...] -> turn into document.jsObRefId[...]
-             */
-
-            // append ; if not found
-            var returnStr = "";
-            bool returnsVoid = false;
-            if (str.StartsWith("void;"))
-            {
-                str = str.Substring(5);
-                returnStr = "return undefined;";
-                returnsVoid = true;
-            }
-            else if (str.StartsWith("return "))
-            {
-                var idx = str.IndexOf(';');
-                ++idx;
-                returnStr = str.Substring(0, idx);
-                str = str.Substring(idx);
-            }
-            else
-            {
-                var idx = str.LastIndexOf("return ");
-                if (idx >= 0)
+                // finally, creation of temporary variables : $temp0 to $temp9
+                for (int i = 0; i < 10; ++i)
                 {
-                    returnStr = str.Substring(idx);
-                    str = str.Substring(0, idx);
+                    var temp = $"$temp{i}";
+                    if (str.IndexOf(temp) >= 0)
+                    {
+                        // look for a single line that is $tempX = ...;
+                        var tempAssign = $"$temp{i} =";
+                        var idxTemp = str.IndexOf(tempAssign);
+                        var idxEnd = str.IndexOf('\r', idxTemp);
+                        var assignment = str.Substring(idxTemp, idxEnd - idxTemp);
+                        constAssignments += $" let temp{i}_{caseIdx} {assignment.Substring(6)}";
+                        str = str.Substring(0, idxTemp) + str.Substring(idxEnd);
+                        str = str.Replace(temp, $"temp{i}_{caseIdx}"); // remove the $ prefix
+                    }
                 }
+
+                /* what does the function return ?
+                 *
+                 * by default, unless ANY of the below are met, it will return the result of the whole expression
+                 *
+                 * 1. if string starts with "void;" -> it returns void (undefined)
+                 * 2. if string starts with return ... -> it returns the expression following return (until first ;)
+                 * 3. if expression ends with return ..., I will take the expression from the last return, to the end.
+                 *
+                 * 4. if expression starts with "ref;" -> it returns a jsObjRef (a reference ID).
+                 *    In this case -> anything that the function would normally return WILL BE TURNED INTO A REFERENCE
+                 *    + If this also contains void;, I will just use the referenceId
+                 *
+                 * 5. If anywhere I find $result, I will assume $result will hold the result to return
+                 */
+
+                str = str.Replace("void;ref;", "ref;void;");
+
+                // append ; if not found
+                var returnStr = "";
+                bool returnsVoid = false;
+                bool returnsRefId = false;
+                bool specificResult = false;
+                if (str.StartsWith("ref;")) 
+                {
+                    str = str.Substring(4);
+                    returnsRefId = true;
+                } 
+
+                if (str.StartsWith("void;"))
+                {
+                    str = str.Substring(5);
+                    returnStr = "return undefined;";
+                    returnsVoid = true;
+                } 
+                else if (str.Contains("$result")) {
+                    specificResult = true;
+                    returnStr = "return _result;";
+                    str = str.Replace("$result", "_result");
+                    constAssignments += $" let _result = undefined;";
+                }
+                else if (str.StartsWith("return ")) {
+                    var idx = str.IndexOf(';');
+                    ++idx;
+                    returnStr = str.Substring(0, idx);
+                    str = str.Substring(idx);
+                } 
                 else
                 {
-                    returnStr = $"return {str}";
-                    str = "";
+                    var idx = str.LastIndexOf("return ");
+                    // if it's a ref-id function -> just execute it and return result
+                    var isRefIdFunction = returnsRefId && (str.Trim().StartsWith("(function") || str.Trim().StartsWith("( function"));
+                    if (idx >= 0 && !isRefIdFunction)
+                    {
+                        returnStr = str.Substring(idx);
+                        str = str.Substring(0, idx);
+                    } else
+                    {
+                        returnStr = $"return {str}";
+                        str = "";
+                    }
                 }
+
+                str = str.Trim();
+                if (str.Length > 0 && !str.EndsWith(";"))
+                    str += ";";
+
+                if (returnsRefId) 
+                {
+                    if (returnsVoid) 
+                    {
+                        returnStr = str;
+                        str = "";
+                    } 
+                    else 
+                        // replace "return ..." with document.jsObjRef[...] = ...
+                        returnStr = returnStr.Substring("return ".Length);
+                    returnStr = $"document.jsObjRef[ jsArgs[jsArgs.length - 1] ] = {returnStr}";
+                    if (!returnStr.EndsWith(";"))
+                        returnStr += ";";
+
+                    if (specificResult)
+                        returnStr = "return _result;";
+                    else if (!returnsVoid)
+                        returnStr += $"return document.jsObjRef[ jsArgs[jsArgs.length - 1] ];";
+                    else
+                        returnStr += "return undefined;";
+                }
+
+                var js = $" case {caseIdx}: {{ {constAssignments} {str} {returnStr} }} break; ";
+
+                return (js, subConstIdx, (returnsRefId ? InteropReturnType.ReferenceId : returnsVoid ? InteropReturnType.Void : InteropReturnType.Object));
             }
-
-            str = str.Trim();
-            if (str.Length > 0 && !str.EndsWith(";"))
-                str += ";";
-
-            var js = $" case {caseIdx}: {constAssignments} {str} {returnStr} break; ";
-            return (js, subConstIdx, returnsVoid);
+            catch (Exception e)
+            {
+                throw new Exception($"ERROR: Invalid case string {originalStr}:{caseIdx}\r\n{e.Message}");
+            }
         }
 
         private static void CreateJavascriptFunctionImpl(string funcName, string javascript)
@@ -155,38 +300,32 @@ namespace OpenSilver
         }
 
 
-        private static (string JS,IReadOnlyDictionary<int, (int ArgCount, bool ReturnsVoid)> ExtraInfo) CreateFunction(IReadOnlyDictionary<int, string> subFunctions)
+        internal static (string JS,IReadOnlyDictionary<int, (int ArgCount, InteropReturnType ReturnType)> ExtraInfo) GetJavascriptFunctionStringForEnum(IReadOnlyDictionary<int, string> subFunctions)
         {
             var js = "\"use strict\";\r\n" +
                      "const jsArgs = args.split('\\b');\r\n" +
                      "switch(subId) { \r\n";
-            Dictionary<int, (int ArgCount, bool ReturnsVoid)> extraInfo = new Dictionary<int, (int, bool)>();
+            Dictionary<int, (int ArgCount, InteropReturnType ReturnType)> extraInfo = new Dictionary<int, (int ArgCount, InteropReturnType ReturnType)>();
             foreach (var func in subFunctions)
             {
                 var result = CreateJavascriptCase(func.Value, func.Key);
                 js += $"{result.Js}\r\n";
-                extraInfo.Add(func.Key, (result.ArgCount, result.ReturnsVoid));
+                extraInfo.Add(func.Key, (result.ArgCount, result.ReturnType));
             }
-
-            js += "}";
+            // add this case just for testing - just call it with argument 111111 -> if it works, we're good
+            // if we get a Javascript error, it means there's a syntax error in the JS code
+            js += $"case 111111: break; }}";
             return (js, extraInfo);
         }
 
-        public static (string JS,IReadOnlyDictionary<int, (int ArgCount, bool ReturnsVoid)> ExtraInfo) CreateFunction(string functionName, IReadOnlyDictionary<int, string> subFunctions)
+        public static (string JS,IReadOnlyDictionary<int, (int ArgCount, InteropReturnType ReturnType)> ExtraInfo) CreateFunction(string functionName, IReadOnlyDictionary<int, string> subFunctions)
         {
-            var result = CreateFunction(subFunctions);
-            try
-            {
-                CreateJavascriptFunctionImpl(functionName, result.JS);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"FATAL: could not create function {functionName}:\r\n{e}");
-            }
+            var result = GetJavascriptFunctionStringForEnum(subFunctions);
+            CreateJavascriptFunctionImpl(functionName, result.JS);
             return result;
         }
 
-        private static object ConvertObjToJs(object a)
+        internal static object ConvertObjToJs(object a)
         {
             if (a == null)
                 return "null";
@@ -195,6 +334,10 @@ namespace OpenSilver
                 return jsc.ToJavaScriptString();
             if (a is string)
                 return a;
+            if (a is double db)
+                return db.ToInvariantString();
+            if (a is float f)
+                return f.ToInvariantString();
             if (a is bool b)
                 return (b ? "true" : "false");
             if (a is IFormattable formattable)
@@ -209,22 +352,42 @@ namespace OpenSilver
             return a;
         }
 
-        public static object CallJavascriptFunction(string funcName, int subId, params object[] args)
+        public static object CallJavascriptFunctionWithAllArgs<T>(string funcName, T subId, string all)
         {
-            var all = string.Join("\b", args.Select(ConvertObjToJs));
             try
             {
-                return CallJavascriptFunctionImpl(funcName, subId, all);
+                ++_callCount;
+                var index = (int)(object)subId;
+
+                if (Interop2.DumpCalls)
+                {
+                    var friendlyName = funcName.Contains('.') ? funcName.Substring(funcName.LastIndexOf('.') + 1) : funcName;
+                    Console.WriteLine($" *** JS     {friendlyName}[{subId}]({all.Replace("\b",", ")})");
+                }
+
+                return CallJavascriptFunctionImpl(funcName, index, all);
             }
             catch (Exception e)
             {
                 // the idea -- write the args passed to the function, so we can investigate
-                Console.WriteLine($"FATAL error on CallJS: {funcName}, args={all}\r\n{e}");
+                Console.WriteLine($"FATAL error on CallJS: {funcName}:{subId}, args={all}\r\n{e}");
                 return null;
             }
         }
 
-        public static string ConvertArgsToString(object[] args) => string.Join("\b", args.Select(ConvertObjToJs));
+        public static object CallJavascriptFunction(string funcName, int subId, params object[] args)
+        {
+            var all = string.Join("\b", args.Select(ConvertObjToJs));
+            return CallJavascriptFunctionWithAllArgs(funcName, subId, all);
+        }
+        // the idea: here, on exception, you get the string corresponding to the enum in the error message
+        public static object CallJavascriptFunction<T>(string funcName, T subId, IReadOnlyList<object> args)
+        {
+            var all = string.Join("\b", args.Select(ConvertObjToJs));
+            return CallJavascriptFunctionWithAllArgs(funcName, subId, all);
+        }
+
+        public static string ConvertArgsToString(IReadOnlyList<object> args) => string.Join("\b", args.Select(ConvertObjToJs));
 
     }
 }

--- a/src/Runtime/Runtime/PublicAPI/Interop2/Interop2OldImplementation.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop2/Interop2OldImplementation.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CSHTML5;
+using CSHTML5.Internal;
+using CSHTML5.Types;
+
+namespace OpenSilver
+{
+    public class Interop2OldImplementation
+    {
+        public Interop2OldImplementation()
+        {
+        }
+
+        public void Void<T>(T subId, string javascript, params object[] vars) where T : Enum
+        {
+            javascript = INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, vars);
+            if (Interop2.DumpCalls)
+            {
+                var funcName = Interop2.CreateFunctionAndReturnName<T>();
+                var friendlyName = funcName.Contains(".") ? funcName.Substring(funcName.LastIndexOf('.') + 1) : funcName;
+
+                Console.WriteLine($" *** JS OLD {friendlyName}[{subId}] {javascript.Replace("\b",", ")}");
+            }
+
+            Interop.ExecuteJavaScriptVoid(javascript);
+        }
+
+        public void VoidAsync<T>(T subId,string javascript) where T : Enum
+        {
+            if (Interop2.DumpCalls)
+            {
+                var funcName = Interop2.CreateFunctionAndReturnName<T>();
+                var friendlyName = funcName.Contains(".") ? funcName.Substring(funcName.LastIndexOf('.') + 1) : funcName;
+
+                Console.WriteLine($" *** JS OLD {friendlyName}[{subId}] {javascript.Replace("\b",", ")}");
+            }
+
+            Interop.ExecuteJavaScriptFastAsync(javascript);
+        }
+
+        public IDisposable Async<T>(T subId,string javascript, params object[] vars) where T : Enum
+        {
+            javascript = INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, vars);
+            if (Interop2.DumpCalls)
+            {
+                var funcName = Interop2.CreateFunctionAndReturnName<T>();
+                var friendlyName = funcName.Contains(".") ? funcName.Substring(funcName.LastIndexOf('.') + 1) : funcName;
+
+                Console.WriteLine($" *** JS OLD {friendlyName}[{subId}] {javascript.Replace("\b",", ")}");
+            }
+
+            return Interop.ExecuteJavaScriptAsync(javascript);
+        }
+
+        public string String<T>(T subId, string javascript) where T : Enum
+        {
+            if (Interop2.DumpCalls)
+            {
+                var funcName = Interop2.CreateFunctionAndReturnName<T>();
+                var friendlyName = funcName.Contains(".") ? funcName.Substring(funcName.LastIndexOf('.') + 1) : funcName;
+
+                Console.WriteLine($" *** JS OLD {friendlyName}[{subId}] {javascript.Replace("\b",", ")}");
+            }
+            return Interop.ExecuteJavaScriptString(javascript);
+        }
+        public int Int<T>(T subId, string javascript) where T : Enum
+        {
+            if (Interop2.DumpCalls)
+            {
+                var funcName = Interop2.CreateFunctionAndReturnName<T>();
+                var friendlyName = funcName.Contains(".") ? funcName.Substring(funcName.LastIndexOf('.') + 1) : funcName;
+
+                Console.WriteLine($" *** JS OLD {friendlyName}[{subId}] {javascript.Replace("\b",", ")}");
+            }
+            return Interop.ExecuteJavaScriptInt32(javascript);
+        }
+        public IDisposable JsObjRef<T>(T subId, string javascript, params object[] vars) where T : Enum
+        {
+            javascript = INTERNAL_InteropImplementation.ReplaceJSArgs(javascript, vars);
+            if (Interop2.DumpCalls)
+            {
+                var funcName = Interop2.CreateFunctionAndReturnName<T>();
+                var friendlyName = funcName.Contains(".") ? funcName.Substring(funcName.LastIndexOf('.') + 1) : funcName;
+
+                Console.WriteLine($" *** JS OLD {friendlyName}[{subId}] {javascript.Replace("\b",", ")}");
+            }
+            return Interop.ExecuteJavaScript(javascript);
+        }
+    }
+}

--- a/src/Runtime/Runtime/PublicAPI/Interop2/JsCallAttribute.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop2/JsCallAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenSilver
+{
+    [System.AttributeUsage(AttributeTargets.Field)]
+    public class JsCallAttribute : System.Attribute {
+        private string _jsCall;
+
+        public string JS => _jsCall;
+
+        public JsCallAttribute(string jsCall) {
+            this._jsCall = jsCall;
+        }
+    }
+}

--- a/src/Runtime/Runtime/PublicAPI/Interop2/JsCallAttribute.cs
+++ b/src/Runtime/Runtime/PublicAPI/Interop2/JsCallAttribute.cs
@@ -14,4 +14,5 @@ namespace OpenSilver
             this._jsCall = jsCall;
         }
     }
+
 }

--- a/src/Runtime/Runtime/Runtime.OpenSilver.csproj
+++ b/src/Runtime/Runtime/Runtime.OpenSilver.csproj
@@ -55,6 +55,7 @@
 		<Compile Include="Core\Main\PrePostDescendentsWalker.cs" />
 		<Compile Include="Core\Main\WeakReferenceList.cs" />
 		<Compile Include="Core\Main\WeakReferenceListEnumerator.cs" />
+		<Compile Include="Core\Rendering\INTERNAL_HtmlDomManager.JsCall.cs" />
 		<Compile Include="Diagnostics\DebugInfo.cs" />
 		<Compile Include="OpenSilver\Controls\OpenFileDialog.cs" />
 		<Compile Include="OpenSilver\Internal\Clipboard.cs" />
@@ -116,6 +117,7 @@
 		<Compile Include="OpenSilver\Internal\IJavaScriptConvertible.cs" />
 		<Compile Include="PublicAPI\Interop2\BulkInterop2.cs" />
 		<Compile Include="PublicAPI\Interop2\Interop2.cs" />
+		<Compile Include="PublicAPI\Interop2\Interop2OldImplementation.cs" />
 		<Compile Include="PublicAPI\Interop2\JsCallAttribute.cs" />
 		<Compile Include="PublicAPI\Interop\BulkExecuteJavascriptAsync.cs" />
 		<Compile Include="PublicAPI\Interop2\Interop2Caller.cs" />
@@ -245,6 +247,7 @@
 		<Compile Include="System.Windows.Controls\MatchedTextInfo.cs" />
 		<Compile Include="System.Windows.Controls\WORKINPROGRESS\ObservableObjectCollection.cs" />
 		<Compile Include="System.Windows.Controls\WrapPanelHelper.cs" />
+		<Compile Include="System.Windows.Input\InputManager.JsCall.cs" />
 		<Compile Include="System.Windows.input\MouseEventArgs.JsArgs.cs" />
 		<Compile Include="System.Windows.Markup\DependencyPropertyConverter.cs" />
 		<Compile Include="System.Windows.Markup\SetterValueConverter.cs" />

--- a/src/Runtime/Runtime/Runtime.OpenSilver.csproj
+++ b/src/Runtime/Runtime/Runtime.OpenSilver.csproj
@@ -114,7 +114,12 @@
 		<Compile Include="PublicAPI\Internal\KnownTypesHelper.cs" />
 		<Compile Include="PublicAPI\Internal\WebRequestsHelper.cs" />
 		<Compile Include="OpenSilver\Internal\IJavaScriptConvertible.cs" />
+		<Compile Include="PublicAPI\Interop2\BulkInterop2.cs" />
+		<Compile Include="PublicAPI\Interop2\Interop2.cs" />
+		<Compile Include="PublicAPI\Interop2\JsCallAttribute.cs" />
 		<Compile Include="PublicAPI\Interop\BulkExecuteJavascriptAsync.cs" />
+		<Compile Include="PublicAPI\Interop2\Interop2Caller.cs" />
+		<Compile Include="PublicAPI\Interop\JavascriptCallsTracker.cs" />
 		<Compile Include="PublicAPI\Interop\JSObjectReferenceHolder.cs" />
 		<Compile Include="PublicAPI\Interop\StackTraceProvider.cs" />
 		<Compile Include="PublicAPI\Interop\Interop.Obsolete.cs" />
@@ -240,6 +245,7 @@
 		<Compile Include="System.Windows.Controls\MatchedTextInfo.cs" />
 		<Compile Include="System.Windows.Controls\WORKINPROGRESS\ObservableObjectCollection.cs" />
 		<Compile Include="System.Windows.Controls\WrapPanelHelper.cs" />
+		<Compile Include="System.Windows.input\MouseEventArgs.JsArgs.cs" />
 		<Compile Include="System.Windows.Markup\DependencyPropertyConverter.cs" />
 		<Compile Include="System.Windows.Markup\SetterValueConverter.cs" />
 		<Compile Include="System.Windows.Media.Imaging\PngEncoder.cs" />
@@ -949,7 +955,7 @@
 		<Compile Include="System.Windows.Input\KeyRoutedEventArgs.cs" />
 		<Compile Include="System.Windows.Input\Pointer.cs" />
 		<Compile Include="System.Windows.Input\PointerEventHandler.cs" />
-		<Compile Include="System.Windows.Input\PointerRoutedEventArgs.cs" />
+		<Compile Include="System.Windows.Input\MouseEventArgs.cs" />
 		<Compile Include="System.Windows.Input\RightTappedEventHandler.cs" />
 		<Compile Include="System.Windows.Input\RightTappedRoutedEventArgs.cs" />
 		<Compile Include="System.Windows.Input\TappedEventHandler.cs" />

--- a/src/Runtime/Runtime/System.Windows.Controls/Image.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Image.cs
@@ -310,7 +310,7 @@ namespace Windows.UI.Xaml.Controls
             if (Source != null)
             {
                 var imageSrc = await Source.GetDataStringAsync(this);
-                INTERNAL_HtmlDomManager.SetDomElementAttribute(_imageDiv, "src", imageSrc ?? string.Empty, true);
+                INTERNAL_HtmlDomManager.SetDomElementAttribute(_imageDiv, "src", imageSrc ?? string.Empty);
             }
             else
             {

--- a/src/Runtime/Runtime/System.Windows.Controls/MediaElement.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/MediaElement.cs
@@ -324,7 +324,7 @@ namespace Windows.UI.Xaml.Controls
                     }
 
                     // Update the "src" property of the <video> or <audio> tag
-                    INTERNAL_HtmlDomManager.SetDomElementAttribute(control._mediaElement, "src", valueForHtml5SourceProperty, true);
+                    INTERNAL_HtmlDomManager.SetDomElementAttribute(control._mediaElement, "src", valueForHtml5SourceProperty);
                 }
                 else
                 {

--- a/src/Runtime/Runtime/System.Windows.input/InputManager.JsCall.cs
+++ b/src/Runtime/Runtime/System.Windows.input/InputManager.JsCall.cs
@@ -1,0 +1,12 @@
+﻿using OpenSilver;
+
+namespace System.Windows.Input;
+
+internal sealed partial class InputManager
+{
+    private enum JsCall
+    {
+        [JsCall("void;document.inputManager.addListeners({sOuter}, {isFocusable,b});")]
+        AddEventListeners,
+    }
+}

--- a/src/Runtime/Runtime/System.Windows.input/InputManager.cs
+++ b/src/Runtime/Runtime/System.Windows.input/InputManager.cs
@@ -13,6 +13,7 @@
 
 using System;
 using CSHTML5.Internal;
+using OpenSilver;
 
 #if MIGRATION
 using System.Windows.Controls;
@@ -31,7 +32,7 @@ namespace System.Windows.Input;
 namespace Windows.UI.Xaml.Input;
 #endif
 
-internal sealed class InputManager
+internal sealed partial class InputManager
 {
     // This must remain synchronyzed with the EVENTS enum defined in cshtml5.js.
     // Make sure to change both files if you update this !
@@ -78,14 +79,16 @@ internal sealed class InputManager
     {
         if (uie.INTERNAL_OuterDomElement is INTERNAL_HtmlDomElementReference domRef)
         {
-            OpenSilver.Interop.ExecuteJavaScriptFastAsync(
-                $"document.inputManager.addListeners('{domRef.UniqueIdentifier}', {(isFocusable ? "true" : "false")});");
+            Interop2.VoidAsync(JsCall.AddEventListeners, domRef.UniqueIdentifier, isFocusable);
+            //OpenSilver.Interop.ExecuteJavaScriptFastAsync(
+            //    $"document.inputManager.addListeners('{domRef.UniqueIdentifier}', {(isFocusable ? "true" : "false")});");
         }
         else
         {
-            string sOuter = CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(uie.INTERNAL_OuterDomElement);
-            OpenSilver.Interop.ExecuteJavaScriptFastAsync(
-                $"document.inputManager.addListeners({sOuter}, {(isFocusable ? "true" : "false")});");
+            Interop2.VoidAsync(JsCall.AddEventListeners, uie.INTERNAL_OuterDomElement, isFocusable);
+            //string sOuter = CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(uie.INTERNAL_OuterDomElement);
+            //OpenSilver.Interop.ExecuteJavaScriptFastAsync(
+            //    $"document.inputManager.addListeners({sOuter}, {(isFocusable ? "true" : "false")});");
         }
     }
 

--- a/src/Runtime/Runtime/System.Windows.input/MouseEventArgs.JsArgs.cs
+++ b/src/Runtime/Runtime/System.Windows.input/MouseEventArgs.JsArgs.cs
@@ -1,0 +1,34 @@
+﻿using OpenSilver;
+
+namespace System.Windows.Input;
+
+public partial class MouseEventArgs
+{
+    private enum JsCall
+    {
+        [JsCall("void;{sEvent}.doNotReroute = true")]
+        DoNotRerouteTrue,
+        [JsCall("{sEvent}.doNotReroute == true")]
+        TestDoNotReroute,
+
+        [JsCall("{sEvent}.shiftKey || false")]
+        ShiftKey,
+        [JsCall("{sEvent}.altKey || false")]
+        AltKey,
+        [JsCall("{sEvent}.ctrlKey || false")]
+        CtrlKey,
+
+        [JsCall("{sEvent}.type")]
+        GetType,
+
+        [JsCall("{sEvent}.changedTouches[0].pageX + '|' + {sEvent}.changedTouches[0].pageY")]
+        GetTouchXY,
+
+        [JsCall("{sEvent}.pageX + '|' + {sEvent}.pageY")]
+        GetPageXY,
+
+        [JsCall("({sElement}.getBoundingClientRect().left - document.body.getBoundingClientRect().left) + '|' + ({sElement}.getBoundingClientRect().top - document.body.getBoundingClientRect().top)")]
+        SetPointerAbsolutePos,
+
+    }
+}

--- a/src/Runtime/Runtime/System.Windows.input/MouseEventArgs.cs
+++ b/src/Runtime/Runtime/System.Windows.input/MouseEventArgs.cs
@@ -106,7 +106,7 @@ namespace Windows.UI.Xaml.Input
             if (Pointer.INTERNAL_captured == null)
             {
                 //this is just in case the handler of this event starts a capture of the Pointer: we do not want to reroute it right away.
-                Interop2.ExecuteJavaScript(JsCall.DoNotRerouteTrue, jsEventArg);
+                Interop2.Void(JsCall.DoNotRerouteTrue, jsEventArg);
                 //todo: check if the comment above is always right (questionnable if capturing element is another one than the one that threw this event).
                 return true;
             }
@@ -114,12 +114,12 @@ namespace Windows.UI.Xaml.Input
             {
                 if (Pointer.INTERNAL_captured == element)
                 {
-                    Interop2.ExecuteJavaScript(JsCall.DoNotRerouteTrue, jsEventArg);
+                    Interop2.Void(JsCall.DoNotRerouteTrue, jsEventArg);
                     return true;
                 }
                 else
                 {
-                    return Interop2.ExecuteJavaScriptBoolean(JsCall.TestDoNotReroute , jsEventArg);
+                    return Interop2.Boolean(JsCall.TestDoNotReroute , jsEventArg);
                 }
             }
         }
@@ -129,7 +129,7 @@ namespace Windows.UI.Xaml.Input
             // If the element has captured the pointer, we do not want the Document to reroute the event to the element because it would result in the event being handled twice.
             if (Pointer.INTERNAL_captured == null || Pointer.INTERNAL_captured == element)
             {
-                Interop2.ExecuteJavaScript(JsCall.DoNotRerouteTrue, jsEventArg);
+                Interop2.Void(JsCall.DoNotRerouteTrue, jsEventArg);
             }
 
             AddKeyModifiers(jsEventArg);
@@ -143,7 +143,7 @@ namespace Windows.UI.Xaml.Input
 #else
             VirtualKeyModifiers keyModifiers = VirtualKeyModifiers.None;
 #endif
-            if (Interop2.ExecuteJavaScriptBoolean(JsCall.ShiftKey , jsEventArg) )
+            if (Interop2.Boolean(JsCall.ShiftKey , jsEventArg) )
             {
 #if MIGRATION
                 keyModifiers |= ModifierKeys.Shift;
@@ -151,7 +151,7 @@ namespace Windows.UI.Xaml.Input
                 keyModifiers |= VirtualKeyModifiers.Shift;
 #endif
             }
-            if (Interop2.ExecuteJavaScriptBoolean(JsCall.AltKey , jsEventArg) )
+            if (Interop2.Boolean(JsCall.AltKey , jsEventArg) )
             {
 #if MIGRATION
                 keyModifiers |= ModifierKeys.Alt;
@@ -159,7 +159,7 @@ namespace Windows.UI.Xaml.Input
                 keyModifiers |= VirtualKeyModifiers.Menu;
 #endif
             }
-            if (Interop2.ExecuteJavaScriptBoolean(JsCall.CtrlKey , jsEventArg))
+            if (Interop2.Boolean(JsCall.CtrlKey , jsEventArg))
             {
 #if MIGRATION
                 keyModifiers |= ModifierKeys.Control;
@@ -175,8 +175,8 @@ namespace Windows.UI.Xaml.Input
             {
                 // Hack to improve the Simulator performance by making only one interop call rather than two:
                 string sEvent = INTERNAL_InteropImplementation.GetVariableStringForJS(jsEventArg);
-                string type = Interop2.ExecuteJavaScriptString(JsCall.GetType, sEvent);
-                var concatenated = Interop2.ExecuteJavaScriptString(type.StartsWith("touch") ? JsCall.GetTouchXY : JsCall.GetPageXY, sEvent);
+                string type = Interop2.String(JsCall.GetType, sEvent);
+                var concatenated = Interop2.String(type.StartsWith("touch") ? JsCall.GetTouchXY : JsCall.GetPageXY, sEvent);
                 int sepIndex = concatenated.IndexOf('|');
                 string pointerAbsoluteXAsString = concatenated.Substring(0, sepIndex);
                 string pointerAbsoluteYAsString = concatenated.Substring(sepIndex + 1);
@@ -196,7 +196,7 @@ namespace Windows.UI.Xaml.Input
                 double windowRootTop;
 
                 // Hack to improve the Simulator performance by making only one interop call rather than two:
-                string concatenated = Interop2.ExecuteJavaScriptString(JsCall.SetPointerAbsolutePos , windowRootDomElement); 
+                string concatenated = Interop2.String(JsCall.SetPointerAbsolutePos , windowRootDomElement); 
                 int sepIndex = concatenated.IndexOf('|');
                 if (sepIndex > -1)
                 {

--- a/src/Runtime/Runtime/System.Windows.input/MouseEventArgs.cs
+++ b/src/Runtime/Runtime/System.Windows.input/MouseEventArgs.cs
@@ -1,0 +1,312 @@
+﻿
+
+/*===================================================================================
+* 
+*   Copyright (c) Userware/OpenSilver.net
+*      
+*   This file is part of the OpenSilver Runtime (https://opensilver.net), which is
+*   licensed under the MIT license: https://opensource.org/licenses/MIT
+*   
+*   As stated in the MIT license, "the above copyright notice and this permission
+*   notice shall be included in all copies or substantial portions of the Software."
+*  
+\*====================================================================================*/
+
+
+using CSHTML5;
+using CSHTML5.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Globalization;
+using OpenSilver;
+#if MIGRATION
+using System.Windows.Media;
+#else
+using Windows.UI.Xaml.Media;
+using Windows.Foundation;
+using Windows.System;
+//using Windows.System;
+using Windows.UI.Input;
+#endif
+
+#if MIGRATION
+namespace System.Windows.Input
+#else
+namespace Windows.UI.Xaml.Input
+#endif
+{
+    /// <summary>
+    /// Provides event data for pointer message events related to specific user interface
+    /// elements, such as PointerPressed.
+    /// </summary>
+#if MIGRATION
+    public partial class MouseEventArgs : RoutedEventArgs
+
+#else
+    public partial class PointerRoutedEventArgs : RoutedEventArgs
+#endif
+    {
+        internal override void InvokeHandler(Delegate handler, object target)
+        {
+#if MIGRATION
+            ((MouseEventHandler)handler)(target, this);
+#else
+            ((PointerEventHandler)handler)(target, this);
+#endif
+        }
+
+        internal double _pointerAbsoluteX = 0d; // Note: they are actually "relative" to the XAML Window root.
+        internal double _pointerAbsoluteY = 0d; // Note: they are actually "relative" to the XAML Window root.
+
+        /// <summary>
+        /// Gets or sets a value that marks the routed event as handled, and prevents
+        /// most handlers along the event route from handling the same event again.
+        /// </summary>
+        public bool Handled
+        {
+            get => HandledImpl;
+            set => HandledImpl = value;
+        }
+
+#if MIGRATION
+        ModifierKeys _keyModifiers;
+#else
+        VirtualKeyModifiers _keyModifiers;
+#endif
+
+        /// <summary>
+        /// Gets a value that indicates which key modifiers were active at the time that
+        /// the pointer event was initiated.
+        /// </summary>
+#if MIGRATION
+        public ModifierKeys KeyModifiers
+#else
+        public VirtualKeyModifiers KeyModifiers
+#endif
+        {
+            get { return _keyModifiers; }
+            internal set { _keyModifiers = value; }
+        }
+
+        /// <summary>
+        /// Gets an object that reports stylus device information, such as the collection
+        /// of stylus points associated with the input.
+        /// </summary>
+        /// <returns>
+        /// The stylus device information object.
+        /// </returns>
+        public StylusDevice StylusDevice => new StylusDevice(this);
+
+        internal bool CheckIfEventShouldBeTreated(UIElement element, object jsEventArg)
+        {
+            //todo: this method is called by "OnMouseEvent", "OnMouseLeave", etc., but there appears to be other events where this method is not called: shouldn't we call it in those methods too? todo: verify that the handler is not called twice when an element has captured the pointer and registered the PointerPressed event for example.
+            if (Pointer.INTERNAL_captured == null)
+            {
+                //this is just in case the handler of this event starts a capture of the Pointer: we do not want to reroute it right away.
+                Interop2.ExecuteJavaScript(JsCall.DoNotRerouteTrue, jsEventArg);
+                //todo: check if the comment above is always right (questionnable if capturing element is another one than the one that threw this event).
+                return true;
+            }
+            else
+            {
+                if (Pointer.INTERNAL_captured == element)
+                {
+                    Interop2.ExecuteJavaScript(JsCall.DoNotRerouteTrue, jsEventArg);
+                    return true;
+                }
+                else
+                {
+                    return Interop2.ExecuteJavaScriptBoolean(JsCall.TestDoNotReroute , jsEventArg);
+                }
+            }
+        }
+
+        internal void FillEventArgs(UIElement element, object jsEventArg)
+        {
+            // If the element has captured the pointer, we do not want the Document to reroute the event to the element because it would result in the event being handled twice.
+            if (Pointer.INTERNAL_captured == null || Pointer.INTERNAL_captured == element)
+            {
+                Interop2.ExecuteJavaScript(JsCall.DoNotRerouteTrue, jsEventArg);
+            }
+
+            AddKeyModifiers(jsEventArg);
+            SetPointerAbsolutePosition(jsEventArg, element.INTERNAL_ParentWindow);
+        }
+
+        private void AddKeyModifiers(object jsEventArg)
+        {
+#if MIGRATION
+            ModifierKeys keyModifiers = ModifierKeys.None;
+#else
+            VirtualKeyModifiers keyModifiers = VirtualKeyModifiers.None;
+#endif
+            if (Interop2.ExecuteJavaScriptBoolean(JsCall.ShiftKey , jsEventArg) )
+            {
+#if MIGRATION
+                keyModifiers |= ModifierKeys.Shift;
+#else
+                keyModifiers |= VirtualKeyModifiers.Shift;
+#endif
+            }
+            if (Interop2.ExecuteJavaScriptBoolean(JsCall.AltKey , jsEventArg) )
+            {
+#if MIGRATION
+                keyModifiers |= ModifierKeys.Alt;
+#else
+                keyModifiers |= VirtualKeyModifiers.Menu;
+#endif
+            }
+            if (Interop2.ExecuteJavaScriptBoolean(JsCall.CtrlKey , jsEventArg))
+            {
+#if MIGRATION
+                keyModifiers |= ModifierKeys.Control;
+#else
+                keyModifiers |= VirtualKeyModifiers.Control;
+#endif
+            }
+            KeyModifiers = keyModifiers;
+        }
+
+        protected internal void SetPointerAbsolutePosition(object jsEventArg, Window window)
+        {
+            {
+                // Hack to improve the Simulator performance by making only one interop call rather than two:
+                string sEvent = INTERNAL_InteropImplementation.GetVariableStringForJS(jsEventArg);
+                string type = Interop2.ExecuteJavaScriptString(JsCall.GetType, sEvent);
+                var concatenated = Interop2.ExecuteJavaScriptString(type.StartsWith("touch") ? JsCall.GetTouchXY : JsCall.GetPageXY, sEvent);
+                int sepIndex = concatenated.IndexOf('|');
+                string pointerAbsoluteXAsString = concatenated.Substring(0, sepIndex);
+                string pointerAbsoluteYAsString = concatenated.Substring(sepIndex + 1);
+                _pointerAbsoluteX = double.Parse(pointerAbsoluteXAsString, CultureInfo.InvariantCulture); //todo: verify that the locale is OK. I think that JS by default always produces numbers in invariant culture (with "." separator).
+                _pointerAbsoluteY = double.Parse(pointerAbsoluteYAsString, CultureInfo.InvariantCulture); //todo: read note above
+            }
+
+            //---------------------------------------
+            // Adjust the absolute coordinates to take into account the fact that the XAML Window is not necessary un the top-left corner of the HTML page:
+            //---------------------------------------
+            if (window != null)
+            {
+                // Get the XAML Window root position relative to the page:
+                object windowRootDomElement = window.INTERNAL_OuterDomElement;
+
+                double windowRootLeft;
+                double windowRootTop;
+
+                // Hack to improve the Simulator performance by making only one interop call rather than two:
+                string concatenated = Interop2.ExecuteJavaScriptString(JsCall.SetPointerAbsolutePos , windowRootDomElement); 
+                int sepIndex = concatenated.IndexOf('|');
+                if (sepIndex > -1)
+                {
+                    string windowRootLeftAsString = concatenated.Substring(0, sepIndex);
+                    string windowRootTopAsString = concatenated.Substring(sepIndex + 1);
+                    windowRootLeft = double.Parse(windowRootLeftAsString, CultureInfo.InvariantCulture);
+                    windowRootTop = double.Parse(windowRootTopAsString, CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    windowRootLeft = Double.NaN;
+                    windowRootTop = Double.NaN;
+                }
+
+                // Substract the XAML Window position, to get the pointer position relative to the XAML Window root:
+                _pointerAbsoluteX -= windowRootLeft;
+                _pointerAbsoluteY -= windowRootTop;
+            }
+        }
+
+        Pointer _pointer;
+
+        /// <summary>
+        /// Gets a reference to a pointer token.
+        /// </summary>
+        public Pointer Pointer
+        {
+            get { return _pointer; }
+            internal set { _pointer = value; }
+        }
+
+
+        int _clickCount = 1;
+        /// <summary>
+        /// Gets the number of times the button was clicked.
+        /// </summary>
+        public int ClickCount { get { return _clickCount; } }
+
+        internal void RefreshClickCount(UIElement sender)
+        {
+            int currentDate = Environment.TickCount;
+            if (currentDate - sender.INTERNAL_lastClickDate > 400) //Note: the duration is apparently dependent on the system's double click but there is apparently no way to get it. mine defaulted to 500ms but I feel it's too long so 400 it is.
+            {
+                sender.INTERNAL_clickCount = 1;
+            }
+            else
+            {
+                ++sender.INTERNAL_clickCount;
+            }
+            sender.INTERNAL_lastClickDate = currentDate;
+            _clickCount = sender.INTERNAL_clickCount;
+        }
+
+        /// <summary>
+        /// Returns the pointer position for this event occurrence, optionally evaluated
+        /// against a coordinate origin of a supplied UIElement.
+        /// </summary>
+        /// <param name="relativeTo">
+        /// Any UIElement-derived object that is connected to the same object tree. To
+        /// specify the object relative to the overall coordinate system, use a relativeTo value
+        /// of null.
+        /// </param>
+        /// <returns>
+        /// A PointerPoint value that represents the pointer point associated with this
+        /// event. If null was passed as relativeTo, the coordinates are in the frame
+        /// of reference of the overall window. If a non-null relativeTo was passed,
+        /// the coordinates are relative to the object referenced by relativeTo.
+        /// </returns>
+#if MIGRATION
+        public Point GetPosition(UIElement relativeTo)
+            => GetPosition(new Point(_pointerAbsoluteX, _pointerAbsoluteY), relativeTo);
+#else
+        public PointerPoint GetCurrentPoint(UIElement relativeTo)
+        {
+            PointerPoint pointerPoint = new PointerPoint();
+            pointerPoint.Properties.MouseWheelDelta = PointerPointProperties.GetPointerWheelDelta(INTERNAL_OriginalJSEventArg);
+            pointerPoint.Position = GetPosition(new Point(_pointerAbsoluteX, _pointerAbsoluteY), relativeTo);
+
+            return pointerPoint;
+        }
+#endif
+
+        internal static Point GetPosition(Point origin, UIElement relativeTo)
+        {
+            if (relativeTo == null)
+            {
+                //-----------------------------------
+                // Return the absolute pointer coordinates:
+                //-----------------------------------
+                return origin;
+            }
+            else if (relativeTo.IsConnectedToLiveTree)
+            {
+                //-----------------------------------
+                // Returns the pointer coordinates relative to the "relativeTo" element:
+                //-----------------------------------
+
+                UIElement rootVisual = Application.Current?.RootVisual;
+                if (rootVisual != null)
+                {
+                    return rootVisual.TransformToVisual(relativeTo).Transform(origin);
+                }
+            }
+
+            return new Point(0.0, 0.0);
+        }
+
+#if MIGRATION
+        [OpenSilver.NotImplemented]
+        public int Delta { get; private set; }
+#endif
+    }
+}

--- a/src/Runtime/Scripts/OpenSilver.js
+++ b/src/Runtime/Scripts/OpenSilver.js
@@ -105,9 +105,26 @@ window.onCallBack = (function () {
     return {
         OnCallbackFromJavaScript: function (callbackId, idWhereCallbackArgsAreStored, callbackArgsObject, returnValue) {
             let formattedArgs = prepareCallbackArgs(callbackArgsObject);
-            const res = DotNet.invokeMethod(opensilver, opensilver_js_callback, callbackId, idWhereCallbackArgsAreStored, formattedArgs, returnValue || false);
-            if (returnValue) {
-                return res;
+            /* protect against :
+
+Uncaught ExitStatus ExitStatus
+    at quit_ (localhost?55591/_framework/dotnet.6.0.15.4de83zsqbd.js:1:251)
+    at exit (localhost?55591/_framework/dotnet.6.0.15.4de83zsqbd.js:1:234777)
+    at _exit (localhost?55591/_framework/dotnet.6.0.15.4de83zsqbd.js:1:106255)
+    at $func111 (undefined:1:38087)
+    at $func2230 (undefined:1:584627)
+    at $func3483 (undefined:1:836327)
+    ....
+
+            */
+            try { 
+                const res = DotNet.invokeMethod(opensilver, opensilver_js_callback, callbackId, idWhereCallbackArgsAreStored, formattedArgs, returnValue || false);
+                if (returnValue) {
+                    return res;
+                }
+            } catch (e) { 
+                // note: stacktrace is useless
+                console.log('ERROR in OnCallbackFromJavaScript: ' + callbackId); 
             }
         },
 

--- a/src/Runtime/Scripts/OpenSilver.js
+++ b/src/Runtime/Scripts/OpenSilver.js
@@ -130,6 +130,8 @@ window.callJS = function (javaScriptToExecute) {
     }
 };
 
+
+
 window.callJSUnmarshalled = function (javaScriptToExecute, referenceId, wantsResult) {
     javaScriptToExecute = BINDING.conv_string(javaScriptToExecute);
     var result = eval(javaScriptToExecute);
@@ -152,6 +154,19 @@ window.callJSUnmarshalled = function (javaScriptToExecute, referenceId, wantsRes
 };
 
 
+window.createFunction = function (id, javaScriptToExecute) { 
+    const js = BINDING.conv_string(javaScriptToExecute);
+    document.jsObjRef["_functions"][id] = new Function('subId', 'args', js);
+}
+
+window.callFunction = function (id, subId, args) { 
+    const jsArgs = BINDING.conv_string(args);
+    return document.jsObjRef["_functions"][id](subId, jsArgs);
+}
+
+
+
+
 // IMPORTANT: this doesn't return anything (this just executes the pending async JS)
 window.callJSUnmarshalledHeap = (function () {
     const textDecoder = new TextDecoder('utf-16le');
@@ -161,3 +176,5 @@ window.callJSUnmarshalledHeap = (function () {
         eval(javaScriptToExecute);
     };
 })();
+
+

--- a/src/Runtime/Scripts/OpenSilver.js
+++ b/src/Runtime/Scripts/OpenSilver.js
@@ -156,12 +156,16 @@ window.callJSUnmarshalled = function (javaScriptToExecute, referenceId, wantsRes
 
 window.createFunction = function (id, javaScriptToExecute) { 
     const js = BINDING.conv_string(javaScriptToExecute);
-    document.jsObjRef["_functions"][id] = new Function('subId', 'args', js);
+    const strId = BINDING.conv_string(id);
+    document.jsObjRef["_functions"][strId] = new Function('subId', 'args', js);
 }
 
 window.callFunction = function (id, subId, args) { 
     const jsArgs = BINDING.conv_string(args);
-    return document.jsObjRef["_functions"][id](subId, jsArgs);
+    const strId = BINDING.conv_string(id);
+    var result = document.jsObjRef["_functions"][strId](subId, jsArgs);
+    if (result !== undefined)
+        return BINDING.js_to_mono_obj(result);
 }
 
 

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -137,7 +137,7 @@ document.onkeyup = function (evt) {
     document.refreshKeyModifiers(evt);
 };
 
-document.jsObjRef = {};
+document.jsObjRef = { "_functions": {} };
 document.callbackCounterForSimulator = 0;
 document.measureTextBlockElement = null;
 

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -141,6 +141,43 @@ document.jsObjRef = { "_functions": {} };
 document.callbackCounterForSimulator = 0;
 document.measureTextBlockElement = null;
 
+document.argToJsObj = function (arg) {
+    if (arg.startsWith("document.jsObjRef")) {
+        const idxEnd = arg.indexOf("]");
+        // note: ignore the start and end quotes as well
+        let refId = arg.substr(19,idxEnd-20);
+
+        let arrayIdx = -1;
+        let argIdx = arg.indexOf("[", idxEnd);
+        if (argIdx > 0) {
+            ++argIdx;
+            arrayIdx = parseInt( arg.substr(argIdx, arg.length - 1 - argIdx), 10);
+        }
+
+        if (arrayIdx >= 0)
+            return document.jsObjRef[refId][arrayIdx];
+        else 
+            return document.jsObjRef[refId];
+    }
+    if (arg.startsWith("document.getElementByIdSafe")) {
+        // note: ignore the start and end quotes as well
+        let refId = arg.substr(29,arg.length-31);
+        return document.getElementByIdSafe(refId);
+    }
+    if (arg.startsWith("document.getCallbackFunc")) {
+        let idxEnd = arg.indexOf(",");
+        let id = parseInt( arg.substr(25,idxEnd-25));
+        ++idxEnd;
+        let idxLastComma = arg.indexOf(",", idxEnd );
+        let isSync = arg.substr(idxEnd , idxLastComma - idxEnd).trim();
+        ++idxLastComma;
+        var isNotSimulator = arg.substr(idxLastComma, arg.length - idxLastComma - 1).trim();
+        return document.getCallbackFunc(id, isSync == "true", isNotSimulator == "true");
+    }
+
+    return arg;
+}
+
 document.reroute = function reroute(e, elem, shiftKey) {
     shiftKey = shiftKey || false;
     if (e.rerouted === undefined) {


### PR DESCRIPTION
Interop2 is another way to execute JS that doesn't consume as much memory.
Basically, it avoids calling of Javascript's eval() altogether.

The idea is this: it seems that when an eval() is executed, it takes a while until the memory used behind the scenes by eval() is released. This can lead to bursts of memory increase and can faster lead to out-of-memory exceptions.

Interop2 avoids this altogether by pre-compiling a JS function, and you just specify which sub-function to call + its arguments (the former JS you used to call Interop.ExecuteJavascript upon)

The idea behind Interop2: 
- instead of eval(), we want to create a JS Function() (which gets precompiled), and then just execute that.
- obviously, we don't want to create a gazillion JS functions. Thus, for each piece of code you want to transition to Interop2 (be it a small module, a class, etc), you'll create an enum, and each piece of javascript code becomes an enum value with an attribute JsCall("<the-javascript-along-with-arguments>")
- simplest example: MouseEventArgs.JsCall enum

Also, I've devised a way for you to trace which JS calls occur the most (so you can try to optimize them into Interop2 calls):
Just set **Interop.DumpJavascriptCallsInfoEveryMs = <some_ms_value>;**

This will dump the top JS calls of last X ms, X * 20ms, and top JS calls of all time.

I've already implemented this for INTERNAL_HtmlDomManager, InputManager, MouseEventArgs.

I've made it as simple as possible to transition from Interop code to Interop2 code, usually it's just copy-paste, but sometimes it can be a bit more code.
Also, in case there's an error with the resulting JS, I will throw an exception showing which sub-function (i.e., enum value) is the culprit.
