### PR TITLE
fix: loadingIndicatorWrapper memory leak

### DIFF
--- a/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/wwwroot/loading-indicator.js
+++ b/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/wwwroot/loading-indicator.js
@@ -5,34 +5,26 @@
     }
 }
 
-let loadingIndicatorWrapper = document.createElement("div");
-loadingIndicatorWrapper.classList.add("loading-indicator-wrapper");
-document.getElementById("app").appendChild(loadingIndicatorWrapper);
+(function () {
+    let loadingIndicatorWrapper = document.createElement("div");
+    loadingIndicatorWrapper.classList.add("loading-indicator-wrapper");
+    document.getElementById("app").appendChild(loadingIndicatorWrapper);
 
-let loadingIndicator = document.createElement("div");
-loadingIndicator.classList.add("loading-indicator");
-loadingIndicatorWrapper.appendChild(loadingIndicator);
+    let loadingIndicator = document.createElement("div");
+    loadingIndicator.classList.add("loading-indicator");
+    loadingIndicatorWrapper.appendChild(loadingIndicator);
 
-for (let i = 0; i < 16; i++) {
-    let loadingIndicatorBall = document.createElement("div");
-    loadingIndicatorBall.classList.add("loading-indicator-ball");
-    loadingIndicator.appendChild(loadingIndicatorBall);
-}
-
-let loadingIndicatorPercentageContainer = document.createElement("div");
-loadingIndicatorPercentageContainer.classList.add("loading-indicator-percentage-container");
-loadingIndicator.appendChild(loadingIndicatorPercentageContainer);
-
-let loadingIndicatorPercentage = document.createElement("div");
-loadingIndicatorPercentage.id = "loading-indicator-percentage";
-loadingIndicatorPercentageContainer.appendChild(loadingIndicatorPercentage);
-
-let cleanUpTimer = setInterval(function () {
-    if (!loadingIndicatorWrapper.isConnected) {
-        clearInterval(cleanUpTimer);
-        loadingIndicatorPercentage = null;
-        loadingIndicatorPercentageContainer = null;
-        loadingIndicator = null;
-        loadingIndicatorWrapper = null;
+    for (let i = 0; i < 16; i++) {
+        let loadingIndicatorBall = document.createElement("div");
+        loadingIndicatorBall.classList.add("loading-indicator-ball");
+        loadingIndicator.appendChild(loadingIndicatorBall);
     }
-}, 1000);
+
+    let loadingIndicatorPercentageContainer = document.createElement("div");
+    loadingIndicatorPercentageContainer.classList.add("loading-indicator-percentage-container");
+    loadingIndicator.appendChild(loadingIndicatorPercentageContainer);
+
+    let loadingIndicatorPercentage = document.createElement("div");
+    loadingIndicatorPercentage.id = "loading-indicator-percentage";
+    loadingIndicatorPercentageContainer.appendChild(loadingIndicatorPercentage);
+})();

--- a/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/wwwroot/loading-indicator.js
+++ b/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/wwwroot/loading-indicator.js
@@ -26,3 +26,13 @@ loadingIndicator.appendChild(loadingIndicatorPercentageContainer);
 let loadingIndicatorPercentage = document.createElement("div");
 loadingIndicatorPercentage.id = "loading-indicator-percentage";
 loadingIndicatorPercentageContainer.appendChild(loadingIndicatorPercentage);
+
+let cleanUpTimer = setInterval(function () {
+    if (!loadingIndicatorWrapper.isConnected) {
+        clearInterval(cleanUpTimer);
+        loadingIndicatorPercentage = null;
+        loadingIndicatorPercentageContainer = null;
+        loadingIndicator = null;
+        loadingIndicatorWrapper = null;
+    }
+}, 1000);

--- a/src/VSExtension/OpenSilverApplicationTemplate/OpenSilverApplication.Browser/wwwroot/loading-indicator.js
+++ b/src/VSExtension/OpenSilverApplicationTemplate/OpenSilverApplication.Browser/wwwroot/loading-indicator.js
@@ -5,34 +5,26 @@
     }
 }
 
-let loadingIndicatorWrapper = document.createElement("div");
-loadingIndicatorWrapper.classList.add("loading-indicator-wrapper");
-document.getElementById("app").appendChild(loadingIndicatorWrapper);
+(function () {
+    let loadingIndicatorWrapper = document.createElement("div");
+    loadingIndicatorWrapper.classList.add("loading-indicator-wrapper");
+    document.getElementById("app").appendChild(loadingIndicatorWrapper);
 
-let loadingIndicator = document.createElement("div");
-loadingIndicator.classList.add("loading-indicator");
-loadingIndicatorWrapper.appendChild(loadingIndicator);
+    let loadingIndicator = document.createElement("div");
+    loadingIndicator.classList.add("loading-indicator");
+    loadingIndicatorWrapper.appendChild(loadingIndicator);
 
-for (let i = 0; i < 16; i++) {
-    let loadingIndicatorBall = document.createElement("div");
-    loadingIndicatorBall.classList.add("loading-indicator-ball");
-    loadingIndicator.appendChild(loadingIndicatorBall);
-}
-
-let loadingIndicatorPercentageContainer = document.createElement("div");
-loadingIndicatorPercentageContainer.classList.add("loading-indicator-percentage-container");
-loadingIndicator.appendChild(loadingIndicatorPercentageContainer);
-
-let loadingIndicatorPercentage = document.createElement("div");
-loadingIndicatorPercentage.id = "loading-indicator-percentage";
-loadingIndicatorPercentageContainer.appendChild(loadingIndicatorPercentage);
-
-let cleanUpTimer = setInterval(function () {
-    if (!loadingIndicatorWrapper.isConnected) {
-        clearInterval(cleanUpTimer);
-        loadingIndicatorPercentage = null;
-        loadingIndicatorPercentageContainer = null;
-        loadingIndicator = null;
-        loadingIndicatorWrapper = null;
+    for (let i = 0; i < 16; i++) {
+        let loadingIndicatorBall = document.createElement("div");
+        loadingIndicatorBall.classList.add("loading-indicator-ball");
+        loadingIndicator.appendChild(loadingIndicatorBall);
     }
-}, 1000);
+
+    let loadingIndicatorPercentageContainer = document.createElement("div");
+    loadingIndicatorPercentageContainer.classList.add("loading-indicator-percentage-container");
+    loadingIndicator.appendChild(loadingIndicatorPercentageContainer);
+
+    let loadingIndicatorPercentage = document.createElement("div");
+    loadingIndicatorPercentage.id = "loading-indicator-percentage";
+    loadingIndicatorPercentageContainer.appendChild(loadingIndicatorPercentage);
+})();

--- a/src/VSExtension/OpenSilverApplicationTemplate/OpenSilverApplication.Browser/wwwroot/loading-indicator.js
+++ b/src/VSExtension/OpenSilverApplicationTemplate/OpenSilverApplication.Browser/wwwroot/loading-indicator.js
@@ -26,3 +26,13 @@ loadingIndicator.appendChild(loadingIndicatorPercentageContainer);
 let loadingIndicatorPercentage = document.createElement("div");
 loadingIndicatorPercentage.id = "loading-indicator-percentage";
 loadingIndicatorPercentageContainer.appendChild(loadingIndicatorPercentage);
+
+let cleanUpTimer = setInterval(function () {
+    if (!loadingIndicatorWrapper.isConnected) {
+        clearInterval(cleanUpTimer);
+        loadingIndicatorPercentage = null;
+        loadingIndicatorPercentageContainer = null;
+        loadingIndicator = null;
+        loadingIndicatorWrapper = null;
+    }
+}, 1000);

--- a/src/VSExtension/OpenSilverUwpApplicationTemplate/OpenSilverUwpApplication.Browser/wwwroot/loading-indicator.js
+++ b/src/VSExtension/OpenSilverUwpApplicationTemplate/OpenSilverUwpApplication.Browser/wwwroot/loading-indicator.js
@@ -5,34 +5,26 @@
     }
 }
 
-let loadingIndicatorWrapper = document.createElement("div");
-loadingIndicatorWrapper.classList.add("loading-indicator-wrapper");
-document.getElementById("app").appendChild(loadingIndicatorWrapper);
+(function () {
+    let loadingIndicatorWrapper = document.createElement("div");
+    loadingIndicatorWrapper.classList.add("loading-indicator-wrapper");
+    document.getElementById("app").appendChild(loadingIndicatorWrapper);
 
-let loadingIndicator = document.createElement("div");
-loadingIndicator.classList.add("loading-indicator");
-loadingIndicatorWrapper.appendChild(loadingIndicator);
+    let loadingIndicator = document.createElement("div");
+    loadingIndicator.classList.add("loading-indicator");
+    loadingIndicatorWrapper.appendChild(loadingIndicator);
 
-for (let i = 0; i < 16; i++) {
-    let loadingIndicatorBall = document.createElement("div");
-    loadingIndicatorBall.classList.add("loading-indicator-ball");
-    loadingIndicator.appendChild(loadingIndicatorBall);
-}
-
-let loadingIndicatorPercentageContainer = document.createElement("div");
-loadingIndicatorPercentageContainer.classList.add("loading-indicator-percentage-container");
-loadingIndicator.appendChild(loadingIndicatorPercentageContainer);
-
-let loadingIndicatorPercentage = document.createElement("div");
-loadingIndicatorPercentage.id = "loading-indicator-percentage";
-loadingIndicatorPercentageContainer.appendChild(loadingIndicatorPercentage);
-
-let cleanUpTimer = setInterval(function () {
-    if (!loadingIndicatorWrapper.isConnected) {
-        clearInterval(cleanUpTimer);
-        loadingIndicatorPercentage = null;
-        loadingIndicatorPercentageContainer = null;
-        loadingIndicator = null;
-        loadingIndicatorWrapper = null;
+    for (let i = 0; i < 16; i++) {
+        let loadingIndicatorBall = document.createElement("div");
+        loadingIndicatorBall.classList.add("loading-indicator-ball");
+        loadingIndicator.appendChild(loadingIndicatorBall);
     }
-}, 1000);
+
+    let loadingIndicatorPercentageContainer = document.createElement("div");
+    loadingIndicatorPercentageContainer.classList.add("loading-indicator-percentage-container");
+    loadingIndicator.appendChild(loadingIndicatorPercentageContainer);
+
+    let loadingIndicatorPercentage = document.createElement("div");
+    loadingIndicatorPercentage.id = "loading-indicator-percentage";
+    loadingIndicatorPercentageContainer.appendChild(loadingIndicatorPercentage);
+})();

--- a/src/VSExtension/OpenSilverUwpApplicationTemplate/OpenSilverUwpApplication.Browser/wwwroot/loading-indicator.js
+++ b/src/VSExtension/OpenSilverUwpApplicationTemplate/OpenSilverUwpApplication.Browser/wwwroot/loading-indicator.js
@@ -26,3 +26,13 @@ loadingIndicator.appendChild(loadingIndicatorPercentageContainer);
 let loadingIndicatorPercentage = document.createElement("div");
 loadingIndicatorPercentage.id = "loading-indicator-percentage";
 loadingIndicatorPercentageContainer.appendChild(loadingIndicatorPercentage);
+
+let cleanUpTimer = setInterval(function () {
+    if (!loadingIndicatorWrapper.isConnected) {
+        clearInterval(cleanUpTimer);
+        loadingIndicatorPercentage = null;
+        loadingIndicatorPercentageContainer = null;
+        loadingIndicator = null;
+        loadingIndicatorWrapper = null;
+    }
+}, 1000);


### PR DESCRIPTION
`loadingIndicatorWrapper` is being detached from DOM and it cannot be garbage collected. I think this happens because of the way Blazor replace the contents of the main "App" tag. This PR will check when the reference is not being used anymore, and then it is nullified so this memory can be reclaimed.


![memory leak](https://github.com/OpenSilver/OpenSilver/assets/122040884/d06d4976-5482-4f79-b8dc-4883a025403c)
