### PR TITLE
Include mono.cecil in the Simulator package

### DIFF
--- a/build/nuspec/OpenSilver.Simulator.nuspec
+++ b/build/nuspec/OpenSilver.Simulator.nuspec
@@ -41,6 +41,8 @@
     <file src="../src/Simulator/Simulator/bin/OpenSilver/Debug/interop_debug_root_opensilver.html" target="contentFiles/any/net462/interop_debug_root.html" />
 
     <!-- OpenSilver compiler -->
+    <file src="../src/Compiler/Compiler.ResourcesExtractor/bin/OpenSilver/Release/net461/Mono.Cecil.dll" target="tools/Mono.Cecil.dll" />
+
     <file src="../src/Compiler/Compiler.ResourcesExtractor/bin/OpenSilver/Release/net461/OpenSilver.Compiler.Resources.dll" target="tools/OpenSilver.Compiler.Resources.dll" />
     <file src="../src/Compiler/Compiler.ResourcesExtractor/bin/OpenSilver/Release/net461/OpenSilver.Compiler.Resources.pdb" target="tools/OpenSilver.Compiler.Resources.pdb" />
     <file src="../src/Compiler/Compiler.Common/bin/OpenSilver/Release/net461/OpenSilver.Compiler.Common.dll" target="tools/OpenSilver.Compiler.Common.dll" />

--- a/build/nuspec/OpenSilver.nuspec
+++ b/build/nuspec/OpenSilver.nuspec
@@ -69,8 +69,6 @@
 
     <!-- OpenSilver compiler -->
     <file src="../../src/Compiler/Compiler/bin/OpenSilver/Release/net461/Mono.Cecil.dll" target="tools/Mono.Cecil.dll" />
-    <file src="../../src/Compiler/Compiler/bin/OpenSilver/Release/net461/Mono.Cecil.Mdb.dll" target="tools/Mono.Cecil.Mdb.dll" />
-    <file src="../../src/Compiler/Compiler/bin/OpenSilver/Release/net461/Mono.Cecil.Pdb.dll" target="tools/Mono.Cecil.Pdb.dll" />
     <file src="../../src/Compiler/Compiler/bin/OpenSilver/Release/net461/Mono.Cecil.Rocks.dll" target="tools/Mono.Cecil.Rocks.dll" />
 
     <file src="../../src/Compiler/Compiler/bin/OpenSilver/Release/net461/OpenSilver.Compiler.dll" target="tools/OpenSilver.Compiler.dll" />


### PR DESCRIPTION
We need to add mono.cecil to the Simulator because the resources extractor uses it.
The current version works properly most times because the simulator reuses copier from one of other projects with OpenSilver reference. However, if the simulator will be loaded as a first project, then it can fail.

Also, we do not need mdb and pdb part of mono.cecil, so, it can be removed from OpenSilver to save package size.