### PR TITLE
Touch scroll over elements that capture mouse

### DIFF
--- a/src/Runtime/Blend/Interactions/Interactivity/Layout/MouseDragElementBehavior.cs
+++ b/src/Runtime/Blend/Interactions/Interactivity/Layout/MouseDragElementBehavior.cs
@@ -435,6 +435,7 @@ namespace Microsoft.Expression.Interactivity.Layout
             this.relativePosition = positionInElementCoordinates;
 
             this.AssociatedObject.CaptureMouse();
+            AssociatedObject.AllowScrollOnTouchMove = false;
 
             this.AssociatedObject.MouseMove += this.OnMouseMove;
             this.AssociatedObject.LostMouseCapture += this.OnLostMouseCapture;

--- a/src/Runtime/Blend/Interactions/Interactivity/Layout/MouseDragElementBehavior.cs
+++ b/src/Runtime/Blend/Interactions/Interactivity/Layout/MouseDragElementBehavior.cs
@@ -461,6 +461,7 @@ namespace Microsoft.Expression.Interactivity.Layout
             this.AssociatedObject.MouseMove -= this.OnMouseMove;
             this.AssociatedObject.LostMouseCapture -= this.OnLostMouseCapture;
             this.AssociatedObject.RemoveHandler(UIElement.MouseLeftButtonUpEvent, new MouseButtonEventHandler(this.OnMouseLeftButtonUp));
+            AssociatedObject.ClearValue(UIElement.AllowScrollOnTouchMoveProperty);
         }
 
         private void OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)

--- a/src/Runtime/Controls.Toolkit/DragDrop/DragDropTarget.cs
+++ b/src/Runtime/Controls.Toolkit/DragDrop/DragDropTarget.cs
@@ -1498,6 +1498,7 @@ namespace System.Windows.Controls
                     return;
                 }
 
+                _originalSource.AllowScrollOnTouchMove = false;
                 UnSubscribeFromEvents();
 
                 _owner.OnItemDragStarting(new ItemDragEventArgs

--- a/src/Runtime/Controls.Toolkit/DragDrop/DragDropTarget.cs
+++ b/src/Runtime/Controls.Toolkit/DragDrop/DragDropTarget.cs
@@ -177,6 +177,7 @@ namespace System.Windows.Controls
 
             if (!eventArgs.Cancel && !SW.DragDrop.IsDragInProgress)
             {
+                eventArgs.OriginalSource.AllowScrollOnTouchMove = false;
                 OnItemDragStarted(eventArgs);
 
                 SW.GiveFeedbackEventHandler giveFeedbackHandler =
@@ -196,6 +197,7 @@ namespace System.Windows.Controls
                                 giveFeedbackHandler);
                         }
                         SW.DragDrop.DragDropCompleted -= handler;
+                        eventArgs.OriginalSource.ClearValue(AllowScrollOnTouchMoveProperty);
 
                         InternalOnItemDragCompleted(
                             new ItemDragEventArgs(eventArgs)
@@ -1498,7 +1500,6 @@ namespace System.Windows.Controls
                     return;
                 }
 
-                _originalSource.AllowScrollOnTouchMove = false;
                 UnSubscribeFromEvents();
 
                 _owner.OnItemDragStarting(new ItemDragEventArgs
@@ -1506,6 +1507,7 @@ namespace System.Windows.Controls
                     DragDecoratorContentMouseOffset = _offset,
                     Data = new SelectionCollection() { new Selection(itemIndex, data) },
                     DragSource = itemsControl,
+                    OriginalSource = _originalSource,
                     AllowedEffects = _owner.ReadLocalValue(AllowedSourceEffectsProperty) == DependencyProperty.UnsetValue
                                             ? _owner.GetAllowedEffects(itemsControl)
                                             : (SW.DragDropEffects)_owner.GetValue(AllowedSourceEffectsProperty),

--- a/src/Runtime/Controls.Toolkit/DragDrop/ItemDragEventArgs.cs
+++ b/src/Runtime/Controls.Toolkit/DragDrop/ItemDragEventArgs.cs
@@ -72,6 +72,11 @@ namespace System.Windows.Controls
         public DependencyObject DragSource { get; set; }
 
         /// <summary>
+        /// Original source of the event, which is the UIElement that initiated the drag operation.
+        /// </summary>
+        internal UIElement OriginalSource { get; set; }
+
+        /// <summary>
         /// Gets or sets the data associated with the item container being dragged.
         /// </summary>
         public object Data { get; set; }
@@ -116,6 +121,7 @@ namespace System.Windows.Controls
             this.DragDecoratorContentMouseOffset = args.DragDecoratorContentMouseOffset;
             this.RemoveDataFromDragSourceAction = args.RemoveDataFromDragSourceAction;
             this.DataRemovedFromDragSource = args.DataRemovedFromDragSource;
+            OriginalSource = args.OriginalSource;
         }
     }
 }

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Thumb.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Thumb.cs
@@ -3,6 +3,7 @@
 // Please see http://go.microsoft.com/fwlink/?LinkID=131993 for details.
 // All other rights reserved. 
 
+using OpenSilver.Internal;
 using System.Diagnostics;
 using System.Windows.Automation.Peers;
 using System.Windows.Input;
@@ -25,15 +26,13 @@ namespace System.Windows.Controls.Primitives
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(Thumb), new PropertyMetadata(typeof(Thumb)));
             IsEnabledProperty.OverrideMetadata(typeof(Thumb), new PropertyMetadata(OnIsEnabledChanged));
+            AllowScrollOnTouchMoveProperty.OverrideMetadata(typeof(Thumb), new PropertyMetadata(BooleanBoxes.FalseBox));
         }
 
         /// <summary> 
         /// Initializes a new instance of the <see cref="Thumb"/> class.
         /// </summary> 
-        public Thumb()
-        {
-            AllowScrollOnTouchMove = false;
-        }
+        public Thumb() { }
 
         /// <summary>
         /// Occurs when a <see cref="Thumb"/> control receives logical focus and 

--- a/src/Runtime/Runtime/System.Windows.Controls.Primitives/Thumb.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls.Primitives/Thumb.cs
@@ -30,7 +30,10 @@ namespace System.Windows.Controls.Primitives
         /// <summary> 
         /// Initializes a new instance of the <see cref="Thumb"/> class.
         /// </summary> 
-        public Thumb() { }
+        public Thumb()
+        {
+            AllowScrollOnTouchMove = false;
+        }
 
         /// <summary>
         /// Occurs when a <see cref="Thumb"/> control receives logical focus and 

--- a/src/Runtime/Runtime/System.Windows.Controls/ComboBoxItem.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ComboBoxItem.cs
@@ -33,10 +33,7 @@ namespace System.Windows.Controls
 
             ComboBox parent = ParentComboBox;
 
-            if (parent != null && !ScrollViewer.IsPanning)
-            {
-                parent.NotifyComboBoxItemMouseUp(this);
-            }
+            parent?.NotifyComboBoxItemMouseUp(this);
 
             base.OnMouseLeftButtonUp(e);
         }

--- a/src/Runtime/Runtime/System.Windows.Controls/InkPresenter.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/InkPresenter.cs
@@ -29,6 +29,11 @@ namespace System.Windows.Controls
         private StylusPoint _lastPos;
         private StylusPoint _mousePos;
 
+        static InkPresenter()
+        {
+            AllowScrollOnTouchMoveProperty.OverrideMetadata(typeof(InkPresenter), new PropertyMetadata(BooleanBoxes.FalseBox));
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="InkPresenter"/> class.
         /// </summary>

--- a/src/Runtime/Runtime/System.Windows.Controls/ScrollViewer.cs
+++ b/src/Runtime/Runtime/System.Windows.Controls/ScrollViewer.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Controls
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(ScrollViewer), new PropertyMetadata(typeof(ScrollViewer)));
             EventManager.RegisterClassHandler<ScrollViewer>(MouseLeftButtonDownEvent, new MouseButtonEventHandler(OnTouchStartThunk), true);
-            EventManager.RegisterClassHandler<ScrollViewer>(MouseLeftButtonUpEvent, new MouseButtonEventHandler(OnTouchEndThunk), true);
+            EventManager.RegisterClassHandler<ScrollViewer>(PreviewMouseLeftButtonUpEvent, new MouseButtonEventHandler(OnTouchEndThunk), true);
             EventManager.RegisterClassHandler<ScrollViewer>(Mouse.MouseMoveEvent, new MouseEventHandler(OnTouchMoveThunk), true);
         }
 
@@ -1527,7 +1527,7 @@ namespace System.Windows.Controls
                 Cancel();
 
                 if (e.IsTouchEvent &&
-                    Pointer.Captured is null &&
+                    e.OriginalSource is UIElement el && el.AllowScrollOnTouchMove &&
                     (IsVerticalScrollBarVisible || IsHorizontalScrollBarVisible) &&
                     _scrollViewer.ScrollInfo is IScrollInfo isi &&
                     _current is null) // prevents scrolling multiple nested ScrollViewers
@@ -1545,7 +1545,7 @@ namespace System.Windows.Controls
 
             public void HandleMouseMove(MouseEventArgs e)
             {
-                if (Pointer.Captured is not null)
+                if (e.OriginalSource is UIElement el && !el.AllowScrollOnTouchMove)
                 {
                     Cancel();
                 }
@@ -1578,6 +1578,7 @@ namespace System.Windows.Controls
                     return;
                 }
 
+                e.Handled = _isPanning;
                 Cancel();
 
                 if ((GetTime() - _lastMoveTime).TotalMilliseconds < MaxWaitForInertiaMS && CanScroll(_velocityX, _velocityY))

--- a/src/Runtime/Runtime/System.Windows/UIElement.cs
+++ b/src/Runtime/Runtime/System.Windows/UIElement.cs
@@ -1342,10 +1342,7 @@ namespace System.Windows
                 nameof(AllowScrollOnTouchMove),
                 typeof(bool),
                 typeof(UIElement),
-                new PropertyMetadata(BooleanBoxes.TrueBox)
-                {
-                    MethodToUpdateDom2 = static (d, oldValue, newValue) => ((UIElement)d).SetTouchAction((bool)newValue ? "auto" : "none"),
-                });
+                new PropertyMetadata(BooleanBoxes.TrueBox));
 
 #endregion
 


### PR DESCRIPTION
Elements like Button, TextBox capture mouse and scrolling does not work on touch screens.
My proposition is to check `AllowScrollOnTouchMove` property instead and set `e.Handled = true` to prevent action like button click after scrolling.
I this case we must set `AllowScrollOnTouchMove = false` for draggable controls. And, if we handle scrolling in the framework, maybe there is no need to set `touchAction` in html.

Related to #970 

https://github.com/user-attachments/assets/61d218cb-4852-46b9-9675-acc881f43a3f

