### PR TITLE
fix for #758 - allow legacy UnmarshalledJavaScriptExecutionHandler im…

### DIFF
--- a/src/Runtime/Runtime/Core/Main/INTERNAL_Simulator.cs
+++ b/src/Runtime/Runtime/Core/Main/INTERNAL_Simulator.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using OpenSilver;
 
 namespace DotNetForHtml5.Core
 {
@@ -96,9 +95,6 @@ namespace DotNetForHtml5.Core
                     }
                     else
                     {
-                        if (!Interop.IsRunningInTheSimulator)
-                            Console.WriteLine("WARNING: Please derive UnmarshalledJavaScriptExecutionHandler from IWebAssemblyExecutionHandler");
-
                         jsRuntime = new JSRuntimeWrapper(value);
                         INTERNAL_ExecuteJavaScript.JavaScriptRuntime = new PendingJavascriptSimulator(value);
                     }

--- a/src/Runtime/Runtime/Core/Main/INTERNAL_Simulator.cs
+++ b/src/Runtime/Runtime/Core/Main/INTERNAL_Simulator.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using OpenSilver;
 
 namespace DotNetForHtml5.Core
 {
@@ -95,6 +96,9 @@ namespace DotNetForHtml5.Core
                     }
                     else
                     {
+                        if (!Interop.IsRunningInTheSimulator)
+                            Console.WriteLine("WARNING: Please derive UnmarshalledJavaScriptExecutionHandler from IWebAssemblyExecutionHandler");
+
                         jsRuntime = new JSRuntimeWrapper(value);
                         INTERNAL_ExecuteJavaScript.JavaScriptRuntime = new PendingJavascriptSimulator(value);
                     }

--- a/src/Runtime/Scripts/OpenSilver.js
+++ b/src/Runtime/Scripts/OpenSilver.js
@@ -130,7 +130,24 @@ window.callJS = function (javaScriptToExecute) {
     }
 };
 
-window.callJSUnmarshalled = function (javaScriptToExecute, referenceId, wantsResult) {
+window.callJSUnmarshalled = function (javaScriptToExecute) {
+    javaScriptToExecute = BINDING.conv_string(javaScriptToExecute);
+    var result = eval(javaScriptToExecute);
+    var resultType = typeof result;
+    if (resultType == 'string' || resultType == 'number' || resultType == 'boolean') {
+        return BINDING.js_to_mono_obj(result);
+    }
+    else if (result == null) {
+        return null;
+    } else {
+        return BINDING.js_to_mono_obj(result + " [NOT USABLE DIRECTLY IN C#] (" + resultType + ")");
+    }
+};
+
+
+
+window.callJSUnmarshalled_v2 = function (javaScriptToExecute, referenceId, wantsResult) {
+
     javaScriptToExecute = BINDING.conv_string(javaScriptToExecute);
     var result = eval(javaScriptToExecute);
 
@@ -161,3 +178,6 @@ window.callJSUnmarshalledHeap = (function () {
         eval(javaScriptToExecute);
     };
 })();
+
+
+

--- a/src/Runtime/Scripts/OpenSilver.js
+++ b/src/Runtime/Scripts/OpenSilver.js
@@ -122,11 +122,10 @@ window.callJS = function (javaScriptToExecute) {
     var resultType = typeof result;
     if (resultType == 'string' || resultType == 'number' || resultType == 'boolean') {
        return result;
-    }
-    else if (result == null) {
+    } else if (result == null) {
         return null;
     } else {     
-            return result + " [NOT USABLE DIRECTLY IN C#] (" + resultType + ")";
+        return result + " [NOT USABLE DIRECTLY IN C#] (" + resultType + ")";
     }
 };
 
@@ -144,10 +143,7 @@ window.callJSUnmarshalled = function (javaScriptToExecute) {
     }
 };
 
-
-
 window.callJSUnmarshalled_v2 = function (javaScriptToExecute, referenceId, wantsResult) {
-
     javaScriptToExecute = BINDING.conv_string(javaScriptToExecute);
     var result = eval(javaScriptToExecute);
 
@@ -160,14 +156,12 @@ window.callJSUnmarshalled_v2 = function (javaScriptToExecute, referenceId, wants
     var resultType = typeof result;
     if (resultType == 'string' || resultType == 'number' || resultType == 'boolean') {
         return BINDING.js_to_mono_obj(result);
-    }
-    else if (result == null) {
+    } else if (result == null) {
         return null;
     } else {
         return BINDING.js_to_mono_obj(result + " [NOT USABLE DIRECTLY IN C#] (" + resultType + ")");
     }
 };
-
 
 // IMPORTANT: this doesn't return anything (this just executes the pending async JS)
 window.callJSUnmarshalledHeap = (function () {
@@ -178,6 +172,3 @@ window.callJSUnmarshalledHeap = (function () {
         eval(javaScriptToExecute);
     };
 })();
-
-
-

--- a/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/Interop/UnmarshalledJavaScriptExecutionHandler.cs
+++ b/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/Interop/UnmarshalledJavaScriptExecutionHandler.cs
@@ -6,7 +6,7 @@ namespace TestApplication.OpenSilver.Browser.Interop
 {
     public class UnmarshalledJavaScriptExecutionHandler : IWebAssemblyExecutionHandler
     {
-        private const string MethodName = "callJSUnmarshalled";
+        private const string MethodName = "callJSUnmarshalled_v2";
         private readonly WebAssemblyJSRuntime _runtime;
 
         public UnmarshalledJavaScriptExecutionHandler(IJSRuntime runtime)


### PR DESCRIPTION
…plementation

Note:
because I need to allow legacy UnmarshalledJavaScriptExecutionHandler implementation as is, I had to create a new JS method (callJSUnmarshalled_v2)

So, in your code, if you derive UnmarshalledJavaScriptExecutionHandler from IWebAssemblyExecutionHandler, you need to update the method name:
        private const string MethodName = "callJSUnmarshalled_v2";