### PR TITLE
Prevent changing styles on detaching

### DIFF
--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
@@ -1208,17 +1208,6 @@ namespace Windows.UI.Xaml
 
 #endregion
 
-        protected internal override void INTERNAL_OnDetachedFromVisualTree()
-        {
-            base.INTERNAL_OnDetachedFromVisualTree();
-            if (HasImplicitStyleFromResources && 
-                (!HasResources || !Resources.Contains(GetType())))
-            {
-                HasStyleInvalidated = false;
-                UpdateStyleProperty();
-            }
-        }
-
         protected internal override void INTERNAL_OnAttachedToVisualTree()
         {
             base.INTERNAL_OnAttachedToVisualTree();


### PR DESCRIPTION
In the current implementation, there is an issue when an element is removed from the tree. The parent's style may be lost, causing the global style to be applied instead. Consequently, this can lead to the “reattachment” of the removed element if a template exists within the global style.

Example is available here - https://github.com/jacob-l/OpenSilverAttachDetach

It appears that we don't need to modify styles when detaching an element. Regardless, if the element is reattached later, its styles will be updated accordingly in the method INTERNAL_OnAttachedToVisualTree.

