### PR TITLE
Fix drawing arcs with clockwise sweep direction

### DIFF
--- a/src/Runtime/Runtime/Core/Rendering/INTERNAL_Html2dContextReference.cs
+++ b/src/Runtime/Runtime/Core/Rendering/INTERNAL_Html2dContextReference.cs
@@ -91,7 +91,13 @@ namespace CSHTML5.Internal
         public void closePath() { InvokeMethod("closePath"); }
         public void createLinearGradient(double x0, double y0, double x1, double y1) { InvokeMethod("createLinearGradient", x0, y0, x1, y1); }
 
-        public void arc(params object[] args) { InvokeMethod("arc", args); }
+        public void arc(double centerX, double centerY, double radius, double startAngle, double endAngle, bool counterClockwise = false)
+        {
+            OpenSilver.Interop.ExecuteJavaScriptFastAsync(@$"
+document.getElementById('{_id}').getContext('2d').arc({centerX.ToInvariantString()}, {centerY.ToInvariantString()}, {radius.ToInvariantString()}, 
+{startAngle.ToInvariantString()}, {endAngle.ToInvariantString()}, {INTERNAL_HtmlDomManager.ConvertToStringToUseInJavaScriptCode(counterClockwise)});");
+        }
+
         public void ellipse(params object[] args) { InvokeMethod("ellipse", args); }
         public void rect(double x, double y, double width, double height) { InvokeMethod("rect", x, y, width, height); }
 


### PR DESCRIPTION
Use direct call of `arc` function instead of using `document.invoke2dContextMethod`.
Fixes the incorrect drawing of arcs with clockwise sweep direction.
Example:
```
        <Canvas Grid.Row="2" Margin="20">
            <Path Width="500" Height="500" Stroke="Black">
                <Path.Data>
                    <PathGeometry>
                        <PathFigure StartPoint="100 0" IsClosed="False">
                            <ArcSegment Point="1 0" Size="1 1" SweepDirection="Clockwise" IsLargeArc="False"/>
                        </PathFigure>
                    </PathGeometry>
                </Path.Data>
            </Path>
        </Canvas>
```
Expected 
![image](https://user-images.githubusercontent.com/7633528/237056313-1a3f8cb3-3d30-48ce-b92e-bf86378a603a.png)

Actual
![image](https://user-images.githubusercontent.com/7633528/237056744-72fc865e-db29-4607-ac63-8ecd52d29343.png)
