### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build-opensilver-package.yml
+++ b/.github/workflows/build-opensilver-package.yml
@@ -31,10 +31,10 @@ jobs:
         run: msbuild slnf/OpenSilver.slnf -p:Configuration=Release -clp:ErrorsOnly -restore
       - name: Format Version Suffix
         id: format-suffix
-        run: echo "::set-output name=suffix::$(date +'%Y-%m-%d-%H%M%S')-${{ env.GITHUB_SHA_SHORT }}"
+        run: echo "suffix=$(date +'%Y-%m-%d-%H%M%S')-${{ env.GITHUB_SHA_SHORT }}" >> $GITHUB_OUTPUT
       - name: Format Package Version
         id: format-version
-        run: echo "::set-output name=version::${{ env.next-release-version }}-preview-${{ steps.format-suffix.outputs.suffix }}"
+        run: echo "version=${{ env.next-release-version }}-preview-${{ steps.format-suffix.outputs.suffix }}" >> $GITHUB_OUTPUT
       - name: Build Simulator
         working-directory: build
         run: msbuild slnf/OpenSilver.Simulator.slnf -p:Configuration=Release -clp:ErrorsOnly -restore

--- a/.github/workflows/build-testapplication-opensilver.yml
+++ b/.github/workflows/build-testapplication-opensilver.yml
@@ -53,10 +53,10 @@ jobs:
         run: msbuild slnf/OpenSilver.slnf -p:Configuration=SL -clp:ErrorsOnly -restore
       - name: Format Version Suffix
         id: format-suffix
-        run: echo "::set-output name=suffix::$(date +'%Y-%m-%d-%H%M%S')-${{ env.GITHUB_SHA_SHORT }}"
+        run: echo "suffix=$(date +'%Y-%m-%d-%H%M%S')-${{ env.GITHUB_SHA_SHORT }}" >> $GITHUB_OUTPUT
       - name: Format Package Version
         id: format-version
-        run: echo "::set-output name=version::${{ env.next-release-version }}-preview-${{ steps.format-suffix.outputs.suffix }}"
+        run: echo "version=${{ env.next-release-version }}-preview-${{ steps.format-suffix.outputs.suffix }}" >> $GITHUB_OUTPUT
       - name: Pack OpenSilver
         working-directory: build
         run: |

--- a/.github/workflows/build-testapplication.yml
+++ b/.github/workflows/build-testapplication.yml
@@ -48,10 +48,10 @@ jobs:
         run: msbuild slnf/OpenSilver.slnf -p:Configuration=SL -clp:ErrorsOnly -restore
       - name: Format Version Suffix
         id: format-suffix
-        run: echo "::set-output name=suffix::$(date +'%Y-%m-%d-%H%M%S')-${{ env.GITHUB_SHA_SHORT }}"
+        run: echo "suffix=$(date +'%Y-%m-%d-%H%M%S')-${{ env.GITHUB_SHA_SHORT }}" >> $GITHUB_OUTPUT
       - name: Format Package Version
         id: format-version
-        run: echo "::set-output name=version::${{ env.next-release-version }}-preview-${{ steps.format-suffix.outputs.suffix }}"
+        run: echo "version=${{ env.next-release-version }}-preview-${{ steps.format-suffix.outputs.suffix }}" >> $GITHUB_OUTPUT
       - name: Pack OpenSilver
         working-directory: build
         run: |

--- a/.github/workflows/validate-prs.yml
+++ b/.github/workflows/validate-prs.yml
@@ -49,10 +49,10 @@ jobs:
         run: msbuild slnf/OpenSilver.Simulator.slnf -p:Configuration=Release -clp:ErrorsOnly -restore
       - name: Format Version Suffix
         id: format-suffix
-        run: echo "::set-output name=suffix::$(date +'%Y-%m-%d-%H%M%S')-${{ env.GITHUB_SHA_SHORT }}"
+        run: echo "suffix=$(date +'%Y-%m-%d-%H%M%S')-${{ env.GITHUB_SHA_SHORT }}" >> $GITHUB_OUTPUT
       - name: Format Package Version
         id: format-version
-        run: echo "::set-output name=version::${{ env.next-release-version }}-preview-${{ steps.format-suffix.outputs.suffix }}"
+        run: echo "version=${{ env.next-release-version }}-preview-${{ steps.format-suffix.outputs.suffix }}" >> $GITHUB_OUTPUT
       - name: Pack OpenSilver
         working-directory: build
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


