### PR TITLE
Prevent 'create element failed' error

### DIFF
--- a/src/Runtime/Runtime/PublicAPI/CSharpXamlForHtml5_DomManagement.cs
+++ b/src/Runtime/Runtime/PublicAPI/CSharpXamlForHtml5_DomManagement.cs
@@ -71,11 +71,11 @@ public static partial class CSharpXamlForHtml5
         /// Sets the Html representation of the UIElement.
         /// </summary>
         /// <param name="control">The UIElement</param>
-        /// <param name="htmlReprensentation">The string that defines the html representation of the UIElement.</param>
+        /// <param name="htmlRepresentation">The string that defines the html representation of the UIElement.</param>
         [Obsolete(Helper.ObsoleteMemberMessage + " Use HtmlPresenter instead.")]
-        public static void SetHtmlRepresentation(UIElement control, string htmlReprensentation)
+        public static void SetHtmlRepresentation(UIElement control, string htmlRepresentation)
         {
-            control.INTERNAL_HtmlRepresentation = htmlReprensentation;
+            control.INTERNAL_HtmlRepresentation = htmlRepresentation;
         }
 
 #if PUBLIC_API_THAT_REQUIRES_SUPPORT_OF_DYNAMIC

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/PopupRoot.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/PopupRoot.cs
@@ -104,7 +104,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
         {
             PopupRoot popupRoot = (PopupRoot)d;
             popupRoot.TemplateChild = null;
-            if (popupRoot.IsConnectedToLiveTree)
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(popupRoot))
             {
                 popupRoot.InvalidateMeasureInternal();
             }

--- a/src/Runtime/Runtime/System.Windows.Controls/ContentPresenter.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ContentPresenter.cs
@@ -15,7 +15,6 @@ using System;
 using System.Windows.Markup;
 using System.Diagnostics;
 using System.Collections.Generic;
-using System.Linq;
 using CSHTML5.Internal;
 
 #if MIGRATION

--- a/src/Runtime/Runtime/System.Windows.Controls/ContentPresenter.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ContentPresenter.cs
@@ -16,6 +16,7 @@ using System.Windows.Markup;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
+using CSHTML5.Internal;
 
 #if MIGRATION
 using System.Windows.Data;
@@ -127,7 +128,7 @@ namespace Windows.UI.Xaml.Controls
                 ctrl.UpdateDataContext();
             }
 
-            if (ctrl.IsConnectedToLiveTree)
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(ctrl))
             {
                 ctrl.InvalidateMeasureInternal();
             }
@@ -165,7 +166,7 @@ namespace Windows.UI.Xaml.Controls
             // if ContentTemplate is really changing, remove the old template
             ctrl.Template = null;
 
-            if (ctrl.IsConnectedToLiveTree)
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(ctrl))
             {
                 ctrl.InvalidateMeasureInternal();
             }
@@ -196,7 +197,7 @@ namespace Windows.UI.Xaml.Controls
             ContentPresenter cp = (ContentPresenter)d;
             UpdateTemplateCache(cp, (FrameworkTemplate)e.OldValue, (FrameworkTemplate)e.NewValue, TemplateProperty);
 
-            if (cp.IsConnectedToLiveTree)
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(cp))
             {
                 cp.InvalidateMeasureInternal();
             }

--- a/src/Runtime/Runtime/System.Windows.Controls/Control.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Control.cs
@@ -639,7 +639,7 @@ namespace Windows.UI.Xaml.Controls
             Control control = (Control)d;
             FrameworkElement.UpdateTemplateCache(control, (FrameworkTemplate)e.OldValue, (FrameworkTemplate)e.NewValue, TemplateProperty);
 
-            if (control.IsConnectedToLiveTree)
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(control))
             {
                 control.InvalidateMeasureInternal();
             }

--- a/src/Runtime/Runtime/System.Windows.Controls/Grid_CSSVersion.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/Grid_CSSVersion.cs
@@ -201,7 +201,7 @@ namespace Windows.UI.Xaml.Controls
             if (element.IsUnderCustomLayout)
                 return;
             int maxRow = 0;
-            if (element.IsConnectedToLiveTree && element.INTERNAL_VisualParent is Grid) //Note: this also checks if INTERNAL_VisualTreeManager.IsElementInVisualTree(element) is true because there is no point in setting it on Windows and Popups.
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(element) && element.INTERNAL_VisualParent is Grid) //Note: this also checks if INTERNAL_VisualTreeManager.IsElementInVisualTree(element) is true because there is no point in setting it on Windows and Popups.
             {
                 Grid parent = (Grid)element.INTERNAL_VisualParent;
                 if (parent._rowDefinitionsOrNull != null && parent._rowDefinitionsOrNull.Count > 0)
@@ -217,7 +217,7 @@ namespace Windows.UI.Xaml.Controls
                     rowSpan = 1;
 
                 var style = INTERNAL_HtmlDomManager.GetFrameworkElementBoxSizingStyleForModification(element);
-                
+
                 int lastRow = elementRow + rowSpan - 1; //note: there was a -1 here before but it seems to not give he result expected.
                 MakeGridPositionCorrect(ref lastRow, maxRow);
 
@@ -231,7 +231,7 @@ namespace Windows.UI.Xaml.Controls
             if (element.IsUnderCustomLayout)
                 return;
             int maxColumn = 0;
-            if (element.IsConnectedToLiveTree && element.INTERNAL_VisualParent is Grid) //Note: this also checks if INTERNAL_VisualTreeManager.IsElementInVisualTree(element) is true because there is no point in setting it on Windows and Popups.
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(element) && element.INTERNAL_VisualParent is Grid) //Note: this also checks if INTERNAL_VisualTreeManager.IsElementInVisualTree(element) is true because there is no point in setting it on Windows and Popups.
             {
                 Grid parent = (Grid)element.INTERNAL_VisualParent;
                 if (parent._columnDefinitionsOrNull != null && parent._columnDefinitionsOrNull.Count > 0)

--- a/src/Runtime/Runtime/System.Windows.Controls/ItemsPresenter.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ItemsPresenter.cs
@@ -11,8 +11,8 @@
 *  
 \*====================================================================================*/
 
-using CSHTML5.Internal;
 using System;
+using CSHTML5.Internal;
 
 #if MIGRATION
 using System.Windows.Controls.Primitives;

--- a/src/Runtime/Runtime/System.Windows.Controls/ItemsPresenter.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ItemsPresenter.cs
@@ -11,6 +11,7 @@
 *  
 \*====================================================================================*/
 
+using CSHTML5.Internal;
 using System;
 
 #if MIGRATION
@@ -104,7 +105,7 @@ namespace Windows.UI.Xaml.Controls
             ip.ClearPanel();
             FrameworkElement.UpdateTemplateCache(ip, (FrameworkTemplate)e.OldValue, (FrameworkTemplate)e.NewValue, TemplateProperty);
 
-            if (ip.IsConnectedToLiveTree)
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(ip))
             {
                 ip.InvalidateMeasureInternal();
             }

--- a/src/Runtime/Runtime/System.Windows.Controls/UserControl.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/UserControl.cs
@@ -13,10 +13,8 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Windows.Markup;
 using OpenSilver.Internal.Controls;
-using OpenSilver.Internal.Xaml.Context;
 using CSHTML5.Internal;
 
 #if MIGRATION

--- a/src/Runtime/Runtime/System.Windows.Controls/UserControl.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/UserControl.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Windows.Markup;
 using OpenSilver.Internal.Controls;
 using OpenSilver.Internal.Xaml.Context;
+using CSHTML5.Internal;
 
 #if MIGRATION
 using System.Windows.Media;
@@ -91,7 +92,7 @@ namespace Windows.UI.Xaml.Controls
             uc.RemoveLogicalChild(e.OldValue);
             uc.AddLogicalChild(e.NewValue);
 
-            if (uc.IsConnectedToLiveTree)
+            if (INTERNAL_VisualTreeManager.IsElementInVisualTree(uc))
             {
                 uc.InvalidateMeasureInternal();
             }

--- a/src/Runtime/Runtime/System.Windows.Printing/PrintDocument.PrintOperation.cs
+++ b/src/Runtime/Runtime/System.Windows.Printing/PrintDocument.PrintOperation.cs
@@ -170,7 +170,7 @@ namespace Windows.UI.Xaml.Printing
                 var unloadedElements = new List<UIElement>();
                 foreach (UIElement e in _elements)
                 {
-                    if (!e.IsConnectedToLiveTree)
+                    if (!INTERNAL_VisualTreeManager.IsElementInVisualTree(e))
                     {
                         unloadedElements.Add(e);
                     }

--- a/src/Runtime/Runtime/System.Windows.Shapes/Ellipse.cs
+++ b/src/Runtime/Runtime/System.Windows.Shapes/Ellipse.cs
@@ -60,7 +60,7 @@ namespace Windows.UI.Xaml.Shapes
         //    ScheduleRedraw();
         //}
 
-        override internal protected void Redraw()
+        protected internal override void Redraw()
         {
             if (INTERNAL_VisualTreeManager.IsElementInVisualTree(this))
             {

--- a/src/Runtime/Runtime/System.Windows.Shapes/Line.cs
+++ b/src/Runtime/Runtime/System.Windows.Shapes/Line.cs
@@ -178,7 +178,7 @@ namespace Windows.UI.Xaml.Shapes
             }
         }
 
-        override internal protected void Redraw()
+        protected internal override void Redraw()
         {
             if (INTERNAL_VisualTreeManager.IsElementInVisualTree(this))
             {

--- a/src/Runtime/Runtime/System.Windows.Shapes/Rectangle.cs
+++ b/src/Runtime/Runtime/System.Windows.Shapes/Rectangle.cs
@@ -148,7 +148,7 @@ namespace Windows.UI.Xaml.Shapes
         //    ScheduleRedraw();
         //}
 
-        override internal protected void Redraw()
+        protected internal override void Redraw()
         {
             if (INTERNAL_VisualTreeManager.IsElementInVisualTree(this))
             {

--- a/src/Runtime/Runtime/System.Windows.Shapes/Shape.cs
+++ b/src/Runtime/Runtime/System.Windows.Shapes/Shape.cs
@@ -128,7 +128,7 @@ namespace Windows.UI.Xaml.Shapes
                 typeof(Shape),
                 new FrameworkPropertyMetadata(Stretch.None, FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender, Stretch_Changed));
 
-        internal protected static void Stretch_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        protected internal static void Stretch_Changed(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             //note: Stretch is actually more implemented in the Redraw method of the classes that inherit from shape (Line, Ellipse, Path, Rectangle)
 
@@ -401,17 +401,17 @@ namespace Windows.UI.Xaml.Shapes
 
         #region Protected Methods
 
-        internal protected virtual void Redraw()
+        protected internal virtual void Redraw()
         {
             _redrawWhenBecomeVisible = false;
         }
 
-        internal protected virtual void ManageStrokeChanged()
+        protected internal virtual void ManageStrokeChanged()
         {
             ScheduleRedraw();
         }
 
-        internal protected virtual void ManageStrokeThicknessChanged()
+        protected internal virtual void ManageStrokeThicknessChanged()
         {
             if (INTERNAL_VisualTreeManager.IsElementInVisualTree(this))
             {

--- a/src/Runtime/Runtime/System.Windows.input/KeyboardNavigation.cs
+++ b/src/Runtime/Runtime/System.Windows.input/KeyboardNavigation.cs
@@ -11,9 +11,9 @@
 *  
 \*====================================================================================*/
 
-using CSHTML5.Internal;
 using System;
 using System.Diagnostics;
+using CSHTML5.Internal;
 
 #if MIGRATION
 using System.Windows.Controls;

--- a/src/Runtime/Runtime/System.Windows.input/KeyboardNavigation.cs
+++ b/src/Runtime/Runtime/System.Windows.input/KeyboardNavigation.cs
@@ -11,6 +11,7 @@
 *  
 \*====================================================================================*/
 
+using CSHTML5.Internal;
 using System;
 using System.Diagnostics;
 
@@ -524,7 +525,7 @@ internal sealed class KeyboardNavigation
         return control.IsTabStop
             && control.IsEnabled
             && control.IsVisible
-            && control.IsConnectedToLiveTree;
+            && INTERNAL_VisualTreeManager.IsElementInVisualTree(control);
     }
 
     private bool IsGroup(DependencyObject e)

--- a/src/Runtime/Runtime/System.Windows.input/PointerRoutedEventArgs.cs
+++ b/src/Runtime/Runtime/System.Windows.input/PointerRoutedEventArgs.cs
@@ -14,6 +14,7 @@
 using System;
 using System.Globalization;
 using CSHTML5;
+using CSHTML5.Internal;
 
 #if MIGRATION
 using System.Windows.Controls.Primitives;
@@ -194,7 +195,7 @@ namespace Windows.UI.Xaml.Input
                 //-----------------------------------
                 return origin;
             }
-            else if (relativeTo.IsConnectedToLiveTree)
+            else if (INTERNAL_VisualTreeManager.IsElementInVisualTree(relativeTo))
             {
                 //-----------------------------------
                 // Returns the pointer coordinates relative to the "relativeTo" element:

--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
@@ -798,7 +798,7 @@ namespace Windows.UI.Xaml
             element.ManageIsEnabled((bool)newValue);
         }
 
-        internal protected virtual void ManageIsEnabled(bool isEnabled)
+        protected internal virtual void ManageIsEnabled(bool isEnabled)
         {
             if (INTERNAL_VisualTreeManager.IsElementInVisualTree(this))
             {

--- a/src/Runtime/Runtime/System.Windows/FrameworkElement_HandlingSizeAndAlignment.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement_HandlingSizeAndAlignment.cs
@@ -947,7 +947,7 @@ namespace Windows.UI.Xaml
 
         internal static void Margin_MethodToUpdateDom(DependencyObject d, object newValue)
         {
-            var fe = (FrameworkElement)d;            
+            var fe = (FrameworkElement)d;
             if (INTERNAL_VisualTreeManager.IsElementInVisualTree(fe) && !fe.IsUnderCustomLayout)
             {
                 var margin = (Thickness)newValue;
@@ -1193,7 +1193,7 @@ namespace Windows.UI.Xaml
                         return 0d;
                     }
                 }
-                
+
                 return 0d;
             }
         }
@@ -1222,7 +1222,7 @@ namespace Windows.UI.Xaml
                         return 0d;
                     }
                 }
-                
+
                 return 0d;
             }
         }

--- a/src/Runtime/Runtime/System.Windows/UIElement.cs
+++ b/src/Runtime/Runtime/System.Windows/UIElement.cs
@@ -82,6 +82,8 @@ namespace Windows.UI.Xaml
 
         internal bool IsConnectedToLiveTree { get; set; }
 
+        internal bool IsUnloading { get; set; }
+
         internal bool LoadingIsPending { get; set; }
 
 #region Visual Parent
@@ -770,7 +772,7 @@ namespace Windows.UI.Xaml
                 }
                 else
                 {
-                    constraintAllowsVisible = uie.IsConnectedToLiveTree;
+                    constraintAllowsVisible = INTERNAL_VisualTreeManager.IsElementInVisualTree(uie);
                 }
 
                 if (!constraintAllowsVisible)
@@ -1125,7 +1127,7 @@ namespace Windows.UI.Xaml
         /// </returns>
         public GeneralTransform TransformToVisual(UIElement visual)
         {
-            if (!IsConnectedToLiveTree)
+            if (!INTERNAL_VisualTreeManager.IsElementInVisualTree(this))
             {
                 throw new ArgumentException();
             }
@@ -1138,7 +1140,7 @@ namespace Windows.UI.Xaml
             object outerDivOfReferenceVisual;
             if (visual != null)
             {
-                if (!visual.IsConnectedToLiveTree)
+                if (!INTERNAL_VisualTreeManager.IsElementInVisualTree(visual))
                 {
                     throw new ArgumentException(nameof(visual));
                 }


### PR DESCRIPTION
This PR fixes 'create element failed' in the browser's console, also it fixes a memory leak related to attaching element back.

I have updated this example: https://github.com/jacob-l/OpenSilverAttachDetach