### PR TITLE
Allow to pass event arguments as a command parameter in InvokeCommandAction

### DIFF
--- a/src/Runtime/Blend/Interactivity/InvokeCommandAction.cs
+++ b/src/Runtime/Blend/Interactivity/InvokeCommandAction.cs
@@ -3,7 +3,9 @@
 // -------------------------------------------------------------------
 
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
+using System.Windows.Data;
 using System.Windows.Input;
 using OpenSilver.Internal.Interactivity;
 
@@ -18,6 +20,9 @@ namespace System.Windows.Interactivity
 
         public static readonly DependencyProperty CommandProperty = DependencyProperty.Register("Command", typeof(ICommand), typeof(InvokeCommandAction), null);
         public static readonly DependencyProperty CommandParameterProperty = DependencyProperty.Register("CommandParameter", typeof(object), typeof(InvokeCommandAction), null);
+        public static readonly DependencyProperty EventArgsConverterProperty = DependencyProperty.Register("EventArgsConverter", typeof(IValueConverter), typeof(InvokeCommandAction), new PropertyMetadata(null));
+        public static readonly DependencyProperty EventArgsConverterParameterProperty = DependencyProperty.Register("EventArgsConverterParameter", typeof(object), typeof(InvokeCommandAction), new PropertyMetadata(null));
+        public static readonly DependencyProperty EventArgsParameterPathProperty = DependencyProperty.Register("EventArgsParameterPath", typeof(string), typeof(InvokeCommandAction), new PropertyMetadata(null));
 
         /// <summary>
         /// Gets or sets the name of the command this action should invoke.
@@ -71,6 +76,41 @@ namespace System.Windows.Interactivity
         }
 
         /// <summary>
+        /// Gets or sets the IValueConverter that is used to convert the EventArgs passed to the Command as a parameter.
+        /// </summary>
+        /// <remarks>If the <see cref="Command"/> or <see cref="EventArgsParameterPath"/> properties are set, this property is ignored.</remarks>
+        public IValueConverter EventArgsConverter
+        {
+            get { return (IValueConverter)GetValue(EventArgsConverterProperty); }
+            set { SetValue(EventArgsConverterProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the parameter that is passed to the EventArgsConverter.
+        /// </summary>
+        public object EventArgsConverterParameter
+        {
+            get { return (object)GetValue(EventArgsConverterParameterProperty); }
+            set { SetValue(EventArgsConverterParameterProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the parameter path used to extract a value from an <see cref= "EventArgs" /> property to pass to the Command as a parameter.
+        /// </summary>
+        /// <remarks>If the <see cref="Command"/> propert is set, this property is ignored.</remarks>
+        public string EventArgsParameterPath
+        {
+            get { return (string)GetValue(EventArgsParameterPathProperty); }
+            set { SetValue(EventArgsParameterPathProperty, value); }
+        }
+
+        /// <summary>
+        /// Specifies whether the EventArgs of the event that triggered this action should be passed to the Command as a parameter.
+        /// </summary>
+        /// <remarks>If the <see cref="Command"/>, <see cref="EventArgsParameterPath"/>, or <see cref="EventArgsConverter"/> properties are set, this property is ignored.</remarks>
+        public bool PassEventArgsToCommand { get; set; }
+
+        /// <summary>
         /// Invokes the action.
         /// </summary>
         /// <param name="parameter">The parameter to the action. If the action does not require a parameter, the parameter may be set to a null reference.</param>
@@ -82,9 +122,29 @@ namespace System.Windows.Interactivity
 
                 if (command != null)
                 {
-                    if (command.CanExecute(this.CommandParameter))
+                    object commandParameter = this.CommandParameter;
+
+                    //if no CommandParameter has been provided, let's check the EventArgsParameterPath
+                    if (commandParameter == null && !string.IsNullOrWhiteSpace(this.EventArgsParameterPath))
                     {
-                        command.Execute(this.CommandParameter);
+                        commandParameter = GetEventArgsPropertyPathValue(parameter);
+                    }
+
+                    //next let's see if an event args converter has been supplied
+                    if (commandParameter == null && this.EventArgsConverter != null)
+                    {
+                        commandParameter = this.EventArgsConverter.Convert(parameter, typeof(object), EventArgsConverterParameter, CultureInfo.CurrentCulture);
+                    }
+
+                    //last resort, let see if they want to force the event args to be passed as a parameter
+                    if (commandParameter == null && this.PassEventArgsToCommand)
+                    {
+                        commandParameter = parameter;
+                    }
+
+                    if (command.CanExecute(commandParameter))
+                    {
+                        command.Execute(commandParameter);
                     }
                 }
                 else
@@ -92,6 +152,21 @@ namespace System.Windows.Interactivity
                     Debug.WriteLine(ExceptionStringTable.CommandDoesNotExistOnBehaviorWarningMessage, this.CommandName, this.AssociatedObject.GetType().Name);
                 }
             }
+        }
+
+        private object GetEventArgsPropertyPathValue(object parameter)
+        {
+            object commandParameter;
+            object propertyValue = parameter;
+            string[] propertyPathParts = EventArgsParameterPath.Split('.');
+            foreach (string propertyPathPart in propertyPathParts)
+            {
+                PropertyInfo propInfo = propertyValue.GetType().GetProperty(propertyPathPart);
+                propertyValue = propInfo.GetValue(propertyValue, null);
+            }
+
+            commandParameter = propertyValue;
+            return commandParameter;
         }
 
         private ICommand ResolveCommand()


### PR DESCRIPTION
Taken from WPF implementation: https://github.com/microsoft/XamlBehaviorsWpf/blob/main/src/Microsoft.Xaml.Behaviors/InvokeCommandAction.cs

Allows to pass event arguments as a command parameter:

```
<i:Interaction.Triggers>
    <i:EventTrigger EventName="EditEnded">
        <i:InvokeCommandAction Command="{Binding CustomerFormEditEndedCommand}"
                      PassEventArgsToCommand="True" EventArgsParameterPath="EditAction"/>
    </i:EventTrigger>
</i:Interaction.Triggers>


[RelayCommand]
public void CustomerFormEditEnded(DataFormEditAction e)
{
    if (e == DataFormEditAction.Commit)
    {
        //...
    }
}
```