### PR TITLE
Fix checking subclass in compiler

### DIFF
--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/TypeDefinitionExtensions.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/TypeDefinitionExtensions.cs
@@ -107,10 +107,25 @@ namespace OpenSilver.Compiler.OtherHelpersAndHandlers.MonoCecilAssembliesInspect
         /// <returns></returns>
         public static IEnumerable<TypeDefinition> EnumerateBaseClasses(this TypeDefinition classType, bool skipSelf = false)
         {
-            for (var typeDefinition = skipSelf ? classType?.BaseType?.ResolveOrThrow() : classType; 
-                typeDefinition != null; typeDefinition = typeDefinition.BaseType?.ResolveOrThrow())
+            if (classType == null)
             {
-                yield return typeDefinition;
+                yield break;
+            }
+
+            TypeDefinition td = classType;
+            if (skipSelf)
+            {
+                if (classType.BaseType == null)
+                {
+                    yield break;
+                }
+
+                td = classType.BaseType.ResolveOrThrow();
+            }
+
+            for (; td != null; td = td.BaseType?.ResolveOrThrow())
+            {
+                yield return td;
             }
         }
 

--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/TypeDefinitionExtensions.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/TypeDefinitionExtensions.cs
@@ -28,8 +28,7 @@ namespace OpenSilver.Compiler.OtherHelpersAndHandlers.MonoCecilAssembliesInspect
         /// <param name="parentType"></param>
         /// <returns></returns>
         public static bool IsSubclassOf(this TypeDefinition childType, TypeDefinition parentType) =>
-           !Equals(childType, parentType)
-           && childType.EnumerateBaseClasses(skipSelf: true).Any(b => Equals(b, parentType));
+           childType.EnumerateBaseClasses(skipSelf: true).Any(b => Equals(b, parentType));
 
         /// <summary>
         /// Returns true if childType directly or indirectly implements parentInterface.
@@ -108,7 +107,7 @@ namespace OpenSilver.Compiler.OtherHelpersAndHandlers.MonoCecilAssembliesInspect
         /// <returns></returns>
         public static IEnumerable<TypeDefinition> EnumerateBaseClasses(this TypeDefinition classType, bool skipSelf = false)
         {
-            for (var typeDefinition = skipSelf ? classType.BaseType?.ResolveOrThrow() : classType; 
+            for (var typeDefinition = skipSelf ? classType?.BaseType?.ResolveOrThrow() : classType; 
                 typeDefinition != null; typeDefinition = typeDefinition.BaseType?.ResolveOrThrow())
             {
                 yield return typeDefinition;

--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/TypeDefinitionExtensions.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/TypeDefinitionExtensions.cs
@@ -28,7 +28,7 @@ namespace OpenSilver.Compiler.OtherHelpersAndHandlers.MonoCecilAssembliesInspect
         /// <param name="parentType"></param>
         /// <returns></returns>
         public static bool IsSubclassOf(this TypeDefinition childType, TypeDefinition parentType) =>
-           childType.MetadataToken != parentType.MetadataToken
+           !Equals(childType, parentType)
            && childType.EnumerateBaseClasses().Any(b => Equals(b, parentType));
 
         /// <summary>

--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/TypeDefinitionExtensions.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/MonoCecilAssembliesInspector/TypeDefinitionExtensions.cs
@@ -29,7 +29,7 @@ namespace OpenSilver.Compiler.OtherHelpersAndHandlers.MonoCecilAssembliesInspect
         /// <returns></returns>
         public static bool IsSubclassOf(this TypeDefinition childType, TypeDefinition parentType) =>
            !Equals(childType, parentType)
-           && childType.EnumerateBaseClasses().Any(b => Equals(b, parentType));
+           && childType.EnumerateBaseClasses(skipSelf: true).Any(b => Equals(b, parentType));
 
         /// <summary>
         /// Returns true if childType directly or indirectly implements parentInterface.
@@ -106,9 +106,10 @@ namespace OpenSilver.Compiler.OtherHelpersAndHandlers.MonoCecilAssembliesInspect
         /// </summary>
         /// <param name="classType"></param>
         /// <returns></returns>
-        public static IEnumerable<TypeDefinition> EnumerateBaseClasses(this TypeDefinition classType)
+        public static IEnumerable<TypeDefinition> EnumerateBaseClasses(this TypeDefinition classType, bool skipSelf = false)
         {
-            for (var typeDefinition = classType; typeDefinition != null; typeDefinition = typeDefinition.BaseType?.ResolveOrThrow())
+            for (var typeDefinition = skipSelf ? classType.BaseType?.ResolveOrThrow() : classType; 
+                typeDefinition != null; typeDefinition = typeDefinition.BaseType?.ResolveOrThrow())
             {
                 yield return typeDefinition;
             }


### PR DESCRIPTION
Use Equals method, because in some cases MetadataToken can be the same for different types.

One case is RadBusyIndicator and FrameworkElement have the same MetadataToken when CallerArgumentExpressionAttribute is present. As a result this breaks changing VisualStates for controls inside RadBusyIndicator 