### PR TITLE
fix: openfiledialog issue for mozilla firefox.

### DIFF
--- a/src/Runtime/Runtime/OpenSilver/Controls/OpenFileDialog.cs
+++ b/src/Runtime/Runtime/OpenSilver/Controls/OpenFileDialog.cs
@@ -280,9 +280,10 @@ namespace OpenSilver.Controls
             _windowFocusCallback = Interop.ExecuteJavaScript(@"
                 (function() {
                     var isChrome = !!window.chrome;
-                    var isMozilla = navigator.userAgent.toLowerCase().includes('firefox');
+                    var isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+
                     var windowFocusCallbackForFileDialogCancel = function(e) {
-                        if (isChrome || isMozilla) {
+                        if (isChrome || isFirefox) {
                             // If on Chrome, verifies flag after timeout because the window 'focus' is called before
                             // the 'change' event, timeout should be enough to make sure 'change' hasn't been triggered
                             setTimeout(function() {

--- a/src/Runtime/Runtime/OpenSilver/Controls/OpenFileDialog.cs
+++ b/src/Runtime/Runtime/OpenSilver/Controls/OpenFileDialog.cs
@@ -280,9 +280,9 @@ namespace OpenSilver.Controls
             _windowFocusCallback = Interop.ExecuteJavaScript(@"
                 (function() {
                     var isChrome = !!window.chrome;
-
+                    var isMozilla = navigator.userAgent.toLowerCase().includes('firefox');
                     var windowFocusCallbackForFileDialogCancel = function(e) {
-                        if (isChrome) {
+                        if (isChrome || isMozilla) {
                             // If on Chrome, verifies flag after timeout because the window 'focus' is called before
                             // the 'change' event, timeout should be enough to make sure 'change' hasn't been triggered
                             setTimeout(function() {


### PR DESCRIPTION
Issue:
============
OpenFileDialog is not working properly in Mozilla Firefox. when we select a file it throws an error.

