### PR TITLE
memory improvements

### DIFF
--- a/src/Runtime/Runtime/System.Windows/DependencyObject.cs
+++ b/src/Runtime/Runtime/System.Windows/DependencyObject.cs
@@ -279,22 +279,6 @@ namespace Windows.UI.Xaml
         }
         #endregion
 
-        ~DependencyObject()
-        {
-            // the idea -> remove this object from any references held by brushes
-            var weakThis = new WeakDependencyObjectWrapper(this);
-            foreach (var dp in INTERNAL_PropertyStorageDictionary.Keys)
-                if (GetValue(dp) is IHasAccessToPropertiesWhereItIsUsed2 hasAccess)
-                {
-                    hasAccess.PropertiesWhereUsed.Remove(weakThis);
-                }
-            foreach (var dp in INTERNAL_AllInheritedProperties.Keys)
-                if (GetValue(dp) is IHasAccessToPropertiesWhereItIsUsed2 hasAccess)
-                {
-                    hasAccess.PropertiesWhereUsed.Remove(weakThis);
-                }
-        }
-
         /// <summary>
         /// Returns the current effective value of a dependency property from a DependencyObject.
         /// </summary>

--- a/src/Runtime/Runtime/System.Windows/DependencyObject.cs
+++ b/src/Runtime/Runtime/System.Windows/DependencyObject.cs
@@ -15,7 +15,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Windows.Media;
 using CSHTML5.Internal;
 using OpenSilver.Internal.Data;
 using OpenSilver.Internal;
@@ -278,6 +277,7 @@ namespace Windows.UI.Xaml
             INTERNAL_AllInheritedProperties = new Dictionary<DependencyProperty, INTERNAL_PropertyStorage>();
         }
         #endregion
+
 
         /// <summary>
         /// Returns the current effective value of a dependency property from a DependencyObject.

--- a/src/Runtime/Runtime/System.Windows/DependencyObject.cs
+++ b/src/Runtime/Runtime/System.Windows/DependencyObject.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Windows.Media;
 using CSHTML5.Internal;
 using OpenSilver.Internal.Data;
 using OpenSilver.Internal;
@@ -278,6 +279,21 @@ namespace Windows.UI.Xaml
         }
         #endregion
 
+        ~DependencyObject()
+        {
+            // the idea -> remove this object from any references held by brushes
+            var weakThis = new WeakDependencyObjectWrapper(this);
+            foreach (var dp in INTERNAL_PropertyStorageDictionary.Keys)
+                if (GetValue(dp) is IHasAccessToPropertiesWhereItIsUsed2 hasAccess)
+                {
+                    hasAccess.PropertiesWhereUsed.Remove(weakThis);
+                }
+            foreach (var dp in INTERNAL_AllInheritedProperties.Keys)
+                if (GetValue(dp) is IHasAccessToPropertiesWhereItIsUsed2 hasAccess)
+                {
+                    hasAccess.PropertiesWhereUsed.Remove(weakThis);
+                }
+        }
 
         /// <summary>
         /// Returns the current effective value of a dependency property from a DependencyObject.

--- a/src/Runtime/Runtime/System.Windows/FrameworkElement_HandlingSizeAndAlignment.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement_HandlingSizeAndAlignment.cs
@@ -1314,18 +1314,15 @@ namespace Windows.UI.Xaml
         #region SizeChanged
 
         private Size _valueOfLastSizeChanged = new Size(0d, 0d);
-        private List<SizeChangedEventHandler> _sizeChangedEventHandlers;
         private readonly IResizeObserverAdapter _resizeObserver = ResizeObserverFactory.Create();
 
         // Size changed event for the CustomLayout Root
         internal Size _valueOfLayoutRootLastSizeChanged = new Size(0d, 0d);
-        internal List<SizeChangedEventHandler> _layoutRootSizeChangedEventHandlers;
         internal readonly IResizeObserverAdapter _layoutRootResizeObserver = ResizeObserverFactory.Create();
 
         private void HandleSizeChanged(Size currentSize)
         {
             if (this._sizeChangedEventHandlers != null
-               && this._sizeChangedEventHandlers.Count > 0
                && INTERNAL_VisualTreeManager.IsElementInVisualTree(this)
                && this._isLoaded)
             {
@@ -1341,10 +1338,7 @@ namespace Windows.UI.Xaml
                     SizeChangedEventArgs e = new SizeChangedEventArgs(currentSize);
 
                     // Raise the "SizeChanged" event of all the listeners:
-                    for (int i = 0; i < this._sizeChangedEventHandlers.Count; i++)
-                    {
-                        this._sizeChangedEventHandlers[i](this, e);
-                    }
+                    this._sizeChangedEventHandlers(this, e);
                 }
             }
         }
@@ -1352,7 +1346,6 @@ namespace Windows.UI.Xaml
         internal void LayoutRootHandleSizeChanged(Size currentSize)
         {
             if (this._layoutRootSizeChangedEventHandlers != null
-               && this._layoutRootSizeChangedEventHandlers.Count > 0
                && INTERNAL_VisualTreeManager.IsElementInVisualTree(this)
                && this._isLoaded)
             {
@@ -1368,10 +1361,7 @@ namespace Windows.UI.Xaml
                     SizeChangedEventArgs e = new SizeChangedEventArgs(currentSize);
 
                     // Raise the "LayoutRootSizeChanged" event of all the listeners:
-                    for (int i = 0; i < this._layoutRootSizeChangedEventHandlers.Count; i++)
-                    {
-                        this._layoutRootSizeChangedEventHandlers[i](this, e);
-                    }
+                    this._layoutRootSizeChangedEventHandlers(this, e);
                 }
             }
         }
@@ -1387,7 +1377,6 @@ namespace Windows.UI.Xaml
                     HandleSizeChanged(Size.Empty);
 
                 if (this._sizeChangedEventHandlers != null &&
-                    this._sizeChangedEventHandlers.Count > 0 &&
                     !this._resizeObserver.IsObserved)
                 {
                     if (double.IsNaN(this.Width) || double.IsNaN(this.Height))
@@ -1401,7 +1390,6 @@ namespace Windows.UI.Xaml
             if (this.IsCustomLayoutRoot)
             {
                 if (this._layoutRootSizeChangedEventHandlers != null &&
-                    this._layoutRootSizeChangedEventHandlers.Count > 0 &&
                     !this._layoutRootResizeObserver.IsObserved)
                 {
                     if (double.IsNaN(this.Width) || double.IsNaN(this.Height))
@@ -1424,14 +1412,11 @@ namespace Windows.UI.Xaml
                 _layoutRootResizeObserver.Unobserve(this.INTERNAL_AdditionalOutsideDivForMargins);
         }
 
+        private SizeChangedEventHandler _sizeChangedEventHandlers;
         public event SizeChangedEventHandler SizeChanged
         {
             add
             {
-                if (this._sizeChangedEventHandlers == null)
-                {
-                    this._sizeChangedEventHandlers = new List<SizeChangedEventHandler>();
-                }
                 if (!this._resizeObserver.IsObserved && this.INTERNAL_OuterDomElement != null)
                 {
                     if (this.IsUnderCustomLayout == false)
@@ -1447,33 +1432,23 @@ namespace Windows.UI.Xaml
                         }
                     }
                 }
-                this._sizeChangedEventHandlers.Add(value);
+                this._sizeChangedEventHandlers += value;
             }
             remove
             {
-                if (this._sizeChangedEventHandlers == null)
+                this._sizeChangedEventHandlers -= value;
+                if (this._sizeChangedEventHandlers == null && this._resizeObserver.IsObserved)
                 {
-                    return;
-                }
-
-                if (this._sizeChangedEventHandlers.Remove(value))
-                {
-                    if (this._sizeChangedEventHandlers.Count == 0 && this._resizeObserver.IsObserved)
-                    {
-                        _resizeObserver.Unobserve(this.INTERNAL_OuterDomElement);
-                    }
+                    _resizeObserver.Unobserve(this.INTERNAL_OuterDomElement);
                 }
             }
         }
 
+        private SizeChangedEventHandler _layoutRootSizeChangedEventHandlers;
         internal event SizeChangedEventHandler LayoutRootSizeChanged
         {
             add
             {
-                if (this._layoutRootSizeChangedEventHandlers == null)
-                {
-                    this._layoutRootSizeChangedEventHandlers = new List<SizeChangedEventHandler>();
-                }
                 if (!this._layoutRootResizeObserver.IsObserved && this.INTERNAL_AdditionalOutsideDivForMargins != null)
                 {
                     if (double.IsNaN(this.Width) || double.IsNaN(this.Height))
@@ -1486,21 +1461,15 @@ namespace Windows.UI.Xaml
                         LayoutRootHandleSizeChanged(new Size(this.Width, this.Height));
                     }
                 }
-                this._layoutRootSizeChangedEventHandlers.Add(value);
+                this._layoutRootSizeChangedEventHandlers += value;
             }
             remove
             {
-                if (this._layoutRootSizeChangedEventHandlers == null)
-                {
-                    return;
-                }
+                this._layoutRootSizeChangedEventHandlers -= value;
 
-                if (this._layoutRootSizeChangedEventHandlers.Remove(value))
+                if (this._layoutRootSizeChangedEventHandlers == null && this._layoutRootResizeObserver.IsObserved)
                 {
-                    if (this._layoutRootSizeChangedEventHandlers.Count == 0 && this._layoutRootResizeObserver.IsObserved)
-                    {
-                        _layoutRootResizeObserver.Unobserve(this.INTERNAL_AdditionalOutsideDivForMargins);
-                    }
+                    _layoutRootResizeObserver.Unobserve(this.INTERNAL_AdditionalOutsideDivForMargins);
                 }
             }
         }


### PR DESCRIPTION
1. SizeChanged / LayoutRootSizeChanged - avoid using a list of delegates when we can use a single one
2. remove dependency objects from Brushes's PropertiesWhereUsed