### PR TITLE
Fix: prevent text overlapping for ComboBox selected item

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ComboBox.cs
@@ -77,6 +77,7 @@ namespace Windows.UI.Xaml.Controls
         public ComboBox()
         {
             DefaultStyleKey = typeof(ComboBox);
+            this.ClipToBounds = true;
             IsEnabledChanged += (o, e) =>
             {
                 if (!(bool)e.NewValue)


### PR DESCRIPTION
In a customized Item Template when the TextBlock.MaxWidth is bigger than the CombBox.MaxWidth we can observe text overlapping. For some reason the issue isn't reproducible in a simple example, it could be related to its parent, but this commit fixes the issue.
