### PR TITLE
Fix XamlPreprocessor design-time failure

### DIFF
--- a/src/Compiler/Compiler/EntryPoints/XamlPreprocessor.cs
+++ b/src/Compiler/Compiler/EntryPoints/XamlPreprocessor.cs
@@ -108,6 +108,9 @@ namespace OpenSilver.Compiler
         [Required]
         public bool VerifyHash { get; set; }
 
+        [Required]
+        public bool IsDesignTime { get; set; }
+
         [Output]
         public ITaskItem[] GeneratedFiles { get; set; }
 
@@ -172,7 +175,7 @@ namespace OpenSilver.Compiler
                 Log.LogMessage($"{operationName} finished after {_watch.ElapsedMilliseconds} ms.");
             }
 
-            return !Log.HasLoggedErrors;
+            return IsDesignTime || !Log.HasLoggedErrors;
         }
 
         private (List<ITaskItem> GeneratedFiles, List<ITaskItem> ProcessedFiles) ProcessFiles(ITaskItem[] sourceFiles)

--- a/src/Targets/OpenSilver.Common.targets
+++ b/src/Targets/OpenSilver.Common.targets
@@ -230,7 +230,8 @@
       VerifyHash="false"
       RootNamespace="$(RootNamespace)"
       Options="$(OpenSilverXamlPreprocessorOptions)"
-      Language="$(Language)">
+      Language="$(Language)"
+      IsDesignTime="false">
       <Output ItemName="_XamlPreprocessorGeneratedFiles" TaskParameter="GeneratedFiles" />
       <Output ItemName="_XamlPreprocessorProcessedPageFiles" TaskParameter="ProcessedPageFiles" />
       <Output ItemName="_XamlPreprocessorProcessedApplicationDefinitionFiles" TaskParameter="ProcessedApplicationDefinitionFiles" />
@@ -320,7 +321,8 @@
       VerifyHash="false"
       RootNamespace="$(RootNamespace)"
       Options="$(OpenSilverXamlPreprocessorOptions)"
-      Language="$(Language)">
+      Language="$(Language)"
+      IsDesignTime="true">
       <Output ItemName="_XamlPreprocessorGeneratedFiles" TaskParameter="GeneratedFiles" />
       <Output ItemName="_XamlPreprocessorProcessedPageFiles" TaskParameter="ProcessedPageFiles" />
       <Output ItemName="_XamlPreprocessorProcessedApplicationDefinitionFiles" TaskParameter="ProcessedApplicationDefinitionFiles" />


### PR DESCRIPTION
This PR prevents the XamlPreprocessor MSBuild task from failing during design-time compilation.  
Previously, a failure in the task caused Visual Studio to fail loading projects