### PR TITLE
Cancel touch scrolling if the mouse is captured

### DIFF
--- a/src/Runtime/Runtime/System.Windows.Controls/ScrollViewer.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ScrollViewer.cs
@@ -1466,6 +1466,11 @@ namespace System.Windows.Controls
 
             public void HandleMouseMove(MouseEventArgs e)
             {
+                if (Pointer.Captured is not null)
+                {
+                    Cancel();
+                }
+
                 if (!IsEnabled)
                 {
                     return;


### PR DESCRIPTION
Cancel scrolling for the case when the mouse is not captured on MouseLeftButtonDown, but becomes captured after a delay. For example, when drag operation started after tap and hold for 200ms.