### PR TITLE
Fix setting dataId attribute when the Name is set by XamlReader

### DIFF
--- a/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
+++ b/src/Runtime/Runtime/System.Windows/FrameworkElement.cs
@@ -842,7 +842,7 @@ namespace System.Windows
                         if (Features.DOM.AssignName && d is FrameworkElement fe)
                         {
                             INTERNAL_HtmlDomManager.SetDomElementAttribute(
-                                fe.OuterDiv, "dataId", (string)newValue ?? string.Empty);
+                                fe.OuterDiv, "dataId", (string)newValue ?? string.Empty, true);
                         }
                     },
                 });


### PR DESCRIPTION
OpenSilver compiler does not allow to set `FrameworkElement.Name` property to special characters like `\` or `"`.
But `XamlReader.Load()` allows it, and then if add the generated element to the page, it tries to set `dataId` attribute and javascript execution fails because the string is not escaped.