### PR TITLE
Getting csharp properties from browser inspector

### DIFF
--- a/src/Runtime/Runtime/OpenSilver/DumpHelper.cs
+++ b/src/Runtime/Runtime/OpenSilver/DumpHelper.cs
@@ -1,4 +1,5 @@
-﻿/*===================================================================================
+﻿
+/*===================================================================================
 * 
 *   Copyright (c) Userware/OpenSilver.net
 *      
@@ -10,12 +11,12 @@
 *  
 \*====================================================================================*/
 
-using CSHTML5.Internal;
-using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using CSHTML5.Internal;
+using Microsoft.JSInterop;
 
 namespace OpenSilver;
 
@@ -35,6 +36,8 @@ public static class DumpHelper
     /// <exception cref="ArgumentNullException">Provided object is null</exception>
     public static IDictionary<string, object> GetPropertiesAndValues(object obj, params string[] names)
     {
+        AssertDEBUG();
+
         if (obj is null)
         {
             throw new ArgumentNullException(nameof(obj));
@@ -86,13 +89,17 @@ public static class DumpHelper
     /// Null or empty value means all public properties are return.
     /// </param>
     [JSInvokable]
-    public static Dictionary<string, string> DumpProperties(string elementId, params string[] names)
+    public static IDictionary<string, string> DumpProperties(string elementId, params string[] names)
     {
-        var element = INTERNAL_HtmlDomManager.GetElementById(elementId);
-        if (element == null) return null;
-        var dictionary = GetPropertiesAndValues(element, names);
+        AssertDEBUG();
 
-        return dictionary.ToDictionary(x => x.Key, x => x.Value?.ToString());
+        if (INTERNAL_HtmlDomManager.GetElementById(elementId) is { } element)
+        {
+            return GetPropertiesAndValues(element, names)
+                .ToDictionary(x => x.Key, x => x.Value?.ToString());
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -105,12 +112,20 @@ public static class DumpHelper
     /// </param>
     public static void PrintProperties(object element, params string[] names)
     {
-        var dictionary = GetPropertiesAndValues(element, names);
+        AssertDEBUG();
 
         Console.WriteLine($"=== {element} Properties ===");
-        foreach (var item in dictionary)
+
+        foreach (var item in GetPropertiesAndValues(element, names))
         {
             Console.WriteLine($"{item.Key}: {item.Value}");
         }
+    }
+
+    private static void AssertDEBUG()
+    {
+#if !DEBUG
+        throw new InvalidOperationException();
+#endif
     }
 }

--- a/src/Runtime/Runtime/OpenSilver/DumpHelper.cs
+++ b/src/Runtime/Runtime/OpenSilver/DumpHelper.cs
@@ -1,0 +1,99 @@
+﻿/*===================================================================================
+* 
+*   Copyright (c) Userware/OpenSilver.net
+*      
+*   This file is part of the OpenSilver Runtime (https://opensilver.net), which is
+*   licensed under the MIT license: https://opensource.org/licenses/MIT
+*   
+*   As stated in the MIT license, "the above copyright notice and this permission
+*   notice shall be included in all copies or substantial portions of the Software."
+*  
+\*====================================================================================*/
+
+using CSHTML5.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace OpenSilver;
+
+/// <summary>
+/// Helps to get the current state (values of properties) of the provided object.
+/// </summary>
+public static class DumpHelper
+{
+    /// <summary>
+    /// Retrieves a dictionary of properties and corresponding values of the provided object.
+    /// </summary>
+    /// <param name="obj">Object to get properties.</param>
+    /// <param name="names">
+    /// Names of properties, provided as string of names separated by comma (,).
+    /// Null or empty value means all public properties are return.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Provided object is null</exception>
+    public static Dictionary<string, object> GetPropertiesAndValues(object obj, string names = null)
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        Type type = obj.GetType();
+        var properties = new List<PropertyInfo>();
+
+        if (string.IsNullOrEmpty(names))
+        {
+            properties.AddRange(type.GetProperties());
+        }
+        else
+        {
+            var propertyNames = names.Split(',');
+            foreach (var name in propertyNames)
+            {
+                var property = type.GetProperty(name);
+                if (property != null)
+                {
+                    properties.Add(property);
+                }
+            }
+        }
+
+        return properties.OrderBy(x => x.Name).ToDictionary(x => x.Name, x => x.GetValue(obj));
+    }
+
+    /// <summary>
+    /// Retrieves a dictionary of properties and corresponding values of the provided element by it's id.
+    /// </summary>
+    /// <param name="elementId">Html id of an element.</param>
+    /// <param name="names">
+    /// Names of properties, provided as string of names separated by comma (,).
+    /// Null or empty value means all public properties are return.
+    /// </param>
+    public static Dictionary<string, string> DumpProperties(string elementId, string names = null)
+    {
+        var element = INTERNAL_HtmlDomManager.GetElementById(elementId);
+        var dictionary = GetPropertiesAndValues(element, names);
+
+        return dictionary.ToDictionary(x => x.Key, x => x.Value?.ToString());
+    }
+
+    /// <summary>
+    /// Prints properties and corresponding values to console.
+    /// </summary>
+    /// <param name="element"></param>
+    /// <param name="names">
+    /// Names of properties, provided as string of names separated by comma (,).
+    /// Null or empty value means all public properties are return.
+    /// </param>
+    public static void PrintProperties(object element, string names = null)
+    {
+        var dictionary = GetPropertiesAndValues(element, names);
+
+        Console.WriteLine($"=== {element} Properties ===");
+        foreach (var item in dictionary)
+        {
+            Console.WriteLine($"{item.Key}: {item.Value}");
+        }
+    }
+}

--- a/src/Runtime/Runtime/OpenSilver/DumpHelper.cs
+++ b/src/Runtime/Runtime/OpenSilver/DumpHelper.cs
@@ -11,6 +11,7 @@
 \*====================================================================================*/
 
 using CSHTML5.Internal;
+using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -69,10 +70,10 @@ public static class DumpHelper
             {
                 continue;
             }
-            
+
             d[prop.Name] = prop.GetValue(obj);
         }
-        
+
         return d;
     }
 

--- a/src/Runtime/Runtime/Runtime.OpenSilver.csproj
+++ b/src/Runtime/Runtime/Runtime.OpenSilver.csproj
@@ -57,6 +57,7 @@
 		<Compile Include="Core\Main\WeakReferenceListEnumerator.cs" />
 		<Compile Include="Diagnostics\DebugInfo.cs" />
 		<Compile Include="OpenSilver\Controls\OpenFileDialog.cs" />
+		<Compile Include="OpenSilver\DumpHelper.cs" />
 		<Compile Include="OpenSilver\Internal\Clipboard.cs" />
 		<Compile Include="OpenSilver\Internal\CriticalExceptions.cs" />
 		<Compile Include="OpenSilver\Internal\DebounceDispatcher.cs" />

--- a/src/Runtime/Runtime/System.Windows/Application.cs
+++ b/src/Runtime/Runtime/System.Windows/Application.cs
@@ -150,8 +150,6 @@ namespace Windows.UI.Xaml
                 this.OnLaunched(new LaunchActivatedEventArgs());
             });
 
-            OpenSilver.Interop.ExecuteJavaScriptVoidAsync(
-                "document.dumpProperties = function(id, names) { return $0(id, names); }", (Func<string, string, object>)OpenSilver.DumpHelper.DumpProperties);
         }
 
         public IList ApplicationLifetimeObjects

--- a/src/Runtime/Runtime/System.Windows/Application.cs
+++ b/src/Runtime/Runtime/System.Windows/Application.cs
@@ -150,6 +150,8 @@ namespace Windows.UI.Xaml
                 this.OnLaunched(new LaunchActivatedEventArgs());
             });
 
+            OpenSilver.Interop.ExecuteJavaScriptVoidAsync(
+                "document.dumpProperties = function(id, names) { return $0(id, names); }", (Func<string, string, object>)OpenSilver.DumpHelper.DumpProperties);
         }
 
         public IList ApplicationLifetimeObjects

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -195,6 +195,7 @@ document.dumpProperties = function (id, ...names) {
     }
     return null;
 };
+
 document.createTextBlockElement = function (id, parentElement, wrap) {
     const newElement = document.createElementSafe('div', id, parentElement, -1);
 

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -181,6 +181,11 @@ document.createElementSafe = function (tagName, id, parentElement, index) {
         var nextSibling = parentElement.children[index];
         parentElement.insertBefore(newElement, nextSibling);
     }
+
+    Object.defineProperty(newElement, 'dump', {
+        get() { return document.dumpProperties(id, ''); }
+    });
+
     return newElement;
 }
 

--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -183,12 +183,18 @@ document.createElementSafe = function (tagName, id, parentElement, index) {
     }
 
     Object.defineProperty(newElement, 'dump', {
-        get() { return document.dumpProperties(id, ''); }
+        get() { return document.dumpProperties(id); }
     });
 
     return newElement;
 }
 
+document.dumpProperties = function (id, ...names) {
+    if (DotNet && DotNet.invokeMethod) {
+        return DotNet.invokeMethod('OpenSilver', 'DumpProperties', id, names);
+    }
+    return null;
+};
 document.createTextBlockElement = function (id, parentElement, wrap) {
     const newElement = document.createElementSafe('div', id, parentElement, -1);
 


### PR DESCRIPTION
This feature lets quickly debug C# properties right in browser inspector.

To see it in action:
1. Open Elements tab of developers tools (F12)
2. Select an element
3. Open Properties tab
4. Click `dump` property to retrieve all the values

![image](https://github.com/OpenSilver/OpenSilver/assets/7633528/16417d2b-2fbe-498f-9778-8d4a4a44fe0a)

Benefits:

- no need to set breakpoint to see actual value of a property, for example DataContext
- ability to see properties in deployed app
- ability to retrieve specific properties, just call in browser console `document.dumpProperties('id6', 'ActualWidth,ActualHeight')`