### PR TITLE
Ensure re-running a stopped dispatcher timer works correctly in the Simulator

### DIFF
--- a/src/Runtime/Runtime/System.Windows/DispatcherTimer.cs
+++ b/src/Runtime/Runtime/System.Windows/DispatcherTimer.cs
@@ -102,9 +102,10 @@ namespace System.Windows.Threading
             var timer = (DispatcherTimer)state;
             if (OpenSilver.Interop.IsRunningInTheSimulator)
             {
+                var internalTimer = timer._timer;
                 INTERNAL_Simulator.OpenSilverDispatcherBeginInvoke(() =>
                 {
-                    if (timer.IsEnabled)
+                    if (internalTimer == timer._timer)
                     {
                         timer.OnTick();
                     }


### PR DESCRIPTION
This PR addresses an issue where a tick occurs while the UI thread is busy. And the current UI logic stops the timer and runs the timer again.
In this case, the previous tick must be abandoned.

The example is here: https://github.com/jacob-l/OpenSilverTimerSimulator