### PR TITLE
fix: TextBlock.Text is not in sync with Run.Text

### DIFF
--- a/src/Runtime/Runtime/OpenSilver/Internal/Documents/TextContainerTextBlock.cs
+++ b/src/Runtime/Runtime/OpenSilver/Internal/Documents/TextContainerTextBlock.cs
@@ -52,7 +52,7 @@ internal sealed class TextContainerTextBlock : TextContainer<TextBlock>
 
     public override void EndChange()
     {
-        Parent.SetTextPropertyNoCallBack(Text);
+        Parent.OnTextContentChanged();
     }
 
     protected override void OnTextAddedOverride(TextElement textElement)

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBlock.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBlock.cs
@@ -143,7 +143,7 @@ namespace System.Windows.Controls
                 textBlock._isTextChanging = false;
             }
         }
-        
+
         internal void OnTextContentChanged()
         {
             if (!_isTextChanging)

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBlock.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBlock.cs
@@ -154,6 +154,11 @@ namespace System.Windows.Controls
             }
         }
 
+        internal void SetTextPropertyNoCallBack()
+        {
+            SetTextPropertyNoCallBack(Inlines.TextContainer.Text);
+        }
+
         /// <summary>
         /// Identifies the <see cref="Padding"/> dependency property.
         /// </summary>

--- a/src/Runtime/Runtime/System.Windows.Controls/TextBlock.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/TextBlock.cs
@@ -143,20 +143,15 @@ namespace System.Windows.Controls
                 textBlock._isTextChanging = false;
             }
         }
-
-        internal void SetTextPropertyNoCallBack(string text)
+        
+        internal void OnTextContentChanged()
         {
             if (!_isTextChanging)
             {
                 _isTextChanging = true;
-                SetCurrentValue(TextProperty, text);
+                SetCurrentValue(TextProperty, Inlines.TextContainer.Text);
                 _isTextChanging = false;
             }
-        }
-
-        internal void SetTextPropertyNoCallBack()
-        {
-            SetTextPropertyNoCallBack(Inlines.TextContainer.Text);
         }
 
         /// <summary>

--- a/src/Runtime/Runtime/System.Windows.Documents/Run.cs
+++ b/src/Runtime/Runtime/System.Windows.Documents/Run.cs
@@ -55,7 +55,7 @@ namespace System.Windows.Documents
             switch (run.GetLayoutParent())
             {
                 case TextBlock tb:
-                    tb.SetTextPropertyNoCallBack();
+                    tb.OnTextContentChanged();
                     break;
 
                 case FrameworkElement fe:

--- a/src/Runtime/Runtime/System.Windows.Documents/Run.cs
+++ b/src/Runtime/Runtime/System.Windows.Documents/Run.cs
@@ -55,7 +55,7 @@ namespace System.Windows.Documents
             switch (run.GetLayoutParent())
             {
                 case TextBlock tb:
-                    tb.InvalidateCacheAndMeasure();
+                    tb.SetTextPropertyNoCallBack();
                     break;
 
                 case FrameworkElement fe:


### PR DESCRIPTION
 It fixes the bug: If Run is used as in-line in TextBlock with Binding, The TextBlock.Text is not in sync with Run.Text. 