### PR TITLE
fix: enable SaveFileDialog without setting Filter

### DIFF
--- a/src/Runtime/Runtime/OpenSilver/Controls/SaveFileDialog.cs
+++ b/src/Runtime/Runtime/OpenSilver/Controls/SaveFileDialog.cs
@@ -165,7 +165,7 @@ public sealed class SaveFileDialog
         if (!string.IsNullOrEmpty(DefaultFileName))
         {
             var messageBoxResult = MessageBox.Show(
-                $"Do you want to save '{DefaultFileName}' ?",
+                $"Do you want to save {DefaultFileName}?",
                 "File Download - Security Warning",
                 MessageBoxButton.OKCancel);
 
@@ -240,7 +240,7 @@ public sealed class SaveFileDialog
 
     private string GetFilename()
     {
-        if (_filterEntries.Count < FilterIndex)
+        if (_filterEntries?.Count < FilterIndex)
         {
             throw new InvalidOperationException("FilterIndex is out of bounds of Filter");
         }

--- a/src/Tests/TestApplication/TestApplication/Tests/FileDialogTest.xaml
+++ b/src/Tests/TestApplication/TestApplication/Tests/FileDialogTest.xaml
@@ -6,15 +6,21 @@
     xmlns:sdk="http://schemas.microsoft.com/winfx/2006/xaml/presentation/sdk">
 
     <StackPanel Orientation="Vertical">
-        <Button Name="LoadImageButton" Content="Load Image..." Click="LoadImageButton_Click" Width="100" Height="22"
+        <Button Name="LoadImageButton" Content="Load Image..." Click="LoadImageButton_Click" Width="200" Height="22"
                 Margin="0,10,0,0"/>
         <TextBlock Name="OperationStatus" Margin="0,10,0,0" HorizontalAlignment="Center"/>
         <Border Background="LightGray" BorderThickness="1" Width="300" Height="300" Margin="0,10,0,0">
             <Image x:Name="UploadedImage"/>
         </Border>
         <TextBlock Margin="0,10,0,0" HorizontalAlignment="Center" Text="Enter text to save:"/>
-        <TextBox Name="ToSaveTextBox" Width="400" Height="30"/>
-        <Button Name="SaveTextButton" Content="Save" Click="SaveTextButton_Click" Width="100" Height="22"
+        <TextBox Name="ToSaveTextBox" Width="400"/>
+        <Button Name="SaveTextButton" Content="Save" Click="SaveTextButton_Click" Width="200" Height="22"
+                Margin="0,10,0,0"/>
+        <Button Name="SaveTextWithoutFilterButton" Content="Save without Filter" Click="SaveTextWithoutFilterButton_Click" Width="200" Height="22"
+                Margin="0,10,0,0"/>
+        <Button Name="SaveTextWithDefaultFilenameButton" Content="Save with DefaultFilename" Click="SaveTextWithDefaultFilenameButton_Click" Width="200" Height="22"
+                Margin="0,10,0,0"/>
+        <Button Name="SaveTextWithDefaultExtButton" Content="Save with DefaultExt" Click="SaveTextWithDefaultExtButton_Click" Width="200" Height="22"
                 Margin="0,10,0,0"/>
     </StackPanel>
 </sdk:Page>

--- a/src/Tests/TestApplication/TestApplication/Tests/FileDialogTest.xaml.cs
+++ b/src/Tests/TestApplication/TestApplication/Tests/FileDialogTest.xaml.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.IO;
-using System.Net;
+﻿using System.IO;
 using System.Text;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Resources;
 #if OPENSILVER
 using OpenFileDialog = OpenSilver.Controls.OpenFileDialog;
 using SaveFileDialog = OpenSilver.Controls.SaveFileDialog;
@@ -60,16 +56,32 @@ namespace TestApplication.OpenSilver.Tests
             }
         }
 
-#if OPENSILVER
-        private async void SaveTextButton_Click(object sender, RoutedEventArgs e)
-#else
         private void SaveTextButton_Click(object sender, RoutedEventArgs e)
+        {
+            Save("Text files|*.txt", null, null);
+        }
+
+#if OPENSILVER
+        private async void Save(string filter, string defaultFilename, string defaultExt)
+#else
+        private void Save(string filter, string defaultFilename, string defaultExt)
 #endif
         {
-            SaveFileDialog saveFileDialog = new SaveFileDialog
+            SaveFileDialog saveFileDialog = new SaveFileDialog();
+
+            if (!string.IsNullOrEmpty(filter))
             {
-                Filter = "*.txt|*.txt"
-            };
+                saveFileDialog.Filter = filter;
+            }
+            if (!string.IsNullOrEmpty(defaultFilename))
+            {
+                saveFileDialog.DefaultFileName = defaultFilename;
+            }
+            if (!string.IsNullOrEmpty(defaultExt))
+            {
+                saveFileDialog.DefaultExt = defaultExt;
+            }
+
 #if OPENSILVER
             bool? result = await saveFileDialog.ShowDialogAsync();
 #else
@@ -97,6 +109,21 @@ namespace TestApplication.OpenSilver.Tests
             {
                 MessageBox.Show("Result from file dialog was false.");
             }
+        }
+
+        private void SaveTextWithoutFilterButton_Click(object sender, RoutedEventArgs e)
+        {
+            Save(null, null, null);
+        }
+
+        private void SaveTextWithDefaultFilenameButton_Click(object sender, RoutedEventArgs e)
+        {
+            Save(null, "default-filename.txt", null);
+        }
+
+        private void SaveTextWithDefaultExtButton_Click(object sender, RoutedEventArgs e)
+        {
+            Save("All files|*.*", "default-filename-without-extension", ".defExt");
         }
     }
 }


### PR DESCRIPTION
SaveFileDialog throws when not setting a Filter and calling ShowDialogAsync().

Added tests for scenarios where Filter is set, Filter isn't set, DefaultFilename is set and DefaultExt (extension) is set.