### PR TITLE
Copy files to wwwroot before ResolveProjectStaticWebAssets

### DIFF
--- a/src/Targets/OpenSilver.MauiHybrid.targets
+++ b/src/Targets/OpenSilver.MauiHybrid.targets
@@ -35,7 +35,7 @@
 
   </Target>
 
-  <Target Name="_CopyWasmResources" BeforeTargets="PostBuildEvent">
+  <Target Name="_CopyWasmResources" BeforeTargets="ResolveProjectStaticWebAssets">
 
     <PropertyGroup>
       <Cshtml5OutputResourcesPath Condition="'$(Cshtml5OutputResourcesPath)' == ''">resources/</Cshtml5OutputResourcesPath>


### PR DESCRIPTION
Ensures that libs and resources files are copied to wwwroot before the ResolveProjectStaticWebAssets target. This fixes the issue where the files were not being included in the final bin output on the first build.