### PR TITLE
fix: getBBox not found issue.

### DIFF
--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -310,7 +310,7 @@ document.arrangeEllipse = function (id, rx, ry, penThickness) {
 };
 
 document.getBBox = function (svgElement) {
-    if (svgElement) {
+    if (svgElement && svgElement instanceof SVGElement) {
         const bbox = svgElement.getBBox();
         return JSON.stringify({ X: bbox.x, Y: bbox.y, Width: bbox.width, Height: bbox.height, });
     }


### PR DESCRIPTION
- During measure and arrange operation system cannot find element and it create dummy element.
document.getBBox(document.getElementByIdSafe(\"id3968\"));

