### PR TITLE
(feat/full-customlayout) fix: fix GetLayoutUpdatedHandler throwing when EventHandler not in di…

### DIFF
--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.Layout.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.Layout.cs
@@ -547,8 +547,11 @@ namespace Windows.UI.Xaml
                 else //already have a list
                 {
                     var list = (Dictionary<EventHandler, object>)cachedLayoutUpdatedItems;
-                    LayoutEventList.ListItem item = (LayoutEventList.ListItem)list[d];
-                    return item;
+                    if (list.ContainsKey(d))
+                    {
+                        LayoutEventList.ListItem item = (LayoutEventList.ListItem)list[d];
+                        return item;
+                    }
                 }
                 return null;
             }


### PR DESCRIPTION
…ctionary

When registering to the LayoutUpdated event, GetLayoutUpdatedHandler is called to check if the EventHandler is already in. In the case that it looks on LayoutUpdatedListItemsField as a Dictionary, if the EventHandler is not a key in it, an exception is thrown.

```
Dispatcher: Method excution failed: System.Collections.Generic.KeyNotFoundException: The given key 'System.EventHandler' was not present in the dictionary.
blazor.webassembly.js:1    at System.Collections.Generic.Dictionary`2[[System.EventHandler, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object, System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].get_Item(EventHandler key)
blazor.webassembly.js:1    at System.Windows.FrameworkElement.GetLayoutUpdatedHandler(EventHandler d)
blazor.webassembly.js:1    at System.Windows.FrameworkElement.add_LayoutUpdated(EventHandler value)
```