### PR TITLE
Solve TestApplication 2.2.0 breaking changes warning

### DIFF
--- a/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/Pages/Index.cs
+++ b/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/Pages/Index.cs
@@ -2,6 +2,8 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.JSInterop;
+using System.Threading.Tasks;
+using System;
 using TestApplication.OpenSilver.Browser.Interop;
 
 namespace TestApplication.OpenSilver.Browser.Pages
@@ -13,9 +15,15 @@ namespace TestApplication.OpenSilver.Browser.Pages
         {
         }
 
-        protected override void OnInitialized()
+        protected async override Task OnInitializedAsync()
         {
-            base.OnInitialized();
+            await base.OnInitializedAsync();
+
+            if (!await JSRuntime.InvokeAsync<bool>("getOSFilesLoadedPromise"))
+            {
+                throw new InvalidOperationException("Failed to initialize OpenSilver. Check your browser's console for error details.");
+            }
+
             Cshtml5Initializer.Initialize(new UnmarshalledJavaScriptExecutionHandler(JSRuntime));
             Program.RunApplication();
         }

--- a/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/TestApplication.OpenSilver.Browser.csproj
+++ b/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/TestApplication.OpenSilver.Browser.csproj
@@ -3,13 +3,13 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <NoXamlPreprocessor>True</NoXamlPreprocessor>
-    <OpenSilverType>5</OpenSilverType>
+    <OpenSilverType>6</OpenSilverType>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.0" PrivateAssets="all" />
-    <PackageReference Include="OpenSilver" Version="1.1.0" />
+    <PackageReference Include="OpenSilver" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/wwwroot/index.html
+++ b/src/Tests/TestApplication/TestApplication.OpenSilver.Browser/wwwroot/index.html
@@ -2,20 +2,49 @@
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>TestApplication.OpenSilver</title>
     <base href="/" />
+    <script>
+        (function () {
+            const style = document.createElement('link');
+            style.setAttribute('rel', 'stylesheet');
+            style.setAttribute('type', 'text/css');
+            style.setAttribute('href', 'loading-indicator.css?date=' + new Date().toISOString());
+            document.head.appendChild(style);
+            const script = document.createElement('script');
+            script.setAttribute('type', 'application/javascript');
+            script.setAttribute('src', 'libs/opensilver.js?date=' + new Date().toISOString());
+            document.head.appendChild(script);
+        })();
+    </script>
 </head>
 <body>
-    <div id="app" style="position:absolute;width:100%;height:100%;"></div>
+    <div id="app">
+        <div class="loading-indicator-wrapper">
+            <div class="loading-indicator">
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-ball"></div>
+                <div class="loading-indicator-text"></div>
+            </div>
+        </div>
+    </div>
     <div id="opensilver-root" style="position: relative; width: 100%; height: 100%; overflow-x: hidden; overflow-y: hidden"></div>
 
-    <!-- loading indicator -->
-    <!-- modify these files to change the loading animation -->
-    <link rel="stylesheet" type="text/css" href="loading-indicator.css" />
-    <script type="text/javascript" src="loading-indicator.js"></script>
-
-    <script src="_framework/blazor.webassembly.js" autostart="false"></script>
-    <script type="text/javascript" src="libs/opensilver.js"></script>
-    <script type="text/javascript" src="BlazorLoader.js"></script>
+    <script src="_framework/blazor.webassembly.js"></script>
 </body>
 </html>

--- a/src/Tests/TestApplication/TestApplication.OpenSilver.Simulator/TestApplication.OpenSilver.Simulator.csproj
+++ b/src/Tests/TestApplication/TestApplication.OpenSilver.Simulator/TestApplication.OpenSilver.Simulator.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OpenSilver.Simulator" Version="1.1.0" />
+		<PackageReference Include="OpenSilver.Simulator" Version="2.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Tests/TestApplication/TestApplication/TestApplication.OpenSilver.csproj
+++ b/src/Tests/TestApplication/TestApplication/TestApplication.OpenSilver.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OpenSilver" Version="1.1.0" />
+		<PackageReference Include="OpenSilver" Version="2.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
The automated build in GitHub fails during the TestApplication phase due to the 2.2.0 breaking changes warning (example: https://github.com/OpenSilver/OpenSilver/actions/runs/9102305306/job/25021581529).
This PR updates TestApplication to OpenSilver 2.2.0 and make the changes necessary for the 2.2.0 warning to go away.