### PR TITLE
fix: revert capture mouse in TextBox when left button is pressed

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBox.cs
@@ -648,12 +648,17 @@ namespace Windows.UI.Xaml.Controls
 
             e.Handled = true;
             Focus();
-#if MIGRATION
-            _textViewHost?.View.CaptureMouse();
-#else
-            _textViewHost?.View.CapturePointer(e.Pointer);
-#endif
         }
+
+        /// <summary>
+        /// Returns a <see cref="TextBoxAutomationPeer"/> for use by the Silverlight automation 
+        /// infrastructure.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="TextBoxAutomationPeer"/> for the <see cref="TextBox"/> object.
+        /// </returns>
+        protected override AutomationPeer OnCreateAutomationPeer()
+            => new TextBoxAutomationPeer(this);
 
 #if MIGRATION
         protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)
@@ -667,28 +672,8 @@ namespace Windows.UI.Xaml.Controls
             base.OnPointerReleased(e);
 #endif
 
-            if (e.Handled)
-            {
-                return;
-            }
-
             e.Handled = true;
-#if MIGRATION
-            _textViewHost?.View.ReleaseMouseCapture();
-#else
-            _textViewHost?.View.ReleasePointerCapture(e.Pointer);
-#endif
         }
-
-        /// <summary>
-        /// Returns a <see cref="TextBoxAutomationPeer"/> for use by the Silverlight automation 
-        /// infrastructure.
-        /// </summary>
-        /// <returns>
-        /// A <see cref="TextBoxAutomationPeer"/> for the <see cref="TextBox"/> object.
-        /// </returns>
-        protected override AutomationPeer OnCreateAutomationPeer()
-            => new TextBoxAutomationPeer(this);
 
 #if MIGRATION
         protected override void OnMouseEnter(MouseEventArgs e)


### PR DESCRIPTION
Rolling back my change to TextBox because this broke focusing on it.

This can be tested on TestApplication -> TextBox Properties or TextBox Template.