### PR TITLE
Fix Runtime.OpenSilver.Tests

### DIFF
--- a/src/Tests/Runtime.OpenSilver.Tests/Maintenance/MemoryLeak/MemoryLeakTest.cs
+++ b/src/Tests/Runtime.OpenSilver.Tests/Maintenance/MemoryLeak/MemoryLeakTest.cs
@@ -27,6 +27,7 @@ using System.Windows.Data;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
+using OpenSilver.Internal;
 
 namespace OpenSilver.MemoryLeak.Tests;
 

--- a/src/Tests/Runtime.OpenSilver.Tests/System.Windows/NameScopeTest.cs
+++ b/src/Tests/Runtime.OpenSilver.Tests/System.Windows/NameScopeTest.cs
@@ -17,6 +17,7 @@ using OpenSilver.Internal.Xaml;
 using System.Windows.Markup;
 using System.Windows.Controls;
 using System.Windows.Media;
+using OpenSilver.Internal;
 
 namespace System.Windows.Tests
 {


### PR DESCRIPTION
Runtime.OpenSilver.Tests currently does not compile due to TemplateContent having been moved namespaces.