### PR TITLE
Replace Soap Response parsing logic to support xml 1.0 character sets.

### DIFF
--- a/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
+++ b/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
@@ -42,6 +42,7 @@ using static System.ServiceModel.INTERNAL_WebMethodsCaller;
 
 #if MIGRATION
 using System.Windows;
+using System.Data;
 #else
 using Windows.UI.Xaml;
 #endif
@@ -289,7 +290,8 @@ namespace System.ServiceModel
             // Attempt to read the WCF endpoint address by first looking into the 
             // "ServiceReferences.ClientConfig" file, and then the "App.Config" file
             string endpointAddress;
-            using (var serviceReferencesClientConfig = OpenSilver.Interop.ExecuteJavaScript("window.ServiceReferencesClientConfig")) {
+            using (var serviceReferencesClientConfig = OpenSilver.Interop.ExecuteJavaScript("window.ServiceReferencesClientConfig"))
+            {
                 if (TryReadEndpoint(serviceReferencesClientConfig,
                         "ServiceReferences.ClientConfig",
                         contractConfigurationName,
@@ -300,7 +302,8 @@ namespace System.ServiceModel
                 }
                 else
                 {
-                    using (var appConfig = OpenSilver.Interop.ExecuteJavaScript("window.AppConfig")) {
+                    using (var appConfig = OpenSilver.Interop.ExecuteJavaScript("window.AppConfig"))
+                    {
                         if (TryReadEndpoint(appConfig,
                                 "App.Config",
                                 contractConfigurationName,
@@ -327,8 +330,7 @@ namespace System.ServiceModel
             bool throwIfFileNotFound,
             out string endpointAddress)
         {
-            bool isNullOrUndefined = OpenSilver.Interop.ExecuteJavaScriptBoolean(
-                $"!{CSHTML5.INTERNAL_InteropImplementation.GetVariableStringForJS(configFileContent)}");
+            bool isNullOrUndefined = OpenSilver.Interop.IsNull(configFileContent);
             if (!isNullOrUndefined)
             {
                 string fileContentAsString = Convert.ToString(configFileContent);
@@ -1120,10 +1122,10 @@ namespace System.ServiceModel
             }
 #endif
 
-            private void ProcessNode(XElement node, Action<XElement> action)
+            private void ProcessNode(XmlElement node, Action<XmlElement> action)
             {
                 action(node);
-                foreach (XElement child in node.Elements())
+                foreach (XmlElement child in node.ChildNodes)
                 {
                     ProcessNode(child, action);
                 }
@@ -1245,7 +1247,7 @@ namespace System.ServiceModel
                                     types,
                                     isXmlSerializer);
 
-                            XDocument xdoc = dataContractSerializer.SerializeToXDocument(requestBody);
+                            XmlDocument xdoc = dataContractSerializer.SerializeToXmlDocument(requestBody);
 
                             XElement paramNameElement =
                                 new XElement(XNamespace.Get(interfaceTypeNamespace)
@@ -1256,15 +1258,23 @@ namespace System.ServiceModel
                                 // because it would be <request> which is not what we want. 
                                 // The correct parameter name is alread in the Request body.
                                 methodNameElement.Add(paramNameElement);
-                                foreach (XNode currentNode in xdoc.Root.Nodes())
+                                foreach (XmlNode currentNode in xdoc.DocumentElement.ChildNodes)
                                 {
-                                    paramNameElement.Add(currentNode);
+                                    switch (currentNode.NodeType)
+                                    {
+                                        case XmlNodeType.Element:
+                                            paramNameElement.Add(XElement.Parse(currentNode.OuterXml));
+                                            break;
+                                        default:
+                                            paramNameElement.Add(new XText(currentNode.OuterXml));
+                                            break;
+                                    }
                                 }
-                                foreach (XAttribute currentAttribute in xdoc.Root.Attributes())
+                                foreach (XmlAttribute currentAttribute in xdoc.DocumentElement.Attributes)
                                 {
                                     // we don't want to keep the "xmlns="http://schemas.microsoft.com/2003/10/Serialization/" 
                                     // because it breaks the request.
-                                    if (currentAttribute.Name.LocalName != "xmlns")
+                                    if (currentAttribute.LocalName != "xmlns")
                                     {
                                         paramNameElement.Add(currentAttribute);
                                     }
@@ -1278,18 +1288,17 @@ namespace System.ServiceModel
                                 //      <Body>
                                 //         <toDoItem
                                 // so we want to go to xdoc.Root.Nodes()[0].Nodes()
-                                foreach (XNode currentNode in xdoc.Root.Nodes())
+                                foreach (XmlNode currentNode in xdoc.DocumentElement.ChildNodes)
                                 {
-                                    XElement xElement = currentNode as XElement;
+                                    XmlElement xElement = currentNode as XmlElement;
                                     if (xElement != null)
                                     {
-                                        foreach (XElement node in xElement.Elements())
+                                        foreach (XmlElement node in xElement.ChildNodes)
                                         {
-                                            ProcessNode(node, x => x.Name = XNamespace.Get(string.IsNullOrEmpty(x.Name.NamespaceName) ?
+                                            ProcessNode(node, x => x.Prefix = string.IsNullOrEmpty(x.Prefix) ?
                                                                                            interfaceTypeNamespace :
-                                                                                           x.Name.NamespaceName)
-                                                                                      .GetName(x.Name.LocalName));
-                                            methodNameElement.Add(node);
+                                                                                           x.Prefix);
+                                            methodNameElement.Add(XElement.Parse(node.OuterXml));
                                         }
                                     }
                                 }
@@ -1399,38 +1408,46 @@ namespace System.ServiceModel
                 const string ns = "http://schemas.xmlsoap.org/soap/envelope/";
 
                 VerifyThatResponseIsNotNullOrEmpty(response);
-                var faultElement = XDocument.Parse(response).Root
-                                                 .Element(XName.Get("Body", ns))
-                                                 .Element(XName.Get("Fault", ns));
+                XmlDocument document = new XmlDocument();
+                document.LoadXml(response);
+
+                XmlNamespaceManager nsmgr = new XmlNamespaceManager(document.NameTable);
+                nsmgr.AddNamespace("ns", ns);
+
+                //XElement envelopeElement = XDocument.Parse(responseAsString).Root;
+                XmlNode headerElement = document.DocumentElement.SelectSingleNode("ns:Header", nsmgr);
+                XmlNode bodyElement = document.DocumentElement.SelectSingleNode("ns:Body", nsmgr);
+
+                XmlNode faultElement = bodyElement.SelectSingleNode("ns:Fault", nsmgr);
 
                 if (faultElement == null)
                 {
                     return new FaultException();
                 }
 
-                var faultStringElement = faultElement.Element(XName.Get("faultstring"));
-                var faultReasonValue = faultStringElement?.Value;
-                var lang = faultStringElement?.Attribute(XName.Get("lang", XNamespace.Xml.NamespaceName))?.Value;
+                var faultStringElement = faultElement.SelectSingleNode("faultstring");
+                var faultReasonValue = faultStringElement?.InnerText;
+                var lang = faultStringElement?.Attributes.GetNamedItem("lang", XNamespace.Xml.NamespaceName)?.Value;
                 var faultReasonText = string.IsNullOrEmpty(lang)
                     ? new FaultReasonText(faultReasonValue)
                     : new FaultReasonText(faultReasonValue, lang);
                 var reason = new FaultReason(faultReasonText);
 
-                var faultCodeElement = faultElement.Element(XName.Get("faultcode"));
-                var code = new FaultCode(faultCodeElement?.Value);
+                var faultCodeElement = faultElement.SelectSingleNode("faultcode");
+                var code = new FaultCode(faultCodeElement?.InnerText);
 
-                var detailElement = faultElement.Element(XName.Get("detail"));
+                var detailElement = faultElement.SelectSingleNode("detail");
                 if (detailElement == null)
                 {
                     return new FaultException(reason, code, null);
                 }
 
-                detailElement = detailElement.Elements().First();
+                detailElement = detailElement.FirstChild;
                 var detailType = ResolveType(detailElement.Name, useXmlSerializerFormat);
 
                 var serializer = new DataContractSerializerCustom(detailType);
 
-                var detail = serializer.DeserializeFromXElement(detailElement);
+                var detail = serializer.DeserializeFromXmlNode(detailElement);
 
                 var type = typeof(FaultException<>).MakeGenericType(detailType);
 
@@ -1457,7 +1474,7 @@ namespace System.ServiceModel
                                          attr.Name == name.LocalName :
                                          type.Name == name.LocalName;
 
-                            if(nameMatch)
+                            if (nameMatch)
                             {
                                 bool namespaceMatch = attr.IsNamespaceSetExplicitly ?
                                     attr.Namespace == name.NamespaceName :
@@ -1521,46 +1538,53 @@ namespace System.ServiceModel
                 // be able to support their custom ones).
 
                 VerifyThatResponseIsNotNullOrEmpty(responseAsString);
-                string NS;
+                string _namespace;
                 if (soapVersion == "1.1")
                 {
-                    NS = "http://schemas.xmlsoap.org/soap/envelope/";
+                    _namespace = "http://schemas.xmlsoap.org/soap/envelope/";
                 }
                 else
                 {
                     Debug.Assert(soapVersion == "1.2",
                                     string.Format("Unexpected soap version ({0}) !", soapVersion));
-                    NS = "http://www.w3.org/2003/05/soap-envelope";
+                    _namespace = "http://www.w3.org/2003/05/soap-envelope";
                 }
 
-                XElement envelopeElement = XDocument.Parse(responseAsString).Root;
-                XElement headerElement = envelopeElement.Element(XName.Get("Header", NS));
-                XElement bodyElement = envelopeElement.Element(XName.Get("Body", NS));
+
+                XmlDocument document = new XmlDocument();
+                document.LoadXml(responseAsString);
+
+                XmlNamespaceManager NS = new XmlNamespaceManager(document.NameTable);
+                NS.AddNamespace("ns", _namespace);
+
+                XmlNode envelopeElement = document.DocumentElement;
+                XmlNode headerElement = envelopeElement.SelectSingleNode("ns:Header", NS);
+                XmlNode bodyElement = envelopeElement.SelectSingleNode("ns:Body", NS);
 
 
 #if OPENSILVER
                 // Error parsing, if applicable
                 if (soapVersion == "1.2")
                 {
-                    XElement faultElement = bodyElement.Element(XName.Get("Fault", NS));
+                    XmlNode faultElement = bodyElement.SelectSingleNode("ns:Fault", NS);
 
                     if (faultElement != null)
                     {
-                        XElement codeElement = faultElement.Element(XName.Get("Code", NS));
-                        XElement reasonElement = faultElement.Element(XName.Get("Reason", NS));
-                        XElement detailElement = faultElement.Element(XName.Get("Detail", NS));
+                        XmlNode codeElement = faultElement.SelectSingleNode("ns:Code", NS);
+                        XmlNode reasonElement = faultElement.SelectSingleNode("ns:Reason", NS);
+                        XmlNode detailElement = faultElement.SelectSingleNode("ns:Detail", NS);
 
-                        FaultCode faultCode = new FaultCode(codeElement.Elements().First().Value);
-                        FaultReason faultReason = new FaultReason(reasonElement.Elements().First().Value);
-                        string action = headerElement.Element(XName.Get("Action", "http://www.w3.org/2005/08/addressing")).Value;
+                        FaultCode faultCode = new FaultCode(codeElement.FirstChild.InnerText);
+                        FaultReason faultReason = new FaultReason(reasonElement.FirstChild.InnerText);
+                        string action = headerElement.SelectSingleNode(headerElement.GetPrefixOfNamespace("http://www.w3.org/2005/08/addressing") + ":Action").Value;
 
                         FaultException faultException;
 
                         if (detailElement != null)
                         {
-                            XElement innerExceptionElement = detailElement.Elements().First();
+                            XmlNode innerExceptionElement = detailElement.FirstChild;
 
-                            object innerException = ParseException(innerExceptionElement, innerExceptionElement.Name.LocalName);
+                            object innerException = ParseException(innerExceptionElement, innerExceptionElement.LocalName);
 
                             Type faultExceptionType = typeof(FaultException<>).MakeGenericType(innerException.GetType());
 
@@ -1575,17 +1599,17 @@ namespace System.ServiceModel
                         return null;
                     }
 
-                    object ParseException(XElement exceptionElement, string exceptionTypeName)
+                    object ParseException(XmlNode exceptionElement, string exceptionTypeName)
                     {
                         Type exceptionType = ResolveType(exceptionTypeName);
 
                         object exception = Activator.CreateInstance(exceptionType);
 
-                        foreach (XElement element in exceptionElement.Elements())
+                        foreach (XmlNode element in exceptionElement.ChildNodes)
                         {
-                            PropertyInfo property = exceptionType.GetProperty(element.Name.LocalName);
+                            PropertyInfo property = exceptionType.GetProperty(element.LocalName);
 
-                            XAttribute isNullAttribute = element.Attributes().FirstOrDefault(a => a.Name.LocalName == "nil");
+                            XmlAttribute isNullAttribute = element.Attributes["nil"];
                             if (isNullAttribute != null && isNullAttribute.Value == "true")
                             {
                                 property.SetValue(exception, null);
@@ -1672,7 +1696,7 @@ namespace System.ServiceModel
                     // to allow passing it as Generic type argument when calling CallWebMethod.
                     if (requestResponseType == typeof(object))
                     {
-                        if (bodyElement != null && bodyElement.Nodes().Count() == 0)
+                        if (bodyElement != null && bodyElement.ChildNodes.Count == 0)
                         {
                             // Note: there might be a more efficient way of checking if the method has a return 
                             // type (possibly through a smart use of responseAsString.IndexOf but it seems 
@@ -1702,7 +1726,7 @@ namespace System.ServiceModel
                     }
 
                     DataContractSerializerCustom deSerializer = new DataContractSerializerCustom(typeToDeserialize, types);
-                    XElement xElement = envelopeElement;
+                    XmlNode xElement = envelopeElement;
 
                     //exclude the parts that are <Enveloppe><Body>... since they are useless 
                     // and would keep the deserialization from working properly
@@ -1721,14 +1745,12 @@ namespace System.ServiceModel
                     // The reason is that the response uses one less XElement in the 
                     // case where we use XmlSerializer and the method has the return 
                     // Type object.
-                    bool isTypeSpecified =
-                        xElement.Attributes(XNamespace.Get("http://www.w3.org/2001/XMLSchema-instance").GetName("type"))
-                                .Any();
+                    bool isTypeSpecified = xElement.Attributes.GetNamedItem("type", "http://www.w3.org/2001/XMLSchema-instance") != null;
                     if (!isXmlSerializer || !isTypeSpecified)
                     {
                         // we are either not in the XmlSerializer version or we have 
                         // the "extra" XElement so we move in once.
-                        xElement = xElement.Elements().FirstOrDefault() ?? xElement; //move inside of the <Body> tag
+                        xElement = xElement.FirstChild ?? xElement; //move inside of the <Body> tag
                     }
 
                     if (!isXmlSerializer)
@@ -1736,24 +1758,24 @@ namespace System.ServiceModel
                         if (typeToDeserialize.GetCustomAttribute<MessageContractAttribute>() != null)
                         {
                             // DataContractSerializer needs correct namespace instead of http://tempuri.org/
-                            XNamespace ns = DataContractSerializer_Helpers.GetDefaultNamespace(typeToDeserialize.Namespace, false);
-                            xElement.Name = ns + xElement.Name.LocalName;
-                            xElement.Attributes("xmlns").Remove();
-                            foreach (var childElement in xElement.Elements())
+                            string ns = DataContractSerializer_Helpers.GetDefaultNamespace(typeToDeserialize.Namespace, false);
+                            xElement.Prefix = ns;
+                            xElement.Attributes.RemoveNamedItem("xmlns");
+                            foreach (XmlNode childElement in xElement.ChildNodes)
                             {
-                                childElement.Name = ns + childElement.Name.LocalName;
+                                childElement.Prefix = ns;
                             }
                         }
                         else
                         {
-                            xElement = xElement.Elements().FirstOrDefault() ?? xElement;
+                            xElement = xElement.FirstChild ?? xElement;
                         }
-                        requestResponse = deSerializer.DeserializeFromXElement(xElement);
+                        requestResponse = deSerializer.DeserializeFromXmlNode(xElement);
                     }
                     else
                     {
                         requestResponse = Activator.CreateInstance(requestResponseType);
-                        object requestResponseBody = deSerializer.DeserializeFromXElement(xElement);
+                        object requestResponseBody = deSerializer.DeserializeFromXmlNode(xElement);
                         bodyFieldInfo.SetValue(requestResponse, requestResponseBody);
                     }
                 }
@@ -1866,7 +1888,7 @@ namespace System.ServiceModel
         /// <summary>
         /// Gets the underlying System.ServiceModel.IClientChannel implementation.
         /// </summary>
-		[OpenSilver.NotImplemented]
+        [OpenSilver.NotImplemented]
         public IClientChannel InnerChannel
         {
             get { return null; }
@@ -1919,7 +1941,7 @@ namespace System.ServiceModel
             /// class from an existing instance of the class.
             /// </summary>
             /// <param name="client">The object used to initialize the new instance of the class.</param>
-		    [OpenSilver.NotImplemented]
+            [OpenSilver.NotImplemented]
             protected ChannelBase(CSHTML5_ClientBase<T> client)
             {
 

--- a/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
+++ b/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
@@ -42,7 +42,6 @@ using static System.ServiceModel.INTERNAL_WebMethodsCaller;
 
 #if MIGRATION
 using System.Windows;
-using System.Data;
 #else
 using Windows.UI.Xaml;
 #endif
@@ -1411,14 +1410,11 @@ namespace System.ServiceModel
                 XmlDocument document = new XmlDocument();
                 document.LoadXml(response);
 
-                XmlNamespaceManager nsmgr = new XmlNamespaceManager(document.NameTable);
-                nsmgr.AddNamespace("ns", ns);
+                XmlNamespaceManager xmlnsManager = new XmlNamespaceManager(document.NameTable);
+                xmlnsManager.AddNamespace("ns", ns);
 
-                //XElement envelopeElement = XDocument.Parse(responseAsString).Root;
-                XmlNode headerElement = document.DocumentElement.SelectSingleNode("ns:Header", nsmgr);
-                XmlNode bodyElement = document.DocumentElement.SelectSingleNode("ns:Body", nsmgr);
-
-                XmlNode faultElement = bodyElement.SelectSingleNode("ns:Fault", nsmgr);
+                XmlNode bodyElement = document.DocumentElement.SelectSingleNode("ns:Body", xmlnsManager);
+                XmlNode faultElement = bodyElement.SelectSingleNode("ns:Fault", xmlnsManager);
 
                 if (faultElement == null)
                 {
@@ -1538,41 +1534,41 @@ namespace System.ServiceModel
                 // be able to support their custom ones).
 
                 VerifyThatResponseIsNotNullOrEmpty(responseAsString);
-                string _namespace;
+                string NS;
                 if (soapVersion == "1.1")
                 {
-                    _namespace = "http://schemas.xmlsoap.org/soap/envelope/";
+                    NS = "http://schemas.xmlsoap.org/soap/envelope/";
                 }
                 else
                 {
                     Debug.Assert(soapVersion == "1.2",
                                     string.Format("Unexpected soap version ({0}) !", soapVersion));
-                    _namespace = "http://www.w3.org/2003/05/soap-envelope";
+                    NS = "http://www.w3.org/2003/05/soap-envelope";
                 }
 
 
                 XmlDocument document = new XmlDocument();
                 document.LoadXml(responseAsString);
 
-                XmlNamespaceManager NS = new XmlNamespaceManager(document.NameTable);
-                NS.AddNamespace("ns", _namespace);
+                XmlNamespaceManager xmlnsManager = new XmlNamespaceManager(document.NameTable);
+                xmlnsManager.AddNamespace("ns", NS);
 
                 XmlNode envelopeElement = document.DocumentElement;
-                XmlNode headerElement = envelopeElement.SelectSingleNode("ns:Header", NS);
-                XmlNode bodyElement = envelopeElement.SelectSingleNode("ns:Body", NS);
+                XmlNode headerElement = envelopeElement.SelectSingleNode("ns:Header", xmlnsManager);
+                XmlNode bodyElement = envelopeElement.SelectSingleNode("ns:Body", xmlnsManager);
 
 
 #if OPENSILVER
                 // Error parsing, if applicable
                 if (soapVersion == "1.2")
                 {
-                    XmlNode faultElement = bodyElement.SelectSingleNode("ns:Fault", NS);
+                    XmlNode faultElement = bodyElement.SelectSingleNode("ns:Fault", xmlnsManager);
 
                     if (faultElement != null)
                     {
-                        XmlNode codeElement = faultElement.SelectSingleNode("ns:Code", NS);
-                        XmlNode reasonElement = faultElement.SelectSingleNode("ns:Reason", NS);
-                        XmlNode detailElement = faultElement.SelectSingleNode("ns:Detail", NS);
+                        XmlNode codeElement = faultElement.SelectSingleNode("ns:Code", xmlnsManager);
+                        XmlNode reasonElement = faultElement.SelectSingleNode("ns:Reason", xmlnsManager);
+                        XmlNode detailElement = faultElement.SelectSingleNode("ns:Detail", xmlnsManager);
 
                         FaultCode faultCode = new FaultCode(codeElement.FirstChild.InnerText);
                         FaultReason faultReason = new FaultReason(reasonElement.FirstChild.InnerText);


### PR DESCRIPTION
Issue:
================
1. Soap 1.1 supports XML 1.0 Standard. but in current implementation some characters are restricted.

Solution:
================
Replaced XDocument with XmlDocument to parse soap response. 