### PR TITLE
fix: capture mouse in TextBoxView to not trigger other events while s…

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBoxView.cs
@@ -24,6 +24,7 @@ using System.Windows.Input;
 using Windows.Foundation;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Input;
+using MouseButtonEventArgs = Windows.UI.Xaml.Input.PointerRoutedEventArgs;
 #endif
 
 #if MIGRATION
@@ -514,6 +515,57 @@ element_OutsideEventHandler.addEventListener('paste', function(e) {{
                 availableSize.Width,
                 "M");
             return TextSize;
+        }
+
+#if MIGRATION
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+#else
+        protected override void OnPointerPressed(MouseButtonEventArgs e)
+#endif
+        {
+#if MIGRATION
+            base.OnMouseLeftButtonDown(e);
+#else
+            base.OnPointerPressed(e);
+#endif
+
+            if (e.Handled)
+            {
+                return;
+            }
+            e.Handled = true;
+
+#if MIGRATION
+            // This is to not trigger other events like Telerik DragDrop when selecting text
+            CaptureMouse();
+#else
+            CapturePointer(e.Pointer);
+#endif
+        }
+
+#if MIGRATION
+        protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
+#else
+        protected override void OnPointerReleased(MouseButtonEventArgs e)
+#endif
+        {
+#if MIGRATION
+            base.OnMouseLeftButtonUp(e);
+#else
+            base.OnPointerReleased(e);
+#endif
+
+            if (e.Handled)
+            {
+                return;
+            }
+            e.Handled = true;
+
+#if MIGRATION
+            ReleaseMouseCapture();
+#else
+            ReleasePointerCapture(e.Pointer);
+#endif
         }
     }
 }


### PR DESCRIPTION
…electing text

Like e.g. Telerik DragDrop.

Selecting text on a TextBox is currently triggering events like DragDrop from Telerik DragDropManager if DragDropManager.AllowDrag is enabled on an ancestor element in the tree. This changes captures the mouse and releases on MouseLeftUp so that DragDrop cannot capture it.