### PR TITLE
Use MauiAsset instead of Content for iPhone builds on Windows

### DIFF
--- a/src/Targets/OpenSilver.MauiHybrid.targets
+++ b/src/Targets/OpenSilver.MauiHybrid.targets
@@ -66,7 +66,7 @@
       <_OpenSilverOldStaticWebAssets Include="wwwroot/$(Cshtml5OutputResourcesPath)/**/*" />
       <_OpenSilverOldStaticWebAssets Include="$(MSBuildProjectDirectory)/wwwroot/libs/**/*" />
       <_OpenSilverOldStaticWebAssets Include="$(MSBuildProjectDirectory)/wwwroot/$(Cshtml5OutputResourcesPath)/**/*" />
-      <Content Remove="@(_OpenSilverOldStaticWebAssets)" />
+      <MauiAsset Remove="@(_OpenSilverOldStaticWebAssets)" />
     </ItemGroup>
 
     <ItemGroup>
@@ -87,7 +87,7 @@
     </ResourcesExtractorAndCopier>
 
     <ItemGroup>
-      <Content Include="@(_OpenSilverStaticWebAssets)" />
+      <MauiAsset Include="@(_OpenSilverStaticWebAssets)" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
It looks like the MauiAsset is a proper choice, and it works on Windows and Mac for all targets.