### PR TITLE
Fix modifier keys on mouse down when page is not focused

### DIFF
--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -611,6 +611,7 @@ document.createInputManager = function (callback) {
             root.addEventListener('mousedown', function (e) {
                 if (shouldIgnoreMouseEvent(e)) return;
 
+                setModifiers(e);
                 e.isHandled = true;
                 let id = (_mouseCapture === null || e.target === _mouseCapture) ? getClosestElementId(e.target) : '';
                 switch (e.button) {


### PR DESCRIPTION
Modifier keys are set only on keydown/up events.

This commit fixes the following issue:
1. Open an OpenSilver app
2. Do not focus any element in the page, or unfocus it by clicking for example on the browser titlebar
3. Hold Ctrl key and click on an element that subscribed to `MouseLeftButtonDown` event
4. Inside the mouse button down handler, check `Keyboard.Modifiers`
Actual Result: the modifiers does not indicate that Ctrl key is pressed