### PR TITLE
Generate separate constructor for App class for Xaml Designer usage

### DIFF
--- a/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.Pass1.cs
+++ b/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.Pass1.cs
@@ -101,7 +101,8 @@ namespace OpenSilver.Compiler
                         new List<string>());
 
                     // Wrap everything into a partial class:
-                    string partialClass = GeneratePartialClass(initializeComponentMethod,
+                    string partialClass = GeneratePartialClass("",
+                                                               initializeComponentMethod,
                                                                new ComponentConnectorBuilder().ToString(),
                                                                resultingFieldsForNamedElements,
                                                                className,

--- a/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.Pass2.cs
+++ b/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.Pass2.cs
@@ -263,8 +263,12 @@ namespace OpenSilver.Compiler
                         _fileNameWithPathRelativeToProjectRoot,
                         parameters.ResultingFindNameCalls);
 
+                    var additionalConstructors = IsClassTheApplicationClass(baseType) ?
+                        "private App(global::OpenSilver.XamlDesignerConstructorStub stub) { InitializeComponent(); }" : "";
+
                     // Wrap everything into a partial class:
-                    string partialClass = GeneratePartialClass(initializeComponentMethod,
+                    string partialClass = GeneratePartialClass(additionalConstructors,
+                                                               initializeComponentMethod,
                                                                connectMethod,
                                                                parameters.ResultingFieldsForNamedElements,
                                                                className,

--- a/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.Pass2.cs
+++ b/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.Pass2.cs
@@ -263,8 +263,9 @@ namespace OpenSilver.Compiler
                         _fileNameWithPathRelativeToProjectRoot,
                         parameters.ResultingFindNameCalls);
 
-                    var additionalConstructors = IsClassTheApplicationClass(baseType) ?
-                        "private App(global::OpenSilver.XamlDesignerConstructorStub stub) { InitializeComponent(); }" : "";
+                    string additionalConstructors = IsClassTheApplicationClass(baseType)
+                        ? $"private {className}(global::OpenSilver.XamlDesignerConstructorStub stub) {{ InitializeComponent(); }}"
+                        : string.Empty;
 
                     // Wrap everything into a partial class:
                     string partialClass = GeneratePartialClass(additionalConstructors,

--- a/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.cs
+++ b/src/Compiler/Compiler/2_ConvertingXamlToCSharp/GeneratingCSharpCode.cs
@@ -200,6 +200,7 @@ namespace OpenSilver.Compiler
         }
 
         private static string GeneratePartialClass(
+            string additionalConstructors,
             string initializeComponentMethod,
             string connectMethod,
             List<string> fieldsForNamedElements,
@@ -227,6 +228,8 @@ public partial class {className} : {baseType}, {IComponentConnectorClass}
 #pragma warning disable 169, 649, 0628 // Prevents warning CS0169 ('field ... is never used'), CS0649 ('field ... is never assigned to, and will always have its default value null'), and CS0628 ('member : new protected member declared in sealed class')
 {fieldsForNamedElementsMergedCode}
 #pragma warning restore 169, 649, 0628
+
+{additionalConstructors}
 
 {initializeComponentMethod}
 

--- a/src/Compiler/Compiler/OtherHelpersAndHandlers/Version.cs
+++ b/src/Compiler/Compiler/OtherHelpersAndHandlers/Version.cs
@@ -16,6 +16,6 @@ namespace OpenSilver.Compiler
 {
     internal static class Version
     {
-        public const int CompilerBuildNumber = 14;
+        public const int CompilerBuildNumber = 15;
     }
 }

--- a/src/Runtime/Runtime/OpenSilver/XamlDesignerConstructorStub.cs
+++ b/src/Runtime/Runtime/OpenSilver/XamlDesignerConstructorStub.cs
@@ -1,0 +1,32 @@
+﻿/*===================================================================================
+*
+*   Copyright (c) Userware/OpenSilver.net
+*
+*   This file is part of the OpenSilver Runtime (https://opensilver.net), which is
+*   licensed under the MIT license: https://opensource.org/licenses/MIT
+*
+*   As stated in the MIT license, "the above copyright notice and this permission
+*   notice shall be included in all copies or substantial portions of the Software."
+*
+\*====================================================================================*/
+
+
+using System.ComponentModel;
+
+namespace OpenSilver
+{
+    /// <summary>
+    /// Represents a stub class for XAML designer.
+    /// </summary>
+    /// <remarks>
+    /// This class serves as a utility to ensure no conflicts with other possible constructors.
+    /// It is not intended to have any functionality or to be instantiated directly.
+    /// Instead, its presence is a signal for XAML Designer to recognize a specialized constructor.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class XamlDesignerConstructorStub
+    {
+        // Currently, the class is empty. However, future enhancements or modifications
+        // can be added if necessary.
+    }
+}

--- a/src/Runtime/Runtime/Runtime.OpenSilver.csproj
+++ b/src/Runtime/Runtime/Runtime.OpenSilver.csproj
@@ -110,6 +110,7 @@
 		<Compile Include="OpenSilver\Runtime\CompilerServices\OpenSilverAssemblyAttribute.cs" />
 		<Compile Include="OpenSilver\Runtime\CompilerServices\OpenSilverResourceExposureAttribute.cs" />
 		<Compile Include="OpenSilver\Utility\FrugalMap.cs" />
+		<Compile Include="OpenSilver\XamlDesignerConstructorStub.cs" />
 		<Compile Include="PagedCollectionView\CollectionViewGroupInternal.cs" />
 		<Compile Include="PagedCollectionView\CollectionViewGroupRoot.cs" />
 		<Compile Include="PagedCollectionView\IPagedCollectionView.cs" />

--- a/src/Targets/OpenSilver.Common.targets
+++ b/src/Targets/OpenSilver.Common.targets
@@ -96,7 +96,7 @@
   Set the default values for some properties (for example, if the output paths have not been specified, we set the default ones):
   ============================================================-->
   <PropertyGroup Condition="'$(CompilerBuildNumber)'==''">
-    <CompilerBuildNumber>14</CompilerBuildNumber>
+    <CompilerBuildNumber>15</CompilerBuildNumber>
   </PropertyGroup>
   <PropertyGroup Condition="'$(IsSecondPass)'==''">
     <IsSecondPass>False</IsSecondPass>


### PR DESCRIPTION
The idea: for the Xaml Preview feature, we would like to instantiate the App instance, but without creating a Main Window. This allows us to easily reuse global styles.

This PR helps to generate an additional constructor, which will be called by reflection in the Xaml Designer.