### PR TITLE
Configure up-to-date checker to check xaml files

### DIFF
--- a/src/Targets/OpenSilver.Common.targets
+++ b/src/Targets/OpenSilver.Common.targets
@@ -36,6 +36,13 @@
   </ItemGroup>
 
   <!--============================================================
+  Configure the Up-To-Date checker to check xaml files - https://github.com/dotnet/project-system/blob/main/docs/up-to-date-check.md
+  ============================================================-->
+  <ItemGroup>
+    <UpToDateCheckInput Include="**\*.xaml"/>
+  </ItemGroup>
+
+  <!--============================================================
   Add the tasks "CSharpXamlForHtml5BeforeCompile" and "CSharpXamlForHtml5BeforeBuild" to the build process:
   ============================================================-->
   <PropertyGroup>


### PR DESCRIPTION
For Blazor projects, the up-to-date checker ignores xaml files out of the box. Add a configuration to check all xaml files too.