### PR TITLE
fix: handled the byref type of parameter in prepare request

### DIFF
--- a/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
+++ b/src/Runtime/Runtime/System.ServiceModel/CSHTML5_ClientBase_1.cs
@@ -1241,7 +1241,7 @@ namespace System.ServiceModel
 
                             DataContractSerializerCustom dataContractSerializer =
                                 new DataContractSerializerCustom(
-                                    parameterInfos[i].ParameterType,
+                                    parameterInfos[i].ParameterType.IsByRef ? parameterInfos[i].ParameterType.GetElementType(): parameterInfos[i].ParameterType,
                                     types,
                                     isXmlSerializer);
 


### PR DESCRIPTION
Issue:
=================
- Method with ref type of parameter cause issue in prepare request.

Resolution:
=================
- The boolean type of variable will be Boolean& so if the variable is the type of ref then use GetElementType() to get the proper type.