### PR TITLE
Use SetCurrentValue for properties IsSelected and IsExpanded in TreeViewItem

### DIFF
--- a/src/Runtime/Controls.Toolkit/DragDrop/TreeViewDragDropTarget.cs
+++ b/src/Runtime/Controls.Toolkit/DragDrop/TreeViewDragDropTarget.cs
@@ -467,7 +467,7 @@ namespace System.Windows.Controls
 
                 if (_treeViewItem is TreeViewItem treeViewItem)
                 {
-                    treeViewItem.IsExpanded = true;
+                    treeViewItem.SetCurrentValue(TreeViewItem.IsExpandedProperty, true);
                 }
             }
         }

--- a/src/Runtime/Controls.Toolkit/TreeView/TreeViewExtensions.cs
+++ b/src/Runtime/Controls.Toolkit/TreeView/TreeViewExtensions.cs
@@ -623,7 +623,7 @@ namespace System.Windows.Controls
 
             if (item != null)
             {
-                item.IsSelected = true;
+                item.SetCurrentValue(TreeViewItem.IsSelectedProperty, true);
             }
             else
             {
@@ -648,7 +648,7 @@ namespace System.Windows.Controls
             TreeViewItem item = view.GetSelectedContainer();
             if (item != null)
             {
-                item.IsSelected = false;
+                item.SetCurrentValue(TreeViewItem.IsSelectedProperty, false);
             }
         }
 
@@ -675,7 +675,7 @@ namespace System.Windows.Controls
             bool found = container != null;
             if (found)
             {
-                container.IsSelected = true;
+                container.SetCurrentValue(TreeViewItem.IsSelectedProperty, true);
             }
 
             return found;
@@ -733,7 +733,7 @@ namespace System.Windows.Controls
             if (expand)
             {
                 bool justExpanded = !item.IsExpanded;
-                item.IsExpanded = true;
+                item.SetCurrentValue(TreeViewItem.IsExpandedProperty, true);
 
                 // If the item was just expanded, we'll need to wait for the
                 // visual tree to update before its children to be created
@@ -755,7 +755,7 @@ namespace System.Windows.Controls
             // Collapse items after recursing through children
             if (!expand)
             {
-                item.IsExpanded = false;
+                item.SetCurrentValue(TreeViewItem.IsExpandedProperty, false);
             }
         }
 
@@ -865,7 +865,7 @@ namespace System.Windows.Controls
                         if (sibling != container)
                         {
                             ExpandOrCollapseAll(sibling, false, 0, null);
-                            sibling.IsExpanded = false;
+                            sibling.SetCurrentValue(TreeViewItem.IsExpandedProperty, false);
                         }
                     }
                 }
@@ -873,7 +873,7 @@ namespace System.Windows.Controls
                 // Expand all but the first item (which stays as we found it)
                 if (container != item)
                 {
-                    container.IsExpanded = true;
+                    container.SetCurrentValue(TreeViewItem.IsExpandedProperty, true);
                 }
             }
         }

--- a/src/Runtime/Controls/TreeView/TreeView.cs
+++ b/src/Runtime/Controls/TreeView/TreeView.cs
@@ -542,7 +542,7 @@ namespace System.Windows.Controls
                     // handler will be fired when it's set to true in
                     // ChangeSelection
                     current.IgnorePropertyChange = true;
-                    current.IsSelected = false;
+                    current.SetCurrentValue(TreeViewItem.IsSelectedProperty, false);
 
                     ChangeSelection(current, current, true);
 
@@ -1065,7 +1065,7 @@ namespace System.Windows.Controls
                     oldValue = SelectedItem;
                     if (SelectedContainer != null)
                     {
-                        SelectedContainer.IsSelected = false;
+                        SelectedContainer.SetCurrentValue(TreeViewItem.IsSelectedProperty, false);
                         SelectedContainer.UpdateContainsSelection(false);
                     }
 
@@ -1094,7 +1094,7 @@ namespace System.Windows.Controls
                     raiseSelectionChanged = true;
                 }
 
-                container.IsSelected = selected;
+                container.SetCurrentValue(TreeViewItem.IsSelectedProperty, selected);
             }
             finally
             {

--- a/src/Runtime/Controls/TreeView/TreeViewItem.cs
+++ b/src/Runtime/Controls/TreeView/TreeViewItem.cs
@@ -1158,7 +1158,7 @@ namespace System.Windows.Controls
                     {
                         bool opened = !IsExpanded;
                         UserInitiatedExpansion |= opened;
-                        IsExpanded = opened;
+                        SetCurrentValue(IsExpandedProperty, opened);
 
                         e.Handled = true;
                     }
@@ -1178,7 +1178,7 @@ namespace System.Windows.Controls
         {
             bool opened = !IsExpanded;
             UserInitiatedExpansion |= opened;
-            IsExpanded = opened;
+            SetCurrentValue(IsExpandedProperty, opened);
         }
 
         /// <summary>
@@ -1263,7 +1263,7 @@ namespace System.Windows.Controls
                             }
                             else
                             {
-                                IsExpanded = false;
+                                SetCurrentValue(IsExpandedProperty, false);
                             }
                             e.Handled = true;
                         }
@@ -1278,7 +1278,7 @@ namespace System.Windows.Controls
                             if (!IsExpanded)
                             {
                                 UserInitiatedExpansion = true;
-                                IsExpanded = true;
+                                SetCurrentValue(IsExpandedProperty, true);
                                 e.Handled = true;
                             }
                             else if (HandleDownKey())
@@ -1303,14 +1303,14 @@ namespace System.Windows.Controls
                         if (CanExpandOnInput && !IsExpanded)
                         {
                             UserInitiatedExpansion = true;
-                            IsExpanded = true;
+                            SetCurrentValue(IsExpandedProperty, true);
                             e.Handled = true;
                         }
                         break;
                     case Key.Subtract:
                         if (CanExpandOnInput && IsExpanded)
                         {
-                            IsExpanded = false;
+                            SetCurrentValue(IsExpandedProperty, false);
                             e.Handled = true;
                         }
                         break;

--- a/src/Runtime/Controls/TreeView/TreeViewItemAutomationPeer.cs
+++ b/src/Runtime/Controls/TreeView/TreeViewItemAutomationPeer.cs
@@ -216,7 +216,7 @@ namespace System.Windows.Automation.Peers
                 throw new InvalidOperationException(Resource.Automation_OperationCannotBePerformed);
             }
 
-            owner.IsExpanded = true;
+            owner.SetCurrentValue(TreeViewItem.IsExpandedProperty, true);
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace System.Windows.Automation.Peers
                 throw new InvalidOperationException(Resource.Automation_OperationCannotBePerformed);
             }
 
-            owner.IsExpanded = false;
+            owner.SetCurrentValue(TreeViewItem.IsExpandedProperty, false);
         }
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace System.Windows.Automation.Peers
             {
                 throw new InvalidOperationException(Resource.Automation_OperationCannotBePerformed);
             }
-            owner.IsSelected = true;
+            owner.SetCurrentValue(TreeViewItem.IsSelectedProperty, true);
         }
 
         /// <summary>
@@ -270,7 +270,7 @@ namespace System.Windows.Automation.Peers
         /// </remarks>
         void ISelectionItemProvider.Select()
         {
-            OwnerTreeViewItem.IsSelected = true;
+            OwnerTreeViewItem.SetCurrentValue(TreeViewItem.IsSelectedProperty, true);
         }
 
         /// <summary>
@@ -282,7 +282,7 @@ namespace System.Windows.Automation.Peers
         /// </remarks>
         void ISelectionItemProvider.RemoveFromSelection()
         {
-            OwnerTreeViewItem.IsSelected = false;
+            OwnerTreeViewItem.SetCurrentValue(TreeViewItem.IsSelectedProperty, false);
         }
 
         /// <summary>


### PR DESCRIPTION
Binding for IsSelected and IsExpanded properties works only once because of direct setting this properties inside.

The example project: [Example](https://github.com/jacob-l/TreeViewSelection/).

This PR replaces direct property setting with SetCurrentValue.